### PR TITLE
Bump converter deps (chokidar 5, @types/node 25, globals 17)

### DIFF
--- a/converter/package-lock.json
+++ b/converter/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^4.0.3",
+        "chokidar": "^5.0.0",
         "dotenv": "^17.4.2",
         "exifr": "^7.1.3",
         "geo-coord": "^0.2.0",
@@ -19,9 +19,9 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@types/gm": "^1.25.4",
-        "@types/node": "^22.10.5",
+        "@types/node": "^25.8.0",
         "eslint": "^9.39.4",
-        "globals": "^16.5.0",
+        "globals": "^17.6.0",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.18.2"
@@ -720,13 +720,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "25.8.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+      "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1132,15 +1132,15 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1567,9 +1567,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1915,12 +1915,12 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -2098,9 +2098,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },

--- a/converter/package.json
+++ b/converter/package.json
@@ -18,7 +18,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "chokidar": "^4.0.3",
+    "chokidar": "^5.0.0",
     "dotenv": "^17.4.2",
     "exifr": "^7.1.3",
     "geo-coord": "^0.2.0",
@@ -28,9 +28,9 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@types/gm": "^1.25.4",
-    "@types/node": "^22.10.5",
+    "@types/node": "^25.8.0",
     "eslint": "^9.39.4",
-    "globals": "^16.5.0",
+    "globals": "^17.6.0",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.18.2"


### PR DESCRIPTION
Consolidated dep-refresh for `converter/` after closing 2 stale Dependabot PRs.

- `chokidar` 4 → 5: the `ignored`-filter watch form we use is unchanged in v5.
- `@types/node` 22 → 25: tracks Node 26 more closely.
- `globals` 16 → 17.

Lint + typecheck + 3/3 pipeline tests clean; `npm audit` reports zero vulnerabilities.

Deferred majors: `typescript` 5→6.