### PR TITLE
Clear remaining lint errors

### DIFF
--- a/server/db/sqlite3/schema.js
+++ b/server/db/sqlite3/schema.js
@@ -243,7 +243,7 @@ const SCHEMA = {
     order: ["key ASC"],
     mapToRow: (meta) => {
       const result = {};
-      if ("key" in user) result[meta.key] = meta.value;
+      if ("key" in meta) result[meta.key] = meta.value;
       return result;
     },
   },

--- a/server/eslint.config.js
+++ b/server/eslint.config.js
@@ -18,7 +18,10 @@ module.exports = [
       },
     },
     rules: {
-      "no-unused-vars": ["error", { caughtErrors: "none" }],
+      "no-unused-vars": [
+        "error",
+        { caughtErrors: "none", argsIgnorePattern: "^_" },
+      ],
       indent: ["error", 2, { SwitchCase: 1 }],
       "linebreak-style": ["error", "unix"],
       quotes: ["error", "double", { avoidEscape: true }],

--- a/server/lib/middleware/error-handler.js
+++ b/server/lib/middleware/error-handler.js
@@ -3,8 +3,7 @@ const HttpStatus = require("http-status-codes");
 const CONST = require("../constants");
 const logger = require("../logger");
 
-// eslint-disable-next-line no-unused-vars
-module.exports = function (error, request, response, next) {
+module.exports = function (error, request, response, _next) {
   logger.debug(error);
   switch (error) {
     case CONST.ERROR_NOT_FOUND:

--- a/server/tests/api/meta.test.js
+++ b/server/tests/api/meta.test.js
@@ -1,6 +1,6 @@
 const { init } = require("../../app");
 const db = require("../../db/dummy")();
-const { createApi, loginUser } = require("./helper");
+const { createApi } = require("./helper");
 
 const { api, close } = createApi();
 
@@ -41,5 +41,3 @@ describe("As guest", () => {
     expect(result.body.name).toBe("dummy instance");
   });
 });
-
-afterAll(() => {});


### PR DESCRIPTION
Three small cleanups so `npm run lint` is clean with no inline disables:

- `db/sqlite3/schema.js`: `meta.mapToRow` referenced a non-existent `user` (copy-paste from `user.mapToRow` below). `updateMeta()` would have thrown `ReferenceError` at runtime.
- `tests/api/meta.test.js`: drop the unused `loginUser` import and a stray empty `afterAll()`.
- `lib/middleware/error-handler.js` + `eslint.config.js`: rename the unused trailing parameter to `_next` and add `argsIgnorePattern: "^_"` to the lint config. Express still recognises this as error middleware because it has four parameters.
