### PR TITLE
Add engines.node: ">=22" to all three packages

### DIFF
--- a/converter/package.json
+++ b/converter/package.json
@@ -14,6 +14,9 @@
   },
   "author": "Ville Misaki",
   "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "chokidar": "^4.0.3",
     "dotenv": "^17.4.2",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -2,6 +2,9 @@
   "name": "photo-diary-app",
   "version": "0.5.1",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@react-leaflet/core": "^1.1.1",
     "axios": "^0.30.3",

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,9 @@
   },
   "author": "Ville Misaki",
   "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^12.10.0",


### PR DESCRIPTION
Adds an `engines.node: ">=22"` field to `server/`, `converter/`, and `react-app/` package.json files. Signals the minimum Node version (current LTS line) so fresh installs on older Node produce an npm warning.

Motivation: better-sqlite3's native module needs the install-time Node ABI to match the run-time ABI. The Node 22 floor catches the common footgun where someone installs on an old Node and then runs on a new one (or vice versa). Same baseline used for converter (tsx + ESM stack assumes recent Node) and react-app (its CRA scripts are happy on 22+).

This is npm's default-warning behavior — not enforcement. Anyone on older Node will see a warning at `npm install` time but the install still completes.
