### PR TITLE
Server tsconfig + dotenv test-log hygiene

### DIFF
--- a/converter/index.ts
+++ b/converter/index.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import { config as dotenvConfig } from "dotenv";
+dotenvConfig({ quiet: true });
 import path from "node:path";
 import chokidar from "chokidar";
 

--- a/converter/lib/config.ts
+++ b/converter/lib/config.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import { config as dotenvConfig } from "dotenv";
+dotenvConfig({ quiet: true });
 import fs from "node:fs";
 import path from "node:path";
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import { config as dotenvConfig } from "dotenv";
+dotenvConfig({ quiet: true });
 import http from "node:http";
 
 import { app, init } from "./app.js";

--- a/server/lib/config/dev-config.ts
+++ b/server/lib/config/dev-config.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import { config as dotenvConfig } from "dotenv";
+dotenvConfig({ quiet: true });
 
 import CONST from "../constants.js";
 

--- a/server/lib/config/index.ts
+++ b/server/lib/config/index.ts
@@ -1,5 +1,6 @@
 /* istanbul ignore file */
-import "dotenv/config";
+import { config as dotenvConfig } from "dotenv";
+dotenvConfig({ quiet: true });
 
 import CONST from "../constants.js";
 import devConfig from "./dev-config.js";

--- a/server/lib/config/prod-config.ts
+++ b/server/lib/config/prod-config.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import { config as dotenvConfig } from "dotenv";
+dotenvConfig({ quiet: true });
 
 import CONST from "../constants.js";
 

--- a/server/lib/config/test-config.ts
+++ b/server/lib/config/test-config.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+import { config as dotenvConfig } from "dotenv";
+dotenvConfig({ quiet: true });
 
 const DEBUG = false;
 const DB_DRIVER = "dummy";

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -11,10 +11,8 @@
     "noEmit": true,
     "isolatedModules": true,
     "allowSyntheticDefaultImports": true,
-    "allowJs": true,
-    "checkJs": false,
     "types": ["vitest/globals", "node"]
   },
-  "include": ["**/*.ts", "**/*.js", "types/**/*.d.ts"],
+  "include": ["**/*.ts", "types/**/*.d.ts"],
   "exclude": ["node_modules", "build", "dist"]
 }


### PR DESCRIPTION
Two small cleanups bundled:

- `server/tsconfig.json`: drop `allowJs: true` and `checkJs: false` and remove `**/*.js` from the include — no `.js` source remains in server/, the flags were lingering from the gradual TS migration and only served to mask new .js drift.
- All 7 `import "dotenv/config"` sites (5 in server, 2 in converter) switched to the explicit `dotenvConfig({ quiet: true })` form so dotenv 17 stops printing its "tip" lines to stdout on every module load. Test logs are noticeably quieter as a result.

Lint + typecheck + tests clean in both projects.