### PR TITLE
Align converter ESLint config with server

### DIFF
--- a/converter/eslint.config.js
+++ b/converter/eslint.config.js
@@ -18,7 +18,10 @@ module.exports = [
       },
     },
     rules: {
-      "no-unused-vars": ["error", { caughtErrors: "none" }],
+      "no-unused-vars": [
+        "error",
+        { caughtErrors: "none", argsIgnorePattern: "^_" },
+      ],
       indent: ["error", 2, { SwitchCase: 1 }],
       "linebreak-style": ["error", "unix"],
       quotes: ["error", "double", { avoidEscape: true }],


### PR DESCRIPTION
Mirrors the argsIgnorePattern: "^_" convention from server/eslint.config.js. No current code change — just enables prefixing intentionally-unused parameters with _ instead of needing inline disable comments.
