### PR TITLE
Add `prod` script to converter

### DIFF
--- a/converter/package.json
+++ b/converter/package.json
@@ -6,6 +6,7 @@
   "main": "index.ts",
   "scripts": {
     "start": "tsx index.ts",
+    "prod": "NODE_ENV=prod pm2 start --interpreter tsx index.ts",
     "dev": "tsx watch index.ts",
     "dumpexif": "tsx bin/dump-exif.ts",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Matches the server's pattern: `pm2 start --interpreter tsx index.ts`. Without this, PM2's auto-detection on the .ts entry tries `bun` and fails when bun isn't installed.

Usage: `npm run prod -- --name dailybw-converter`