### PR TITLE
Type SQLite row shapes per table; drop server `any` islands

### DIFF
--- a/server/bin/add-gallery.ts
+++ b/server/bin/add-gallery.ts
@@ -49,12 +49,12 @@ db.loadGallery(galleryId)
   .catch(async () => {
     const newGallery = {
       id: galleryId,
-      title: argv.title,
-      description: argv.description,
-      epoch: argv.epoch,
-      epoch_type: argv.epoch_type,
-      theme: argv.theme,
-      initial_view: argv.initial_view,
+      title: argv.title as string | undefined,
+      description: argv.description as string | undefined,
+      epoch: argv.epoch as string | undefined,
+      epochType: argv.epoch_type as string | undefined,
+      theme: argv.theme as string | undefined,
+      initialView: argv.initial_view as string | undefined,
     };
     db.createGallery(newGallery).catch((error) => {
       logger.error("Failed:", error);

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1,7 +1,12 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import config from "../lib/config/index.js";
-
-type Row = Record<string, any>;
+import type {
+  Gallery,
+  GalleryInput,
+  MetaRow,
+  Photo,
+  PhotoInput,
+  User,
+} from "./sqlite3/schema.js";
 
 const drivers = {
   dummy: () => import("./dummy.js"),
@@ -25,17 +30,20 @@ const connectDb = async () => {
 const db = await connectDb();
 
 export default {
-  loadMetas: async () => {
-    const metas = (await db.loadMetas()) as Row[];
-    return metas.reduce<Row>((acc, obj) => ({ ...acc, ...obj }), {});
+  loadMetas: async (): Promise<Record<string, string>> => {
+    const metas = (await db.loadMetas()) as Array<Record<string, string>>;
+    return metas.reduce<Record<string, string>>(
+      (acc, obj) => ({ ...acc, ...obj }),
+      {}
+    );
   },
-  createMeta: async (meta: Row) => {
+  createMeta: async (meta: { key: string; value: string }) => {
     await db.createMeta(meta);
   },
   loadMeta: async (key: string) => {
     return await db.loadMeta(key);
   },
-  updateMeta: async (key: string, meta: Row) => {
+  updateMeta: async (key: string, meta: Partial<MetaRow>) => {
     await db.updateMeta(key, meta);
   },
   deleteMeta: async (key: string) => {
@@ -45,33 +53,35 @@ export default {
   loadUsers: async () => {
     return await db.loadUsers();
   },
-  createUser: async (user: Row) => {
+  createUser: async (user: User) => {
     await db.createUser(user);
   },
   loadUser: async (userId: string) => {
     return await db.loadUser(userId);
   },
-  updateUser: async (userId: string, user: Row) => {
+  updateUser: async (userId: string, user: Partial<User>) => {
     await db.updateUser(userId, user);
   },
   deleteUser: async (userId: string) => {
     await db.deleteUser(userId);
   },
 
-  loadUserAccessControl: async (userId: string): Promise<Record<string, number>> => {
+  loadUserAccessControl: async (
+    userId: string
+  ): Promise<Record<string, number>> => {
     return await db.loadUserAccessControl(userId);
   },
 
   loadGalleries: async () => {
     return await db.loadGalleries();
   },
-  createGallery: async (gallery: Row) => {
-    await db.createGallery(gallery);
+  createGallery: async (gallery: GalleryInput) => {
+    await db.createGallery(gallery as Gallery);
   },
   loadGallery: async (galleryId: string) => {
     return await db.loadGallery(galleryId);
   },
-  updateGallery: async (galleryId: string, gallery: Row) => {
+  updateGallery: async (galleryId: string, gallery: GalleryInput) => {
     await db.updateGallery(galleryId, gallery);
   },
   deleteGallery: async (galleryId: string) => {
@@ -100,16 +110,19 @@ export default {
   loadPhotos: async () => {
     return await db.loadPhotos();
   },
-  createPhoto: async (photo: Row) => {
+  createPhoto: async (photo: PhotoInput) => {
     await db.createPhoto(photo);
   },
   loadPhoto: async (photoId: string) => {
     return await db.loadPhoto(photoId);
   },
-  updatePhoto: async (photoId: string, photo: Row) => {
+  updatePhoto: async (photoId: string, photo: PhotoInput) => {
     await db.updatePhoto(photoId, photo);
   },
   deletePhoto: async (photoId: string) => {
     await db.deletePhoto(photoId);
   },
 };
+
+// Re-export shared types so models can use them without reaching into the driver.
+export type { Gallery, GalleryInput, MetaRow, Photo, PhotoInput, User };

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -1,13 +1,21 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import Database from "better-sqlite3";
 
 import CONST from "../../lib/constants.js";
 import config from "../../lib/config/index.js";
 import logger from "../../lib/logger.js";
 
-import schemaFactory from "./schema.js";
-
-type Row = Record<string, any>;
+import schemaFactory, {
+  type AclRow,
+  type Gallery,
+  type GalleryInput,
+  type GalleryPhoto,
+  type GalleryRow,
+  type MetaRow,
+  type PhotoInput,
+  type PhotoRow,
+  type User,
+  type UserRow,
+} from "./schema.js";
 
 const SCHEMA = schemaFactory();
 
@@ -54,68 +62,92 @@ if (!config.DB_OPTS) {
 const db = new Database(config.DB_OPTS);
 logger.debug("Connected to DB");
 
-type SchemaEntry = ReturnType<typeof schemaFactory>[keyof ReturnType<typeof schemaFactory>];
-
-const loadAll = (schema: SchemaEntry) => {
-  return (db.prepare(schema.buildSelectQuery()).all() as Row[]).map(
-    schema.mapRow as (row: Row) => Row
-  );
-};
-const create = (schema: SchemaEntry, data: Row) => {
-  db.prepare(schema.buildCreateQuery()).run(schema.mapInsert(data) as never[]);
-};
-const loadById = (schema: SchemaEntry, id: string) => {
-  const row = db.prepare(schema.buildSelectByIdQuery()).get(id) as
-    | Row
-    | undefined;
-  if (!row) {
-    throw CONST.ERROR_NOT_FOUND;
-  }
-  return (schema.mapRow as (row: Row) => Row)(row);
-};
-const updateById = (schema: SchemaEntry, id: string, data: Row) => {
-  const { query, values } = schema.buildUpdateByIdQuery(data);
-  if (!query || !values) {
-    return;
-  }
-  db.prepare(query).run([...values, id]);
-};
-const deleteById = (schema: SchemaEntry, id: string) => {
+const deleteById = (
+  schema: { buildDeleteByIdQuery: () => string },
+  id: string
+) => {
   db.prepare(schema.buildDeleteByIdQuery()).run([id]);
 };
 
-const loadMetas = async () => loadAll(SCHEMA.meta);
-const createMeta = async (meta: Row) => create(SCHEMA.meta, meta);
-const loadMeta = async (key: string) => loadById(SCHEMA.meta, key);
-const updateMeta = async (key: string, meta: Row) =>
-  updateById(SCHEMA.meta, key, meta);
+const loadMetas = async () => {
+  const rows = db.prepare(SCHEMA.meta.buildSelectQuery()).all() as MetaRow[];
+  return rows.map(SCHEMA.meta.mapRow);
+};
+const createMeta = async (meta: { key: string; value: string }) => {
+  db.prepare(SCHEMA.meta.buildCreateQuery()).run(SCHEMA.meta.mapInsert(meta));
+};
+const loadMeta = async (key: string) => {
+  const row = db.prepare(SCHEMA.meta.buildSelectByIdQuery()).get(key) as
+    | MetaRow
+    | undefined;
+  if (!row) throw CONST.ERROR_NOT_FOUND;
+  return SCHEMA.meta.mapRow(row);
+};
+const updateMeta = async (key: string, meta: Partial<MetaRow>) => {
+  const { query, values } = SCHEMA.meta.buildUpdateByIdQuery(meta);
+  if (!query || !values) return;
+  db.prepare(query).run([...values, key]);
+};
 const deleteMeta = async (key: string) => deleteById(SCHEMA.meta, key);
 
-const loadUsers = async () => loadAll(SCHEMA.user);
-const createUser = async (user: Row) => create(SCHEMA.user, user);
-const loadUser = async (userId: string) => loadById(SCHEMA.user, userId);
-const updateUser = async (userId: string, user: Row) =>
-  updateById(SCHEMA.user, userId, user);
+const loadUsers = async () => {
+  const rows = db.prepare(SCHEMA.user.buildSelectQuery()).all() as UserRow[];
+  return rows.map(SCHEMA.user.mapRow);
+};
+const createUser = async (user: User) => {
+  db.prepare(SCHEMA.user.buildCreateQuery()).run(SCHEMA.user.mapInsert(user));
+};
+const loadUser = async (userId: string) => {
+  const row = db.prepare(SCHEMA.user.buildSelectByIdQuery()).get(userId) as
+    | UserRow
+    | undefined;
+  if (!row) throw CONST.ERROR_NOT_FOUND;
+  return SCHEMA.user.mapRow(row);
+};
+const updateUser = async (userId: string, user: Partial<User>) => {
+  const { query, values } = SCHEMA.user.buildUpdateByIdQuery(user);
+  if (!query || !values) return;
+  db.prepare(query).run([...values, userId]);
+};
 const deleteUser = async (userId: string) => deleteById(SCHEMA.user, userId);
 
-const loadUserAccessControl = async (userId: string) => {
+const loadUserAccessControl = async (
+  userId: string
+): Promise<Record<string, number>> => {
   const schema = SCHEMA.acl;
   // TODO: cache in memory
   const stmt = db.prepare(schema.buildSelectQuery(["user_id IN (?)"]));
-  const userRows = stmt.all([userId]) as Row[];
-  const guestRows = stmt.all([":guest"]) as Row[];
+  const userRows = stmt.all([userId]) as AclRow[];
+  const guestRows = stmt.all([":guest"]) as AclRow[];
   return {
-    ...Object.fromEntries(guestRows.map((row) => schema.mapRow(row))),
-    ...Object.fromEntries(userRows.map((row) => schema.mapRow(row))),
+    ...Object.fromEntries(guestRows.map(schema.mapRow)),
+    ...Object.fromEntries(userRows.map(schema.mapRow)),
   };
 };
 
-const loadGalleries = async () => loadAll(SCHEMA.gallery);
-const createGallery = async (gallery: Row) => create(SCHEMA.gallery, gallery);
-const loadGallery = async (galleryId: string) =>
-  loadById(SCHEMA.gallery, galleryId);
-const updateGallery = async (galleryId: string, gallery: Row) =>
-  updateById(SCHEMA.gallery, galleryId, gallery);
+const loadGalleries = async () => {
+  const rows = db
+    .prepare(SCHEMA.gallery.buildSelectQuery())
+    .all() as GalleryRow[];
+  return rows.map(SCHEMA.gallery.mapRow);
+};
+const createGallery = async (gallery: Gallery) => {
+  db.prepare(SCHEMA.gallery.buildCreateQuery()).run(
+    SCHEMA.gallery.mapInsert(gallery)
+  );
+};
+const loadGallery = async (galleryId: string) => {
+  const row = db
+    .prepare(SCHEMA.gallery.buildSelectByIdQuery())
+    .get(galleryId) as GalleryRow | undefined;
+  if (!row) throw CONST.ERROR_NOT_FOUND;
+  return SCHEMA.gallery.mapRow(row);
+};
+const updateGallery = async (galleryId: string, gallery: GalleryInput) => {
+  const { query, values } = SCHEMA.gallery.buildUpdateByIdQuery(gallery);
+  if (!query || !values) return;
+  db.prepare(query).run([...values, galleryId]);
+};
 const deleteGallery = async (galleryId: string) =>
   deleteById(SCHEMA.gallery, galleryId);
 
@@ -143,15 +175,19 @@ const loadGalleryPhotos = async (galleryId: string) => {
   const stmt = db.prepare(getQuery());
   const rows = (galleryId.startsWith(CONST.SPECIAL_GALLERY_PREFIX)
     ? stmt.all()
-    : stmt.all(galleryId)) as Row[];
+    : stmt.all(galleryId)) as PhotoRow[];
   return rows.map((row, index) => schema.mapRow(row, index));
 };
-const linkGalleryPhoto = async (galleryIds: string[], photoIds: string[]) => {
+const linkGalleryPhoto = async (
+  galleryIds: string[],
+  photoIds: string[]
+) => {
   const stmt = db.prepare(SCHEMA.galleryPhoto.buildCreateQuery());
   const insertAll = db.transaction(() => {
     photoIds.forEach((photoId) => {
       galleryIds.forEach((galleryId) => {
-        stmt.run(SCHEMA.galleryPhoto.mapInsert({ galleryId, photoId }));
+        const link: GalleryPhoto = { galleryId, photoId };
+        stmt.run(SCHEMA.galleryPhoto.mapInsert(link));
       });
     });
   });
@@ -186,19 +222,22 @@ const loadGalleryPhoto = async (galleryId: string, photoId: string) => {
   const stmt = db.prepare(getQuery());
   const rows = (galleryId.startsWith(CONST.SPECIAL_GALLERY_PREFIX)
     ? stmt.all(photoId)
-    : stmt.all(galleryId, photoId)) as Row[];
+    : stmt.all(galleryId, photoId)) as PhotoRow[];
   if (rows.length === 0) {
     throw CONST.ERROR_NOT_FOUND;
   }
   return schema.mapRow(rows[0], 0);
 };
 const unlinkGalleryPhoto = async (galleryId: string, photoId: string) => {
-  db.prepare(SCHEMA.galleryPhoto.buildDeleteByIdQuery()).run([galleryId, photoId]);
+  db.prepare(SCHEMA.galleryPhoto.buildDeleteByIdQuery()).run([
+    galleryId,
+    photoId,
+  ]);
 };
 const unlinkAllPhotos = async (galleryId: string) => {
-  db.prepare(SCHEMA.galleryPhoto.buildDeleteQuery(["gallery_id = ?"])).run([
-    galleryId,
-  ]);
+  db.prepare(
+    SCHEMA.galleryPhoto.buildDeleteQuery(["gallery_id = ?"])
+  ).run([galleryId]);
 };
 const unlinkAllGalleries = async (photoId: string) => {
   db.prepare(SCHEMA.galleryPhoto.buildDeleteQuery(["photo_id = ?"])).run([
@@ -206,9 +245,26 @@ const unlinkAllGalleries = async (photoId: string) => {
   ]);
 };
 
-const loadPhotos = async () => loadAll(SCHEMA.photo);
-const createPhoto = async (photo: Row) => create(SCHEMA.photo, photo);
-const loadPhoto = async (photoId: string) => loadById(SCHEMA.photo, photoId);
-const updatePhoto = async (photoId: string, photo: Row) =>
-  updateById(SCHEMA.photo, photoId, photo);
-const deletePhoto = async (photoId: string) => deleteById(SCHEMA.photo, photoId);
+const loadPhotos = async () => {
+  const rows = db.prepare(SCHEMA.photo.buildSelectQuery()).all() as PhotoRow[];
+  return rows.map((row, index) => SCHEMA.photo.mapRow(row, index));
+};
+const createPhoto = async (photo: PhotoInput) => {
+  db.prepare(SCHEMA.photo.buildCreateQuery()).run(
+    SCHEMA.photo.mapInsert(photo)
+  );
+};
+const loadPhoto = async (photoId: string) => {
+  const row = db.prepare(SCHEMA.photo.buildSelectByIdQuery()).get(photoId) as
+    | PhotoRow
+    | undefined;
+  if (!row) throw CONST.ERROR_NOT_FOUND;
+  return SCHEMA.photo.mapRow(row, 0);
+};
+const updatePhoto = async (photoId: string, photo: PhotoInput) => {
+  const { query, values } = SCHEMA.photo.buildUpdateByIdQuery(photo);
+  if (!query || !values) return;
+  db.prepare(query).run([...values, photoId]);
+};
+const deletePhoto = async (photoId: string) =>
+  deleteById(SCHEMA.photo, photoId);

--- a/server/db/sqlite3/schema.ts
+++ b/server/db/sqlite3/schema.ts
@@ -1,22 +1,157 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import CONST from "../../lib/constants.js";
 
-type Row = Record<string, any>;
-type Conditions = string[] | undefined;
+// Raw DB row shapes (one per table). Mirror the SELECT column list exactly.
+export interface MetaRow {
+  key: string;
+  value: string;
+}
+export interface UserRow {
+  id: string;
+  password: string;
+  secret: string;
+}
+export interface AclRow {
+  user_id: string;
+  gallery_id: string;
+  level: number;
+}
+export interface GalleryRow {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  epoch: string;
+  epoch_type: string;
+  theme: string;
+  initial_view: string;
+  hostname: string;
+}
+export interface GalleryPhotoRow {
+  gallery_id: string;
+  photo_id: string;
+}
+export interface PhotoRow {
+  id: string;
+  title: string;
+  description: string;
+  author: string;
+  taken: string;
+  country_code: string | null;
+  place: string;
+  coord_lat: number | null;
+  coord_lon: number | null;
+  coord_alt: number | null;
+  camera_make: string;
+  camera_model: string;
+  camera_serial: string;
+  lens_make: string;
+  lens_model: string;
+  lens_serial: string;
+  focal: number | null;
+  fstop: number | null;
+  exposure_time: number | null;
+  iso: number | null;
+  orig_width: number | null;
+  orig_height: number | null;
+  disp_width: number | null;
+  disp_height: number | null;
+  thumb_width: number | null;
+  thumb_height: number | null;
+}
+
+// App-side shapes (what mapRow returns / mapInsert and mapToRow take).
+export type Meta = Record<string, string>;
+export type User = UserRow;
+export type Acl = [galleryId: string, level: number];
+export interface Gallery {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  epoch: string;
+  epochType: string;
+  theme: string;
+  initialView: string;
+  hostname: string;
+}
+export interface GalleryPhoto {
+  galleryId: string;
+  photoId: string;
+}
+export interface Photo {
+  id: string;
+  index: number;
+  title: string;
+  description: string;
+  taken: {
+    instant: {
+      timestamp: string;
+      year: number;
+      month: number;
+      day: number;
+      hour: number;
+      minute: number;
+      second: number;
+    };
+    author: string;
+    location: {
+      country: string | undefined;
+      place: string;
+      coordinates: {
+        latitude: number | null;
+        longitude: number | null;
+        altitude: number | null;
+      };
+    };
+  };
+  camera: { make: string; model: string; serial: string };
+  lens: { make: string; model: string; serial: string };
+  exposure: {
+    focalLength: number | undefined;
+    aperture: number | undefined;
+    exposureTime: number | undefined;
+    iso: number | undefined;
+  };
+  dimensions: {
+    original: { width: number | undefined; height: number | undefined };
+    display: { width: number | undefined; height: number | undefined };
+    thumbnail: { width: number | undefined; height: number | undefined };
+  };
+}
+
+// Partial input shapes for updates / inserts. DeepPartial so nested
+// subtrees (e.g. photo.taken.location) can also be partially filled.
+type DeepPartial<T> = T extends object
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : T;
+export type GalleryInput = DeepPartial<Gallery>;
+export type PhotoInput = DeepPartial<Photo>;
+
+type Conditions = string[];
+
+type TableSchema = {
+  table: string;
+  columns: string[];
+  primaryKey: string[];
+  order: string[];
+  mapToRow?: (data: Record<string, unknown>) => Record<string, unknown>;
+};
 
 export default () => {
   return {
     meta: {
-      mapRow: (row: Row) => {
-        return {
-          [toString(row.key)]: toString(row.value),
-        };
-      },
-      mapInsert: (meta: Row) => [meta.key, meta.value],
+      mapRow: (row: MetaRow): Meta => ({
+        [toString(row.key)]: toString(row.value),
+      }),
+      mapInsert: (meta: { key: string; value: string }): unknown[] => [
+        meta.key,
+        meta.value,
+      ],
 
       buildCreateQuery: () => buildCreateQuery(SCHEMA.meta),
       buildSelectByIdQuery: () => buildSelectByIdQuery(SCHEMA.meta),
-      buildUpdateByIdQuery: (data: Row) => buildUpdateByIdQuery(SCHEMA.meta, data),
+      buildUpdateByIdQuery: (data: Partial<MetaRow>) =>
+        buildUpdateByIdQuery(SCHEMA.meta, data),
       buildDeleteByIdQuery: () => buildDeleteByIdQuery(SCHEMA.meta),
 
       buildSelectQuery: (conditions?: Conditions) =>
@@ -25,18 +160,21 @@ export default () => {
         buildDeleteQuery(SCHEMA.meta, conditions),
     },
     user: {
-      mapRow: (row: Row) => {
-        return {
-          id: toString(row.id),
-          password: toString(row.password),
-          secret: toString(row.secret),
-        };
-      },
-      mapInsert: (user: Row) => [user.id, user.password, user.secret],
+      mapRow: (row: UserRow): User => ({
+        id: toString(row.id),
+        password: toString(row.password),
+        secret: toString(row.secret),
+      }),
+      mapInsert: (user: User): unknown[] => [
+        user.id,
+        user.password,
+        user.secret,
+      ],
 
       buildCreateQuery: () => buildCreateQuery(SCHEMA.user),
       buildSelectByIdQuery: () => buildSelectByIdQuery(SCHEMA.user),
-      buildUpdateByIdQuery: (data: Row) => buildUpdateByIdQuery(SCHEMA.user, data),
+      buildUpdateByIdQuery: (data: Partial<User>) =>
+        buildUpdateByIdQuery(SCHEMA.user, data),
       buildDeleteByIdQuery: () => buildDeleteByIdQuery(SCHEMA.user),
 
       buildSelectQuery: (conditions?: Conditions) =>
@@ -45,15 +183,14 @@ export default () => {
         buildDeleteQuery(SCHEMA.user, conditions),
     },
     acl: {
-      mapRow: (row: Row) => {
-        return [row.gallery_id, row.level];
-      },
-      mapInsert: () => {
+      mapRow: (row: AclRow): Acl => [row.gallery_id, row.level],
+      mapInsert: (): unknown[] => {
         throw CONST.ERROR_NOT_IMPLEMENTED;
       },
       buildCreateQuery: () => buildCreateQuery(SCHEMA.acl),
       buildSelectByIdQuery: () => buildSelectByIdQuery(SCHEMA.acl),
-      buildUpdateByIdQuery: (data: Row) => buildUpdateByIdQuery(SCHEMA.acl, data),
+      buildUpdateByIdQuery: (data: Partial<AclRow>) =>
+        buildUpdateByIdQuery(SCHEMA.acl, data),
       buildDeleteByIdQuery: () => buildDeleteByIdQuery(SCHEMA.acl),
 
       buildSelectQuery: (conditions?: Conditions) =>
@@ -62,36 +199,32 @@ export default () => {
         buildDeleteQuery(SCHEMA.acl, conditions),
     },
     gallery: {
-      mapRow: (row: Row) => {
-        return {
-          id: toString(row.id),
-          title: toString(row.title),
-          description: toString(row.description),
-          icon: toString(row.icon),
-          epoch: toString(row.epoch).substring(0, 10),
-          epochType: toString(row.epoch_type),
-          theme: toString(row.theme),
-          initialView: toString(row.initial_view),
-          hostname: toString(row.hostname),
-        };
-      },
-      mapInsert: (gallery: Row) => {
-        return [
-          gallery.id,
-          gallery.title,
-          gallery.description,
-          gallery.icon,
-          gallery.epoch,
-          gallery.epochType,
-          gallery.theme,
-          gallery.initialView,
-          gallery.hostname,
-        ];
-      },
+      mapRow: (row: GalleryRow): Gallery => ({
+        id: toString(row.id),
+        title: toString(row.title),
+        description: toString(row.description),
+        icon: toString(row.icon),
+        epoch: toString(row.epoch).substring(0, 10),
+        epochType: toString(row.epoch_type),
+        theme: toString(row.theme),
+        initialView: toString(row.initial_view),
+        hostname: toString(row.hostname),
+      }),
+      mapInsert: (gallery: Gallery): unknown[] => [
+        gallery.id,
+        gallery.title,
+        gallery.description,
+        gallery.icon,
+        gallery.epoch,
+        gallery.epochType,
+        gallery.theme,
+        gallery.initialView,
+        gallery.hostname,
+      ],
 
       buildCreateQuery: () => buildCreateQuery(SCHEMA.gallery),
       buildSelectByIdQuery: () => buildSelectByIdQuery(SCHEMA.gallery),
-      buildUpdateByIdQuery: (data: Row) =>
+      buildUpdateByIdQuery: (data: GalleryInput) =>
         buildUpdateByIdQuery(SCHEMA.gallery, data),
       buildDeleteByIdQuery: () => buildDeleteByIdQuery(SCHEMA.gallery),
 
@@ -101,16 +234,14 @@ export default () => {
         buildDeleteQuery(SCHEMA.gallery, conditions),
     },
     galleryPhoto: {
-      mapRow: () => {
+      mapRow: (): GalleryPhoto => {
         throw CONST.ERROR_NOT_IMPLEMENTED;
       },
-      mapInsert: (galleryPhoto: Row) => {
-        return [galleryPhoto.galleryId, galleryPhoto.photoId];
-      },
+      mapInsert: (link: GalleryPhoto): unknown[] => [link.galleryId, link.photoId],
 
       buildCreateQuery: () => buildCreateQuery(SCHEMA.galleryPhoto),
       buildSelectByIdQuery: () => buildSelectByIdQuery(SCHEMA.galleryPhoto),
-      buildUpdateByIdQuery: (data: Row) =>
+      buildUpdateByIdQuery: (data: Partial<GalleryPhotoRow>) =>
         buildUpdateByIdQuery(SCHEMA.galleryPhoto, data),
       buildDeleteByIdQuery: () => buildDeleteByIdQuery(SCHEMA.galleryPhoto),
 
@@ -120,32 +251,25 @@ export default () => {
         buildDeleteQuery(SCHEMA.galleryPhoto, conditions),
     },
     photo: {
-      mapRow: (row: Row, index: number) => {
+      mapRow: (row: PhotoRow, index: number): Photo => {
         const taken = new Date(toString(row.taken).substring(0, 19));
-        const year = 0 + taken.getFullYear();
-        const month = taken.getMonth() + 1;
-        const day = taken.getDate();
-        const hour = taken.getHours();
-        const minute = taken.getMinutes();
-        const second = taken.getSeconds();
-
-        const normalizeCountry = (country: string | undefined) =>
+        const normalizeCountry = (country: string | null) =>
           !country || country === "unknown" ? undefined : country;
 
         return {
           id: toString(row.id),
-          index: index,
+          index,
           title: toString(row.title),
           description: toString(row.description),
           taken: {
             instant: {
               timestamp: toString(row.taken),
-              year: year,
-              month: month,
-              day: day,
-              hour: hour,
-              minute: minute,
-              second: second,
+              year: taken.getFullYear(),
+              month: taken.getMonth() + 1,
+              day: taken.getDate(),
+              hour: taken.getHours(),
+              minute: taken.getMinutes(),
+              second: taken.getSeconds(),
             },
             author: toString(row.author),
             location: {
@@ -190,8 +314,8 @@ export default () => {
           },
         };
       },
-      mapInsert: (photo: Row) => {
-        const map = SCHEMA.photo.mapToRow(photo);
+      mapInsert: (photo: PhotoInput): unknown[] => {
+        const map = photoMapToRow(photo);
         return [
           photo.id,
           map.title,
@@ -228,7 +352,8 @@ export default () => {
 
       buildCreateQuery: () => buildCreateQuery(SCHEMA.photo),
       buildSelectByIdQuery: () => buildSelectByIdQuery(SCHEMA.photo),
-      buildUpdateByIdQuery: (data: Row) => buildUpdateByIdQuery(SCHEMA.photo, data),
+      buildUpdateByIdQuery: (data: PhotoInput) =>
+        buildUpdateByIdQuery(SCHEMA.photo, data),
       buildDeleteByIdQuery: () => buildDeleteByIdQuery(SCHEMA.photo),
 
       buildSelectQuery: (conditions?: Conditions) =>
@@ -239,40 +364,126 @@ export default () => {
   };
 };
 
+// Per-table mapToRow: app-shape (possibly partial) → flat DB-column subset.
+const metaMapToRow = (
+  meta: Partial<MetaRow>
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  if ("key" in meta && meta.key !== undefined && "value" in meta) {
+    result[meta.key] = meta.value;
+  }
+  return result;
+};
+const userMapToRow = (user: Partial<User>): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  if ("password" in user) result.password = user.password;
+  if ("secret" in user) result.secret = user.secret;
+  return result;
+};
+const aclMapToRow = (acl: Partial<AclRow>): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  if ("level" in acl) result.level = acl.level;
+  return result;
+};
+const galleryMapToRow = (
+  gallery: GalleryInput
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  if ("title" in gallery) result.title = gallery.title;
+  if ("description" in gallery) result.description = gallery.description;
+  if ("icon" in gallery) result.icon = gallery.icon;
+  if ("epoch" in gallery) result.epoch = gallery.epoch;
+  if ("epochType" in gallery) result.epoch_type = gallery.epochType;
+  if ("theme" in gallery) result.theme = gallery.theme;
+  if ("initialView" in gallery) result.initial_view = gallery.initialView;
+  if ("hostname" in gallery) result.hostname = gallery.hostname;
+  return result;
+};
+const photoMapToRow = (photo: PhotoInput): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+  if ("title" in photo) result.title = photo.title;
+  if ("description" in photo) result.description = photo.description;
+  if (photo.taken) {
+    const taken = photo.taken;
+    if ("author" in taken) result.author = taken.author;
+    if (taken.instant) {
+      const instant = taken.instant;
+      if ("timestamp" in instant) result.taken = instant.timestamp;
+    }
+    if (taken.location) {
+      const location = taken.location;
+      if ("country" in location) result.country_code = location.country;
+      if ("place" in location) result.place = location.place;
+      if (location.coordinates) {
+        const coordinates = location.coordinates;
+        if ("latitude" in coordinates) result.coord_lat = coordinates.latitude;
+        if ("longitude" in coordinates) result.coord_lon = coordinates.longitude;
+        if ("altitude" in coordinates) result.coord_alt = coordinates.altitude;
+      }
+    }
+  }
+  if (photo.camera) {
+    const camera = photo.camera;
+    if ("make" in camera) result.camera_make = camera.make;
+    if ("model" in camera) result.camera_model = camera.model;
+    if ("serial" in camera) result.camera_serial = camera.serial;
+  }
+  if (photo.lens) {
+    const lens = photo.lens;
+    if ("make" in lens) result.lens_make = lens.make;
+    if ("model" in lens) result.lens_model = lens.model;
+    if ("serial" in lens) result.lens_serial = lens.serial;
+  }
+  if (photo.exposure) {
+    const exposure = photo.exposure;
+    if ("focalLength" in exposure) result.focal = exposure.focalLength;
+    if ("aperture" in exposure) result.fstop = exposure.aperture;
+    if ("exposureTime" in exposure)
+      result.exposure_time = exposure.exposureTime;
+    if ("iso" in exposure) result.iso = exposure.iso;
+  }
+  if (photo.dimensions) {
+    const dimensions = photo.dimensions;
+    if (dimensions.original) {
+      const original = dimensions.original;
+      if ("width" in original) result.orig_width = original.width;
+      if ("height" in original) result.orig_height = original.height;
+    }
+    if (dimensions.display) {
+      const display = dimensions.display;
+      if ("width" in display) result.disp_width = display.width;
+      if ("height" in display) result.disp_height = display.height;
+    }
+    if (dimensions.thumbnail) {
+      const thumbnail = dimensions.thumbnail;
+      if ("width" in thumbnail) result.thumb_width = thumbnail.width;
+      if ("height" in thumbnail) result.thumb_height = thumbnail.height;
+    }
+  }
+  return result;
+};
+
 const SCHEMA = {
   meta: {
     table: "meta",
     columns: ["key", "value"],
     primaryKey: ["key"],
     order: ["key ASC"],
-    mapToRow: (meta: Row) => {
-      const result: Row = {};
-      if ("key" in meta) result[meta.key] = meta.value;
-      return result;
-    },
+    mapToRow: metaMapToRow as (data: Record<string, unknown>) => Record<string, unknown>,
   },
   user: {
     table: "user",
     columns: ["id", "password", "secret"],
     primaryKey: ["id"],
     order: ["id ASC"],
-    mapToRow: (user: Row) => {
-      const result: Row = {};
-      if ("password" in user) result.password = user.password;
-      if ("secret" in user) result.secret = user.secret;
-      return result;
-    },
+    mapToRow: userMapToRow as (data: Record<string, unknown>) => Record<string, unknown>,
   },
   acl: {
     table: "acl",
     columns: ["user_id", "gallery_id", "level"],
     primaryKey: ["user_id", "gallery_id"],
     order: ["user_id ASC", "gallery_id ASC"],
-    mapToRow: (acl: Row) => {
-      const result: Row = {};
-      if ("level" in acl) result.level = acl.level;
-      return result;
-    },
+    mapToRow: aclMapToRow as (data: Record<string, unknown>) => Record<string, unknown>,
   },
   gallery: {
     table: "gallery",
@@ -289,27 +500,14 @@ const SCHEMA = {
     ],
     primaryKey: ["id"],
     order: ["id ASC"],
-    mapToRow: (gallery: Row) => {
-      const result: Row = {};
-      if ("title" in gallery) result.title = gallery.title;
-      if ("description" in gallery) result.description = gallery.description;
-      if ("icon" in gallery) result.icon = gallery.icon;
-      if ("epoch" in gallery) result.epoch = gallery.epoch;
-      if ("epochType" in gallery) result.epoch_type = gallery.epochType;
-      if ("theme" in gallery) result.theme = gallery.theme;
-      if ("initialView" in gallery) result.initial_view = gallery.initialView;
-      if ("hostname" in gallery) result.hostname = gallery.hostname;
-      return result;
-    },
+    mapToRow: galleryMapToRow as (data: Record<string, unknown>) => Record<string, unknown>,
   },
   galleryPhoto: {
     table: "gallery_photo",
     columns: ["gallery_id", "photo_id"],
     primaryKey: ["gallery_id", "photo_id"],
     order: ["gallery_id ASC", "photo_id ASC"],
-    mapToRow: () => {
-      return {};
-    },
+    mapToRow: (): Record<string, unknown> => ({}),
   },
   photo: {
     table: "photo",
@@ -347,77 +545,10 @@ const SCHEMA = {
     ],
     primaryKey: ["id"],
     order: ["taken ASC", "id ASC"],
-    mapToRow: (photo: Row) => {
-      const result: Row = {};
-      if ("title" in photo) result.title = photo.title;
-      if ("description" in photo) result.description = photo.description;
-      if (isSubTree(photo, "taken")) {
-        const taken = photo.taken;
-        if ("author" in taken) result.author = taken.author;
-        if (isSubTree(taken, "instant")) {
-          const instant = taken.instant;
-          if ("timestamp" in instant) result.taken = instant.timestamp;
-        }
-        if (isSubTree(taken, "location")) {
-          const location = taken.location;
-          if ("country" in location) result.country_code = location.country;
-          if ("place" in location) result.place = location.place;
-          if (isSubTree(location, "coordinates")) {
-            const coordinates = location.coordinates;
-            if ("latitude" in coordinates)
-              result.coord_lat = coordinates.latitude;
-            if ("longitude" in coordinates)
-              result.coord_lon = coordinates.longitude;
-            if ("altitude" in coordinates)
-              result.coord_alt = coordinates.altitude;
-          }
-        }
-      }
-      if (isSubTree(photo, "camera")) {
-        const camera = photo.camera;
-        if ("make" in camera) result.camera_make = camera.make;
-        if ("model" in camera) result.camera_model = camera.model;
-        if ("serial" in camera) result.camera_serial = camera.serial;
-      }
-      if (isSubTree(photo, "lens")) {
-        const lens = photo.lens;
-        if ("make" in lens) result.lens_make = lens.make;
-        if ("model" in lens) result.lens_model = lens.model;
-        if ("serial" in lens) result.lens_serial = lens.serial;
-      }
-      if (isSubTree(photo, "exposure")) {
-        const exposure = photo.exposure;
-        if ("focalLength" in exposure) result.focal = exposure.focalLength;
-        if ("aperture" in exposure) result.fstop = exposure.aperture;
-        if ("exposureTime" in exposure)
-          result.exposure_time = exposure.exposureTime;
-        if ("iso" in exposure) result.iso = exposure.iso;
-      }
-      if (isSubTree(photo, "dimensions")) {
-        const dimensions = photo.dimensions;
-        if (isSubTree(dimensions, "original")) {
-          const original = dimensions.original;
-          if ("width" in original) result.orig_width = original.width;
-          if ("height" in original) result.orig_height = original.height;
-        }
-        if (isSubTree(dimensions, "display")) {
-          const display = dimensions.display;
-          if ("width" in display) result.disp_width = display.width;
-          if ("height" in display) result.disp_height = display.height;
-        }
-        if (isSubTree(dimensions, "thumbnail")) {
-          const thumbnail = dimensions.thumbnail;
-          if ("width" in thumbnail) result.thumb_width = thumbnail.width;
-          if ("height" in thumbnail) result.thumb_height = thumbnail.height;
-        }
-      }
-      return result;
-    },
+    mapToRow: photoMapToRow as (data: Record<string, unknown>) => Record<string, unknown>,
   },
-};
+} satisfies Record<string, TableSchema>;
 
-const isSubTree = (obj: Row, key: string) =>
-  key in obj && typeof obj[key] === "object";
 const toString = (str: unknown): string => {
   if (str === null || str === undefined) {
     return "";
@@ -429,14 +560,6 @@ const toNumber = (num: unknown): number | undefined => {
     return undefined;
   }
   return Number(num);
-};
-
-type TableSchema = {
-  table: string;
-  columns: string[];
-  primaryKey: string[];
-  order: string[];
-  mapToRow?: (data: Row) => Row;
 };
 
 const buildSelectQuery = (schema: TableSchema, conditions?: Conditions) => {
@@ -463,15 +586,19 @@ const buildSelectByIdQuery = (schema: TableSchema) => {
     ` ORDER BY ${schema.order}`
   );
 };
-const buildUpdateByIdQuery = (schema: TableSchema, data: Row) => {
+const buildUpdateByIdQuery = (
+  schema: TableSchema,
+  data: Record<string, unknown>
+) => {
   if (!data) {
     return { query: undefined, values: undefined };
   }
-  schema.primaryKey.forEach((key) => delete data[key]);
-  if (Object.keys(data).length === 0) {
+  const cleaned: Record<string, unknown> = { ...data };
+  schema.primaryKey.forEach((key) => delete cleaned[key]);
+  if (Object.keys(cleaned).length === 0) {
     return { query: undefined, values: undefined };
   }
-  const columnData = schema.mapToRow ? schema.mapToRow(data) : data;
+  const columnData = schema.mapToRow ? schema.mapToRow(cleaned) : cleaned;
   const columns = schema.columns.filter((column) => column in columnData);
   const cleanData = Object.fromEntries(
     columns.map((column) => [column, columnData[column]])


### PR DESCRIPTION
Replaces the `Row = Record<string, any>` escape hatch in `db/sqlite3/schema.ts`, `db/sqlite3/index.ts`, and `db/index.ts` with concrete per-table interfaces — one for the raw DB row (matching the SELECT column list) and one for the app-side shape that `mapRow` returns / `mapInsert` and `mapToRow` accept.

**Types added in `schema.ts`:** `MetaRow`, `UserRow`, `AclRow`, `GalleryRow`, `GalleryPhotoRow`, `PhotoRow` (raw rows) and `User`, `Gallery`, `GalleryPhoto`, `Photo`, `Meta`, `Acl` plus `GalleryInput` / `PhotoInput` (DeepPartial variants for `buildUpdateByIdQuery` and create paths). The driver and the db/ facade re-export these so models can use them without reaching into the sqlite3 driver.

**Surfaced and fixed two latent bugs:**
- `bin/add-gallery.ts` was constructing new gallery rows with the DB snake_case keys (`epoch_type`, `initial_view`) where the model layer expects the app-side camelCase form (`epochType`, `initialView`). Without strict types those fields silently never reached the DB.
- `bin/add-gallery.ts`'s `argv` accesses are typed as `unknown` by yargs; added a small `as string | undefined` cast for each.

All three `eslint-disable` comments for `@typescript-eslint/no-explicit-any` in this layer are removed. Lint + typecheck + 569/569 tests clean; smoke-tested against a copy of the prod DB (meta, gallery list, single gallery + photos all return correctly).