### PR TITLE
Fix flaky API tests caused by ephemeral supertest servers

### DIFF
--- a/server/lib/middleware/error-handler.js
+++ b/server/lib/middleware/error-handler.js
@@ -3,6 +3,7 @@ const HttpStatus = require("http-status-codes");
 const CONST = require("../constants");
 const logger = require("../logger");
 
+// eslint-disable-next-line no-unused-vars
 module.exports = function (error, request, response, next) {
   logger.debug(error);
   switch (error) {
@@ -29,5 +30,4 @@ module.exports = function (error, request, response, next) {
       response.status(HttpStatus.INTERNAL_SERVER_ERROR).send({ error });
       break;
   }
-  next(error);
 };

--- a/server/models/token.js
+++ b/server/models/token.js
@@ -9,6 +9,7 @@ const logger = require("../lib/logger");
 const db = require("../db");
 
 const secrets = {};
+let reloadTimer = undefined;
 
 const loadSecrets = async () => {
   logger.debug("Loading secrets");
@@ -26,8 +27,11 @@ const getSecret = (userId) => {
 
 const init = async () => {
   await loadSecrets();
-  // Reload every minute or so
-  setTimeout(async () => await init(), 60000);
+  if (reloadTimer) clearTimeout(reloadTimer);
+  // Reload every minute or so. unref() so the timer doesn't keep the
+  // event loop alive on its own (matters in tests).
+  reloadTimer = setTimeout(async () => await init(), 60000);
+  reloadTimer.unref();
 };
 
 module.exports = () => {

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "start": "cross-env NODE_ENV=dev node index.js",
     "prod": "cross-env NODE_ENV=prod pm2 start index.js",
     "dev": "cross-env NODE_ENV=dev nodemon run index.js",
-    "test": "cross-env DB_DRIVER=dummy NODE_ENV=test jest --runInBand --forceExit --detectOpenHandles --verbose",
+    "test": "cross-env DB_DRIVER=dummy NODE_ENV=test jest --runInBand --verbose",
     "lint": "eslint .",
     "build:ui": "cd ../react-app && npm run build --prod && rm -rf ../server/build && cp -r build ../server/"
   },

--- a/server/tests/api/galleries.test.js
+++ b/server/tests/api/galleries.test.js
@@ -1,14 +1,15 @@
-const supertest = require("supertest");
-const { app, init } = require("../../app");
-
-const api = supertest(app);
+const { init } = require("../../app");
 const db = require("../../db/dummy")();
-const { loginUser } = require("./helper");
+const { createApi, loginUser } = require("./helper");
+
+const { api, close } = createApi();
 
 beforeEach(async () => {
   await db.init();
   await init();
 });
+
+afterAll(close);
 
 const getGalleries = async (token, status = 200) =>
   api

--- a/server/tests/api/gallery-photos.test.js
+++ b/server/tests/api/gallery-photos.test.js
@@ -1,14 +1,15 @@
-const supertest = require("supertest");
-const { app, init } = require("../../app");
-
-const api = supertest(app);
+const { init } = require("../../app");
 const db = require("../../db/dummy")();
-const { loginUser } = require("./helper");
+const { createApi, loginUser } = require("./helper");
+
+const { api, close } = createApi();
 
 beforeEach(async () => {
   await db.init();
   await init();
 });
+
+afterAll(close);
 
 const getGalleryPhoto = async (token, galleryId, photoId, status = 200) =>
   api

--- a/server/tests/api/helper.js
+++ b/server/tests/api/helper.js
@@ -1,3 +1,16 @@
+const supertest = require("supertest");
+const { app } = require("../../app");
+
+// Create one persistent server per test file. Letting supertest spin up an
+// ephemeral server per request causes intermittent "Parse Error: Expected
+// HTTP/" failures (port-reuse race between consecutive ephemeral servers).
+const createApi = () => {
+  const server = app.listen();
+  const api = supertest(server);
+  const close = () => new Promise((resolve) => server.close(resolve));
+  return { api, close };
+};
+
 const loginUser = async (api, id) => {
   const authRes = await api
     .post("/api/v1/tokens")
@@ -10,5 +23,6 @@ const loginUser = async (api, id) => {
 };
 
 module.exports = {
+  createApi,
   loginUser,
 };

--- a/server/tests/api/meta.test.js
+++ b/server/tests/api/meta.test.js
@@ -1,14 +1,15 @@
-const supertest = require("supertest");
-const { app, init } = require("../../app");
-
-const api = supertest(app);
+const { init } = require("../../app");
 const db = require("../../db/dummy")();
-const { loginUser } = require("./helper");
+const { createApi, loginUser } = require("./helper");
+
+const { api, close } = createApi();
 
 beforeEach(async () => {
   await db.init();
   await init();
 });
+
+afterAll(close);
 
 const getMetas = async (status = 200) =>
   api

--- a/server/tests/api/photos.test.js
+++ b/server/tests/api/photos.test.js
@@ -1,14 +1,15 @@
-const supertest = require("supertest");
-const { app, init } = require("../../app");
-
-const api = supertest(app);
+const { init } = require("../../app");
 const db = require("../../db/dummy")();
-const { loginUser } = require("./helper");
+const { createApi, loginUser } = require("./helper");
+
+const { api, close } = createApi();
 
 beforeEach(async () => {
   await db.init();
   await init();
 });
+
+afterAll(close);
 
 const getPhotos = async (token, status = 200) =>
   api.get("/api/v1/photos").set("Authorization", `Bearer ${token}`).expect(status);

--- a/server/tests/api/tokens.test.js
+++ b/server/tests/api/tokens.test.js
@@ -1,12 +1,13 @@
-const supertest = require("supertest");
-const { app, init } = require("../../app");
+const { init } = require("../../app");
+const { createApi, loginUser } = require("./helper");
 
-const api = supertest(app);
-const { loginUser } = require("./helper");
+const { api, close } = createApi();
 
 beforeEach(async () => {
   await init();
 });
+
+afterAll(close);
 
 describe("Login", () => {
   test("Non-existing user", async () => {

--- a/server/tests/api/users.test.js
+++ b/server/tests/api/users.test.js
@@ -1,14 +1,15 @@
-const supertest = require("supertest");
-const { app, init } = require("../../app");
-
-const api = supertest(app);
+const { init } = require("../../app");
 const db = require("../../db/dummy")();
-const { loginUser } = require("./helper");
+const { createApi, loginUser } = require("./helper");
+
+const { api, close } = createApi();
 
 beforeEach(async () => {
   await db.init();
   await init();
 });
+
+afterAll(close);
 
 const getUsers = async (token, status = 200) =>
   api.get("/api/v1/users").set("Authorization", `Bearer ${token}`).expect(status);


### PR DESCRIPTION
Full-suite test runs failed ~1 in 10 with "Parse Error: Expected HTTP/"
in one of the api/ files. Three commits:

1. The actual fix: each test file now uses one persistent server
   (via tests/api/helper.js createApi()) instead of letting supertest
   spin one up per request. The ephemeral-server churn was racing with
   the kernel's socket cleanup, leaving stale bytes on a reused port.
2. Token model's setTimeout was self-rescheduling without clearing
   the previous handle, so init() leaked timers. Now cleared+unref()ed,
   and the test script's --forceExit/--detectOpenHandles can go.
3. error-handler was calling next(error) after sending the response.
   Removed.

Verified by 30 consecutive full-suite runs, no failures.