### PR TITLE
Bump geo-coord to 0.2.0; drop local types shim

### DIFF
--- a/converter/package-lock.json
+++ b/converter/package-lock.json
@@ -12,7 +12,7 @@
         "chokidar": "^4.0.3",
         "dotenv": "^17.4.2",
         "exifr": "^7.1.3",
-        "geo-coord": "^0.1.1",
+        "geo-coord": "^0.2.0",
         "gm": "^1.25.1",
         "image-size": "^2.0.2"
       },
@@ -25,6 +25,9 @@
         "tsx": "^4.19.2",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1542,10 +1545,13 @@
       }
     },
     "node_modules/geo-coord": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/geo-coord/-/geo-coord-0.1.1.tgz",
-      "integrity": "sha512-bC2IMRtg+8OWvL4Xz/xkRF1Lu4VX6892m6icWUA4tzkw4HbF8a5fj3XCDArXKXWoQiVqCqtcV0DmisZakmJZ1g==",
-      "license": "MIT"
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/geo-coord/-/geo-coord-0.2.0.tgz",
+      "integrity": "sha512-7NVPSneNylUphOfsgYSnFEYVsnoiyzueTFiFOBYtAlyRbhg0AqFM5CJUkysAVBg0cl0BLkgpxWErKR5x2bdGtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",

--- a/converter/package.json
+++ b/converter/package.json
@@ -21,7 +21,7 @@
     "chokidar": "^4.0.3",
     "dotenv": "^17.4.2",
     "exifr": "^7.1.3",
-    "geo-coord": "^0.1.1",
+    "geo-coord": "^0.2.0",
     "gm": "^1.25.1",
     "image-size": "^2.0.2"
   },

--- a/converter/tsconfig.json
+++ b/converter/tsconfig.json
@@ -12,6 +12,6 @@
     "isolatedModules": true,
     "allowSyntheticDefaultImports": true
   },
-  "include": ["**/*.ts", "types/**/*.d.ts"],
+  "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/converter/types/geo-coord.d.ts
+++ b/converter/types/geo-coord.d.ts
@@ -1,6 +1,0 @@
-declare module "geo-coord" {
-  export class GeoCoord {
-    constructor(...args: unknown[]);
-    toDD(): { latitude: number; longitude: number };
-  }
-}


### PR DESCRIPTION
geo-coord 0.2.0 ships ESM + CJS + its own .d.ts, so the converter's `types/geo-coord.d.ts` shim and the `"types/**/*.d.ts"` include in tsconfig are no longer needed.

Typecheck, lint, and tests all green against the published 0.2.0; direct API exercise (8-arg DMS constructor + `toDD()`) verified before publishing.