### PR TITLE
Bump TypeScript 5 → 6 in server and converter

### DIFF
--- a/converter/package-lock.json
+++ b/converter/package-lock.json
@@ -23,7 +23,7 @@
         "eslint": "^9.39.4",
         "globals": "^17.6.0",
         "tsx": "^4.19.2",
-        "typescript": "^5.7.2",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.18.2"
       },
       "engines": {
@@ -2060,9 +2060,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/converter/package.json
+++ b/converter/package.json
@@ -32,7 +32,7 @@
     "eslint": "^9.39.4",
     "globals": "^17.6.0",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.18.2"
   }
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -37,7 +37,7 @@
         "globals": "^17.6.0",
         "supertest": "^7.2.2",
         "tsx": "^4.19.2",
-        "typescript": "^5.7.2",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.18.2",
         "vitest": "^4.1.6"
       },
@@ -5153,9 +5153,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/server/package.json
+++ b/server/package.json
@@ -47,7 +47,7 @@
     "globals": "^17.6.0",
     "supertest": "^7.2.2",
     "tsx": "^4.19.2",
-    "typescript": "^5.7.2",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.18.2",
     "vitest": "^4.1.6"
   },


### PR DESCRIPTION
Both codebases compile cleanly under the new compiler; lint + tests unchanged (569/569 server vitest, 3/3 converter pipeline). No source changes required.