### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  server:
+    name: Server (lint + test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "26"
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+
+  converter:
+    name: Converter (lint + typecheck + test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: converter
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ImageMagick
+        run: sudo apt-get update && sudo apt-get install -y imagemagick
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "26"
+          cache: npm
+          cache-dependency-path: converter/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test
+
+  react-app:
+    name: React app (lint + test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: react-app
+    env:
+      CI: "true"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "26"
+          cache: npm
+          cache-dependency-path: react-app/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
     defaults:
       run:
         working-directory: server
+    env:
+      # Required by lib/config/index.js at module load. Value doesn't
+      # matter for tests (DB_DRIVER=dummy), it just has to exist.
+      SECRET: ci-test-secret
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Upgrade converter dependencies (jest 29, nodemon 3, dotenv 17, etc.)
 - Upgrade converter ESLint to v9 with flat config
 - Migrate converter to ESM + TypeScript (chokidar 4, image-size 2)
+- Add GitHub Actions CI for server, converter, and react-app
 
 ## [0.5.1] - 2022-05-02
 

--- a/converter/package.json
+++ b/converter/package.json
@@ -10,7 +10,7 @@
     "dumpexif": "tsx bin/dump-exif.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
-    "test": "node --import tsx/esm --test tests/**/*.test.ts"
+    "test": "tsx --test tests/**/*.test.ts"
   },
   "author": "Ville Misaki",
   "license": "MIT",

--- a/react-app/src/lib/format.test.js
+++ b/react-app/src/lib/format.test.js
@@ -111,7 +111,7 @@ describe("countryName()", () => {
     expect(format.countryName("en", countryData)("en")).toBe("en"));
 });
 describe("exposure", () => {
-  const formatExposure = format.exposure("en", (key) => { return key });
+  const formatExposure = format.exposure("en", (key) => { return key; });
   describe("focalLength()", () => {
     test("N/A", () => expect(formatExposure.focalLength("N/A")).toBe("N/A"));
     test("50", () => expect(formatExposure.focalLength(50)).toBe("50"));

--- a/react-app/src/lib/stats.test.js
+++ b/react-app/src/lib/stats.test.js
@@ -869,7 +869,7 @@ describe("collectTopics", () => {
             byAspectRatio: {
               "3:2": 2,
             },
-              byExposureTime: {
+            byExposureTime: {
               0.01: 2,
             },
             byExposureValue: {

--- a/react-app/src/models/PhotoModel.test.js
+++ b/react-app/src/models/PhotoModel.test.js
@@ -739,11 +739,13 @@ describe("With samples", () => {
       expect(samples["empty.jpg"].uniqueValues()).toStrictEqual({
         exposure: {
           aperture: new Set([null]),
+          "aspect-ratio": new Set([undefined]),
           ev: new Set([undefined]),
           "exposure-time": new Set([null]),
           "focal-length": new Set([null]),
           iso: new Set([null]),
           lv: new Set([undefined]),
+          orientation: new Set(["landscape"]),
           resolution: new Set([0]),
         },
         gear: {
@@ -765,11 +767,13 @@ describe("With samples", () => {
       expect(samples["1.jpg"].uniqueValues()).toStrictEqual({
         exposure: {
           aperture: new Set([2.8]),
+          "aspect-ratio": new Set(["3:2"]),
           ev: new Set([9.5]),
           "exposure-time": new Set([0.01]),
           "focal-length": new Set([23]),
           iso: new Set([100]),
           lv: new Set([9.5]),
+          orientation: new Set(["portrait"]),
           resolution: new Set([6]),
         },
         gear: {


### PR DESCRIPTION
Three parallel jobs on Node 26, running on push and PR against main:

- **server**: `npm ci`, lint, test (569 tests) — pure JS, no system deps.
- **converter**: `npm ci`, lint, typecheck, test (3 pipeline tests). Installs `imagemagick` via apt before the npm steps — the converter shells out to it via the `gm` package at runtime.
- **react-app**: `npm ci`, lint, test (945 tests). `CI=true` so `react-scripts test` runs once instead of dropping into watch mode.

All three jobs use `actions/setup-node@v4`'s built-in npm cache, keyed on each codebase's `package-lock.json`.

The first commit on this branch fixes four pre-existing issues that would have made CI red from day 1: two trivial lint errors (a missing semicolon, an indent slip) and two `PhotoModel.uniqueValues()` test expectations that were missing the `aspect-ratio` and `orientation` keys the implementation added at some point.
