### PR TITLE
Export stats types and replace any in Stats/Filters chain

### DIFF
--- a/react-app/src/components/Gallery/Filters/Category.tsx
+++ b/react-app/src/components/Gallery/Filters/Category.tsx
@@ -6,7 +6,10 @@ import { BsFillXCircleFill, BsFillPlusCircleFill } from "react-icons/bs";
 import Value from "./Value";
 
 import filter, { type Filters as FiltersT } from "../../../lib/filter";
-import stats from "../../../lib/stats";
+import stats, {
+  type UniqueValues,
+  type UniqueValueEntry,
+} from "../../../lib/stats";
 
 interface CountryData {
   getName(code: string, lang: string): string | undefined;
@@ -47,14 +50,9 @@ interface Props {
   category: string;
   filters: FiltersT;
   setFilters: (filters: FiltersT) => void;
-  uniqueValues: any;
+  uniqueValues: UniqueValues;
   lang: string;
   countryData: CountryData;
-}
-
-interface ValueOption {
-  key: string;
-  value: string;
 }
 
 const Category = ({
@@ -110,11 +108,11 @@ const Category = ({
   const alreadyFilteredValue = (
     topic: string,
     category: string,
-    value: ValueOption
+    value: UniqueValueEntry
   ): boolean =>
     topic in filters &&
     category in filters[topic] &&
-    value.key in filters[topic][category];
+    String(value.key) in filters[topic][category];
 
   const renderValueAdder = (topic: string, category: string) => {
     const handleSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -147,7 +145,7 @@ const Category = ({
         category in valueSelector[topic] &&
         valueSelector[topic][category])
     ) {
-      const valuesLeft = (uniqueValues[topic][category] as ValueOption[]).filter(
+      const valuesLeft = uniqueValues[topic][category].filter(
         (value) => !alreadyFilteredValue(topic, category, value)
       );
       if (!valuesLeft.length) {
@@ -199,7 +197,6 @@ const Category = ({
           value={value}
           filters={filters}
           setFilters={setFilters}
-          uniqueValues={uniqueValues}
           lang={lang}
           countryData={countryData}
         />

--- a/react-app/src/components/Gallery/Filters/Topic.tsx
+++ b/react-app/src/components/Gallery/Filters/Topic.tsx
@@ -6,7 +6,7 @@ import { BsFillXCircleFill, BsFillPlusCircleFill } from "react-icons/bs";
 import Category from "./Category";
 
 import filter, { type Filters as FiltersT } from "../../../lib/filter";
-import stats from "../../../lib/stats";
+import stats, { type UniqueValues } from "../../../lib/stats";
 
 interface CountryData {
   getName(code: string, lang: string): string | undefined;
@@ -51,7 +51,7 @@ interface Props {
   topic: string;
   filters: FiltersT;
   setFilters: (filters: FiltersT) => void;
-  uniqueValues: any;
+  uniqueValues: UniqueValues;
   lang: string;
   countryData: CountryData;
 }
@@ -103,11 +103,11 @@ const Topic = ({
   const alreadyFilteredValue = (
     topic: string,
     category: string,
-    value: { key: string }
+    value: { key: string | number }
   ): boolean =>
     topic in filters &&
     category in filters[topic] &&
-    value.key in filters[topic][category];
+    String(value.key) in filters[topic][category];
 
   const renderCategoryAdder = (topic: string) => {
     const handleSelect = (event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -144,12 +144,7 @@ const Topic = ({
                 data-type="category"
                 data-key={category}
               >
-                {(
-                  uniqueValues[topic][category] as {
-                    key: string;
-                    value: string;
-                  }[]
-                )
+                {uniqueValues[topic][category]
                   .filter(
                     (value) => !alreadyFilteredValue(topic, category, value)
                   )

--- a/react-app/src/components/Gallery/Filters/Value.tsx
+++ b/react-app/src/components/Gallery/Filters/Value.tsx
@@ -36,7 +36,6 @@ interface Props {
   value: string;
   filters: FiltersT;
   setFilters: (filters: FiltersT) => void;
-  uniqueValues?: any;
   lang: string;
   countryData: CountryData;
 }

--- a/react-app/src/components/Gallery/Filters/index.tsx
+++ b/react-app/src/components/Gallery/Filters/index.tsx
@@ -10,6 +10,7 @@ import {
 import Topic from "./Topic";
 
 import filter, { type Filters as FiltersT } from "../../../lib/filter";
+import type { UniqueValues } from "../../../lib/stats";
 
 interface CountryData {
   getName(code: string, lang: string): string | undefined;
@@ -51,7 +52,7 @@ const NewCategory = styled.option``;
 interface Props {
   filters: FiltersT;
   setFilters: (filters: FiltersT) => void;
-  uniqueValues: any;
+  uniqueValues: UniqueValues;
   lang: string;
   countryData: CountryData;
 }

--- a/react-app/src/components/Gallery/Stats/Category.tsx
+++ b/react-app/src/components/Gallery/Stats/Category.tsx
@@ -6,6 +6,7 @@ import Charts from "./Charts";
 import Table from "./Table";
 
 import type { Filters as FiltersT } from "../../../lib/filter";
+import type { StatsTopic, StatsCategory } from "../../../lib/stats";
 
 type ActiveTheme = { get: (name: string) => string };
 
@@ -27,8 +28,8 @@ const Title = styled.h3`
 `;
 
 interface Props {
-  topic: any;
-  category: any;
+  topic: StatsTopic;
+  category: StatsCategory;
   filters: FiltersT;
   setFilters: (filters: FiltersT) => void;
   theme: ActiveTheme;

--- a/react-app/src/components/Gallery/Stats/Charts.tsx
+++ b/react-app/src/components/Gallery/Stats/Charts.tsx
@@ -4,6 +4,8 @@ import styled from "@emotion/styled";
 import "chart.js/auto";
 import { Doughnut, PolarArea, Bar, Line } from "react-chartjs-2";
 
+import type { StatsCategory } from "../../../lib/stats";
+
 const Root = styled.div`
   margin: 5px;
   width: 100%;
@@ -27,17 +29,17 @@ const StyledChartContainer2 = styled.div`
 `;
 
 interface Props {
-  category: any;
+  category: StatsCategory;
 }
 
 const Charts = ({ category }: Props): React.ReactElement => {
-  if (!("charts" in category) || !category.charts) {
+  if (!category.charts) {
     return <></>;
   }
   return (
     <Root>
-      {category.charts.map((chart: any) => {
-        const key = `${category.name}:${chart.type}`;
+      {category.charts.map((chart) => {
+        const key = `${category.key}:${chart.type}`;
         switch (chart.type) {
           case "doughnut":
             return (

--- a/react-app/src/components/Gallery/Stats/Summary.tsx
+++ b/react-app/src/components/Gallery/Stats/Summary.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "@emotion/styled";
 
+import type { StatsCategory } from "../../../lib/stats";
+
 const Root = styled.div`
   margin: 0;
   width: 100%;
@@ -57,19 +59,19 @@ const Value = styled.span`
 `;
 
 interface Props {
-  category: any;
+  category: StatsCategory;
 }
 
 const Summary = ({ category }: Props): React.ReactElement => {
   const { t } = useTranslation();
 
-  if (!("kpi" in category) || !category.kpi) {
+  if (!category.kpi) {
     return <></>;
   }
   return (
     <Root>
       <List>
-        {category.kpi.map((kpi: { key: string; value: string }) => (
+        {category.kpi.map((kpi) => (
           <Kpi key={`kpi:${kpi.key}`}>
             <Title>{t(`stats-kpi-title-${kpi.key}`)}</Title>
             <Value>

--- a/react-app/src/components/Gallery/Stats/Table.tsx
+++ b/react-app/src/components/Gallery/Stats/Table.tsx
@@ -5,6 +5,12 @@ import styled from "@emotion/styled";
 import color from "../../../lib/color";
 import stats from "../../../lib/stats";
 import filter, { type Filters as FiltersT } from "../../../lib/filter";
+import type {
+  StatsTopic,
+  StatsCategory,
+  TableRow,
+  TableColumn,
+} from "../../../lib/stats";
 
 type ActiveTheme = { get: (name: string) => string };
 
@@ -88,14 +94,9 @@ const getHeatColors = (theme: ActiveTheme): string[] => {
   return cachedHeatColors.values;
 };
 
-interface Column {
-  title: string;
-  align: string;
-  header?: boolean;
-}
 interface Props {
-  topic: any;
-  category: any;
+  topic: StatsTopic;
+  category: StatsCategory;
   filters: FiltersT;
   setFilters: (filters: FiltersT) => void;
   theme: ActiveTheme;
@@ -136,24 +137,25 @@ const Table = ({
     setFilters(newFilters);
   };
 
-  if (!("table" in category) || !category.table) {
+  if (!category.table || !category.tableColumns) {
     return <></>;
   }
-  const renderColumns = (values: Record<string, React.ReactNode>, i: number) => {
-    return category.tableColumns.map((column: Column) =>
+  const tableColumns = category.tableColumns;
+  const renderColumns = (values: TableRow, i: number) => {
+    return tableColumns.map((column: TableColumn) =>
       column.header ? (
         <RowHeader
           key={`${topic.key}:${category.key}:${i}${column.title}`}
           $align={column.align}
         >
-          {values[column.title]}
+          {values[column.title] as React.ReactNode}
         </RowHeader>
       ) : (
         <Column
           key={`${topic.key}:${category.key}:${i}${column.title}`}
           $align={column.align}
         >
-          {values[column.title]}
+          {values[column.title] as React.ReactNode}
         </Column>
       )
     );
@@ -174,7 +176,7 @@ const Table = ({
   const renderRows = (
     topic: string,
     category: string,
-    table: Record<string, React.ReactNode>[]
+    table: TableRow[]
   ) => {
     return table.map((value, i) => {
       const valueKey = stats.decodeTableRowKey(value.key as string | undefined);
@@ -221,7 +223,7 @@ const Table = ({
     <Root>
       <Block>
         <HeaderRow>
-          {category.tableColumns.map((column: Column) => (
+          {tableColumns.map((column: TableColumn) => (
             <Header
               key={`${topic.key}:header:${column.title}`}
               $align={column.align}

--- a/react-app/src/components/Gallery/Stats/Topic.tsx
+++ b/react-app/src/components/Gallery/Stats/Topic.tsx
@@ -4,6 +4,7 @@ import styled from "@emotion/styled";
 import Category from "./Category";
 
 import type { Filters as FiltersT } from "../../../lib/filter";
+import type { StatsTopic } from "../../../lib/stats";
 
 type ActiveTheme = { get: (name: string) => string };
 
@@ -33,7 +34,7 @@ const Categories = styled.section`
 `;
 
 interface Props {
-  topic: any;
+  topic: StatsTopic;
   filters: FiltersT;
   setFilters: (filters: FiltersT) => void;
   theme: ActiveTheme;
@@ -49,7 +50,7 @@ const Topic = ({
     <Root key={topic.key} data-type="topic" data-key={topic.key}>
       <Title>{topic.title}</Title>
       <Categories>
-        {topic.categories.map((category: any) => (
+        {topic.categories.map((category) => (
           <Category
             key={`${category.key}:${topic.key}`}
             topic={topic}

--- a/react-app/src/components/Gallery/Stats/index.tsx
+++ b/react-app/src/components/Gallery/Stats/index.tsx
@@ -5,7 +5,7 @@ import styled from "@emotion/styled";
 import Topic from "./Topic";
 import MapContainer from "../../MapContainer";
 
-import stats from "../../../lib/stats";
+import stats, { type UniqueValues } from "../../../lib/stats";
 
 import type { Photo } from "../../../models/PhotoModel";
 import type { Filters as FiltersT } from "../../../lib/filter";
@@ -26,7 +26,7 @@ const Root = styled.div`
 interface Props {
   children?: React.ReactNode;
   photos: Photo[];
-  uniqueValues: any;
+  uniqueValues: UniqueValues;
   filters: FiltersT;
   setFilters: (filters: FiltersT) => void;
   lang: string;
@@ -74,7 +74,7 @@ const Stats = ({
       <Root>
         {stats
           .collectTopics(data, lang, t, countryData, theme)
-          .map((topic: any) => (
+          .map((topic) => (
             <Topic
               key={topic.key}
               topic={topic}

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -24,7 +24,10 @@ import PhotoModel, { type Photo as PhotoT } from "../../models/PhotoModel";
 import collection from "../../lib/collection";
 import config from "../../lib/config";
 import format from "../../lib/format";
-import stats from "../../lib/stats";
+import stats, {
+  type UniqueValues,
+  type UniqueValueEntry,
+} from "../../lib/stats";
 import theme from "../../lib/theme";
 
 import type { Filters as FiltersT } from "../../lib/filter";
@@ -78,7 +81,9 @@ const Gallery = ({
   );
   const [gallery, setGallery] = React.useState<GalleryT | undefined>(undefined);
   const [photos, setPhotos] = React.useState<PhotoT[] | undefined>(undefined);
-  const [uniqueValues, setUniqueValues] = React.useState<any>(undefined);
+  const [uniqueValues, setUniqueValues] = React.useState<
+    UniqueValues | undefined
+  >(undefined);
   const [filters, setFilters] = React.useState<FiltersT>({});
   const [error, setError] = React.useState("");
 
@@ -148,36 +153,43 @@ const Gallery = ({
     if (!photos) {
       return;
     }
-    const newUniqueValues: any = photos
+    // The reduce builds up a `{ topic: { category: Set<unknown> } }` shape,
+    // then the forEach normalizes each Set into the consumer-facing
+    // `UniqueValueEntry[]`. The accumulator is typed as the loose
+    // Record-of-Record-of-Set during the build and cast to `UniqueValues`
+    // once the Sets have been flattened.
+    const accumulator: Record<string, Record<string, Set<unknown>>> = photos
       .map((photo) => photo.uniqueValues())
       .reduce(
         collection.mergeObjects<unknown>(
           (a, b) => new Set([...a, ...b]) as Set<unknown>
         ),
         {}
-      );
+      ) as Record<string, Record<string, Set<unknown>>>;
     const categoryValueFormatter = format.categoryValue(lang, t, countryData);
-    Object.keys(newUniqueValues).forEach((topic) => {
-      Object.keys(newUniqueValues[topic]).forEach((category) => {
-        newUniqueValues[topic][category] = [
-          ...(newUniqueValues[topic][category] as Iterable<unknown>),
-        ]
+    const flattened: UniqueValues = {} as UniqueValues;
+    Object.keys(accumulator).forEach((topic) => {
+      const topicBag: Record<string, UniqueValueEntry[]> = {};
+      Object.keys(accumulator[topic]).forEach((category) => {
+        topicBag[category] = [...accumulator[topic][category]]
           .map((value) => {
             if (value === "" || value === undefined || value === null) {
               return {
                 key: stats.UNKNOWN,
-                value: t("stats-unknown"),
+                value: String(t("stats-unknown")),
               };
             }
             return {
-              key: value,
-              value: categoryValueFormatter(category)(value as never),
+              key: value as string | number,
+              value: categoryValueFormatter(category)(value),
             };
           })
-          .sort(format.categorySorter("key", "value")(category) as any);
+          .sort(format.categorySorter("key", "value")(category));
       });
+      (flattened as Record<string, Record<string, UniqueValueEntry[]>>)[topic] =
+        topicBag;
     });
-    setUniqueValues(newUniqueValues);
+    setUniqueValues(flattened);
   }, [photos, lang, t, countryData]);
   React.useEffect(() => {
     if (!selectedGallery || !photos) {

--- a/react-app/src/lib/stats.test.ts
+++ b/react-app/src/lib/stats.test.ts
@@ -1194,7 +1194,7 @@ describe("collectTopics", () => {
     });
     expect(topics[0].categories[1].key).toBe("author");
     expect(topics[0].categories[1].title).toBe("stats-category-author");
-    expect(topics[0].categories[1].charts.length).toBe(2);
+    expect(topics[0].categories[1].charts!.length).toBe(2);
     expect(topics[0].categories[1].tableColumns).toStrictEqual([
       { title: "rank", align: "right", header: true },
       { title: "author", align: "left" },
@@ -1213,7 +1213,7 @@ describe("collectTopics", () => {
     ]);
     expect(topics[0].categories[2].key).toBe("country");
     expect(topics[0].categories[2].title).toBe("stats-category-country");
-    expect(topics[0].categories[2].charts.length).toBe(2);
+    expect(topics[0].categories[2].charts!.length).toBe(2);
     expect(topics[0].categories[2].tableColumns).toStrictEqual([
       { title: "rank", align: "right", header: true },
       { title: "flag", align: "right", header: true },
@@ -1221,8 +1221,8 @@ describe("collectTopics", () => {
       { title: "count", align: "right" },
       { title: "share", align: "right" },
     ]);
-    delete topics[0].categories[2].table[0].flag;
-    delete topics[0].categories[2].table[0].country;
+    delete topics[0].categories[2].table![0].flag;
+    delete topics[0].categories[2].table![0].country;
     expect(topics[0].categories[2].table).toStrictEqual([
       {
         key: '{"value":"jp","isUnknown":false}',

--- a/react-app/src/lib/stats.tsx
+++ b/react-app/src/lib/stats.tsx
@@ -39,13 +39,66 @@ interface Theme {
   get: (name: string) => string;
 }
 
+// Public types describing the shape `collectTopics` returns and the
+// shape `uniqueValues` flowing through Gallery / Filters / Stats components.
+// The internal aggregation carriers stay `any` (see the file header comment);
+// these are the consumer-facing shapes.
+export interface KpiItem {
+  key: string;
+  value: string;
+}
+export interface ChartSpec {
+  type: "doughnut" | "polar" | "horizontal-bar" | "line";
+  // chart.js data and options stay `any` — chart.js's own types are deep and
+  // we don't gain from authoring them here.
+  data: any;
+  options: any;
+}
+export interface TableColumn {
+  title: string;
+  align: string;
+  header?: boolean;
+}
+export interface TableRow {
+  key: string;
+  standardScore?: number;
+  [columnKey: string]: unknown;
+}
+// A single category bag: summary categories carry `kpi`; data categories
+// (author/country/year/etc.) carry `charts`/`tableColumns`/`table`. The fields
+// are optional because the union flattens through this single shape; consumers
+// guard with `if (category.kpi)` / `if (category.charts)` etc.
+export interface StatsCategory {
+  key: string;
+  title: string;
+  kpi?: KpiItem[];
+  charts?: ChartSpec[];
+  tableColumns?: TableColumn[];
+  table?: TableRow[];
+}
+export interface StatsTopic {
+  key: string;
+  title: string;
+  categories: StatsCategory[];
+}
+export interface UniqueValueEntry {
+  key: string | number;
+  value: string;
+}
+// Indexed by topic → category. The values are nested arrays of {key, value}
+// entries. Concrete topics include general/time/gear/exposure; concrete
+// categories include author/country/year/year-month/month/weekday/hour/
+// camera-make/camera/lens/camera-lens/focal-length/aperture/exposure-time/
+// iso/ev/lv/resolution/orientation/aspect-ratio.
+export type UniqueValues = Record<string, Record<string, UniqueValueEntry[]>>;
+
 const math = create(all, {});
 
 const UNKNOWN = "unknown";
 
 const generate = async (
   photos: (Photo | undefined)[],
-  uniqueValues: any
+  uniqueValues: UniqueValues
 ) => {
   return collectStatistics(photos.filter((p): p is Photo => !!p), uniqueValues);
 };
@@ -65,7 +118,7 @@ const collectTopics = (
   t: TFunction,
   countryData: CountryData,
   theme: Theme
-): any[] => {
+): StatsTopic[] => {
   const formatNumber = format.number(lang);
   const formatExposure = format.exposure(lang, t);
 
@@ -1127,7 +1180,9 @@ const collectTopics = (
     collectGear(),
     collectExposure(),
   ];
-  return topics;
+  // The internal carrier widens chart.type/table cell types to `string`/`any`;
+  // the public StatsTopic shape narrows them back. Runtime values match.
+  return topics as unknown as StatsTopic[];
 };
 
 export default { UNKNOWN, decodeTableRowKey, generate, collectTopics };


### PR DESCRIPTION
## Summary

Define and export consumer-facing types from `lib/stats.tsx`: `StatsTopic`, `StatsCategory`, `KpiItem`, `ChartSpec`, `TableColumn`, `TableRow`, `UniqueValueEntry`, `UniqueValues`. Thread them through `Gallery/index.tsx`'s `uniqueValues` state, the four Filters components, and the six Stats components. Replaces ~25 `any` annotations in the UI layer with real types.

`StatsCategory` is a flat shape with optional `kpi`/`charts`/`tableColumns`/`table` fields rather than a discriminated union — the JS reality is that the "summary" category carries `kpi` and the data categories carry `charts`/etc., and a discriminated union would need a runtime tag we don't have. Consumers guard with `if (!category.charts) return <></>`, which reads cleanly. The Charts component also benefits from `ChartSpec.type` being the narrow union `"doughnut" | "polar" | "horizontal-bar" | "line"` — the switch in `Stats/Charts.tsx` now gets exhaustiveness for free.

`collectTopics`'s return is cast `as unknown as StatsTopic[]` once at the boundary — the internal accumulator widens chart-type string literals back to `string`, but the runtime values match the narrow union that consumers benefit from.

`Gallery/index.tsx`'s `uniqueValues` building block was previously a single `any` accumulator with in-place mutation; rewrote it as a typed `accumulator: Record<string, Record<string, Set<unknown>>>` build pass followed by a typed `flattened: UniqueValues` normalize pass. Same runtime, no more `any`.

`lib/format.ts`'s `ValueFormatter` keeps `(value: any) => string` — the union of valid inputs (string country code, number aperture, string-formatted year-month, etc.) is genuinely too wide for a useful typed signature. Same with the lone `data: any` state in `Stats/index.tsx` (it's the internal stats accumulator that `collectTopics` consumes as `any` anyway).

Source `any` count (excluding `lib/stats.tsx`'s deliberately-typed internal carrier and test files) drops from ~30 to 2.

Two test sites use `!` non-null assertions on the now-optional `charts` / `table` fields (`topics[0].categories[1].charts!.length`).

## Test plan

- [x] `npm run typecheck` — clean, 0 errors
- [x] `npm run lint`
- [x] `npm test` — 945 tests pass
- [x] `npm run build` — vite production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)