### PR TITLE
Prepare for v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,34 +2,54 @@
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-19
+
+### Features
+
 - Add map to statistics page
 - Cluster closely grouped markers on the map
+
+### Server
+
 - Replace jsonwebtoken with jose to unblock Node 26
-- Upgrade server test infrastructure (jest 29, supertest 7, nodemon 3)
-- Upgrade server runtime dependencies (bcrypt 6, dotenv 17, uuid 11, cross-env 10, etc.)
-- Upgrade server to Express 5
-- Upgrade server ESLint to v9 with flat config
-- Upgrade converter dependencies (jest 29, nodemon 3, dotenv 17, etc.)
-- Upgrade converter ESLint to v9 with flat config
-- Migrate converter to ESM + TypeScript (chokidar 4, image-size 2)
-- Add GitHub Actions CI for server, converter, and react-app
-- Migrate server to ESM (vitest replaces jest, drops cross-env and nodemon)
+- Upgrade test infrastructure (jest 29, supertest 7, nodemon 3)
+- Upgrade runtime dependencies (bcrypt 6, dotenv 17, uuid 11, cross-env 10, etc.)
+- Upgrade to Express 5
+- Upgrade ESLint to v9 with flat config
+- Migrate to ESM (vitest replaces jest, drops cross-env and nodemon)
 - Swap sqlite3 for better-sqlite3 (sync API, simpler driver code)
   - **Heads-up (long-lived DBs):** better-sqlite3 enables `PRAGMA foreign_keys = ON` by default, whereas the old `sqlite3` driver left it off. If your prod DB was bootstrapped from the legacy schema, the `gallery_photo` foreign keys point at `photos(id)` / `galleries(id)` (plural) instead of the actual `photo` / `gallery` tables, and every mutation now fails with `no such table: main.galleries`. Fix by rebuilding the table on the prod DB with corrected references (back up first): `CREATE TABLE gallery_photo_new (gallery_id TEXT, photo_id TEXT, PRIMARY KEY(photo_id, gallery_id), FOREIGN KEY(photo_id) REFERENCES photo(id), FOREIGN KEY(gallery_id) REFERENCES gallery(id)); INSERT INTO gallery_photo_new SELECT * FROM gallery_photo; DROP TABLE gallery_photo; ALTER TABLE gallery_photo_new RENAME TO gallery_photo;` — wrap in `PRAGMA foreign_keys=OFF; BEGIN; … COMMIT; PRAGMA foreign_key_check; PRAGMA foreign_keys=ON;`.
-- Migrate server to TypeScript (strict mode, tsx runtime)
-- Replace CRA with Vite + Vitest for the react-app; swap react-helmet for react-helmet-async, axios for native fetch, drop date-diff
-  - **Breaking (deployment):** frontend env vars in `react-app/.env` (and any per-environment `.env`) renamed from `REACT_APP_*` to `VITE_*`. Update each deployed environment's config: `REACT_APP_PHOTO_ROOT_URL` → `VITE_PHOTO_ROOT_URL`, `REACT_APP_THEME` → `VITE_THEME`, `REACT_APP_DEFAULT_LANGUAGE` → `VITE_DEFAULT_LANGUAGE`, `REACT_APP_DEFAULT_GALLERY` → `VITE_DEFAULT_GALLERY`, `REACT_APP_INITIAL_GALLERY_VIEW` → `VITE_INITIAL_GALLERY_VIEW`, `REACT_APP_FIRST_WEEKDAY` → `VITE_FIRST_WEEKDAY`. Old names are silently ignored at build time.
-- Refresh server and converter dependencies to latest majors: vitest 4, uuid 14, jose 6, yargs 18, TypeScript 6, ESLint 10, chokidar 5, `@types/*` packages
-- Type the SQLite row shapes per table in the server's db layer; drop the `Record<string, any>` escape hatches. Fixed two latent bugs in `bin/add-gallery.ts` (snake_case keys instead of camelCase, untyped argv accesses) surfaced by the new strict types.
-- Quieten dotenv 17 "tip" output in tests via the `DOTENV_CONFIG_QUIET=true` env var on the test scripts; keep production using the side-effect `import "dotenv/config"` so `.env` is loaded during import resolution (before downstream modules read `process.env`)
-- Tighten server `tsconfig.json`: drop `allowJs`/`checkJs` now that no `.js` source remains
-- Replace `gm` with `sharp` in the converter; image processing is ~20× faster on real-size photos
+- Migrate to TypeScript (strict mode, tsx runtime)
+- Type SQLite row shapes per table in the db layer; drop the `Record<string, any>` escape hatches
+- Tighten `tsconfig.json`: drop `allowJs`/`checkJs` now that no `.js` source remains
+- Quieten dotenv 17 "tip" output in tests via `DOTENV_CONFIG_QUIET=true`; keep production on side-effect `import "dotenv/config"` so `.env` loads during import resolution
+
+### Converter
+
+- Upgrade dependencies (jest 29, nodemon 3, dotenv 17, etc.)
+- Upgrade ESLint to v9 with flat config
+- Migrate to ESM + TypeScript (chokidar 4, image-size 2)
+- Replace `gm` with `sharp`; image processing is ~20× faster on real-size photos
   - **Breaking (deployment):** the converter no longer requires the ImageMagick (or GraphicsMagick) CLI on the host — sharp ships its own libvips bindings via npm. You can `apt-get remove imagemagick` (or equivalent) on the converter host. CI's converter job no longer installs imagemagick.
-- Warm-up dep refresh in the react-app: jose 4→6, mathjs 10→15, react-icons 4→5, geo-coord 0.1→0.2, jsdom 25→27, globals 16→17, vitest 2→3. Drop the unused `@testing-library/user-event`.
-- Upgrade the react-app to React 18 with coupled deps: react/react-dom/react-is 17→18, react-helmet-async 1→2, react-leaflet 3→4, react-leaflet-markercluster 3→4, react-chartjs-2 3→4, react-i18next 11→14 with i18next 21→23, react-swipeable 6→7, @testing-library/react 12→14. Pin `prop-types` as a direct dep so it doesn't disappear when the router and React majors churn their transitive graphs. Also fix latent prop-type bugs surfaced by React 18's louder validator (string literals where numbers/booleans were expected on `<MapContainer>`, `Swipeable.children` declared as `object` instead of `node`).
-- Upgrade `react-router-dom` 5→7: `Switch` → `Routes`, the `element` prop replaces children, `Redirect` → `Navigate` with explicit `replace` to preserve v5's history-replace semantics. Skips the intermediate v6 because v7 is mostly a thin re-export and the meaningful API rewrite is v5→v6.
-- Upgrade the react-app to React 19 with coupled deps: react/react-dom/react-is 18→19, react-helmet-async 2→3, react-leaflet 4→5, react-leaflet-markercluster 4→5.0.0-rc.0, react-chartjs-2 4→5 with chart.js 3→4, react-i18next 14→17 with i18next 23→26, @testing-library/react 14→16. No source changes needed.
-- Swap `styled-components` for `@emotion/styled` (37 files). Mechanical import swap for 36 files; the one `createGlobalStyle` site converts to emotion's `Global` component. Done before the upcoming JS→TS migration so the styled-component types are right from the start.
+
+### Frontend (react-app)
+
+- Replace CRA with Vite + Vitest; swap react-helmet for react-helmet-async, axios for native fetch, drop date-diff
+  - **Breaking (deployment):** frontend env vars in `react-app/.env` (and any per-environment `.env`) renamed from `REACT_APP_*` to `VITE_*`. Update each deployed environment's config: `REACT_APP_PHOTO_ROOT_URL` → `VITE_PHOTO_ROOT_URL`, `REACT_APP_THEME` → `VITE_THEME`, `REACT_APP_DEFAULT_LANGUAGE` → `VITE_DEFAULT_LANGUAGE`, `REACT_APP_DEFAULT_GALLERY` → `VITE_DEFAULT_GALLERY`, `REACT_APP_INITIAL_GALLERY_VIEW` → `VITE_INITIAL_GALLERY_VIEW`, `REACT_APP_FIRST_WEEKDAY` → `VITE_FIRST_WEEKDAY`. Old names are silently ignored at build time.
+- Warm-up dep refresh: jose 4→6, mathjs 10→15, react-icons 4→5, geo-coord 0.1→0.2, jsdom 25→27, globals 16→17, vitest 2→3. Drop unused `@testing-library/user-event`.
+- Upgrade to React 18 with coupled deps: react/react-dom/react-is 17→18, react-helmet-async 1→2, react-leaflet 3→4, react-leaflet-markercluster 3→4, react-chartjs-2 3→4, react-i18next 11→14 with i18next 21→23, react-swipeable 6→7, @testing-library/react 12→14
+- Upgrade `react-router-dom` 5→7 (skips intermediate v6): `Switch` → `Routes`, `element` prop replaces children, `Redirect` → `Navigate` with explicit `replace`
+- Upgrade to React 19 with coupled deps: react/react-dom/react-is 18→19, react-helmet-async 2→3, react-leaflet 4→5, react-leaflet-markercluster 4→5.0.0-rc.0, react-chartjs-2 4→5 with chart.js 3→4, react-i18next 14→17 with i18next 23→26, @testing-library/react 14→16
+- Swap `styled-components` for `@emotion/styled` (37 files); the one `createGlobalStyle` site converts to emotion's `Global` component
+- Migrate to strict TypeScript across source and tests (8-PR incremental migration covering setup, lib, models, services, stats, components, and tests); drop `prop-types` runtime dep and `allowJs`
+- Export `StatsTopic` / `StatsCategory` / `KpiItem` / `ChartSpec` / `TableColumn` / `TableRow` / `UniqueValues` types from `lib/stats`; replaces ~25 `any` annotations threading through Gallery, Filters, and Stats components
+- Upgrade Vite 6→8 and `@vitejs/plugin-react` 4→5; production build ~4× faster via Rolldown
+
+### Cross-package
+
+- Add GitHub Actions CI for server, converter, and react-app
+- Refresh server and converter dependencies to latest majors: vitest 4, uuid 14, jose 6, yargs 18, TypeScript 6, ESLint 10, chokidar 5, `@types/*` packages
+- Patch-bump server and converter dev deps: `@types/node` 25.8→25.9, `tsx` 4.22.1→4.22.2, `typescript-eslint` 8.59.3→8.59.4
 
 ## [0.5.1] - 2022-05-02
 
@@ -150,7 +170,8 @@
 
 ## Initial commit - 2020-07-04
 
-[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/vlumi/photo-diary/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/vlumi/photo-diary/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/vlumi/photo-diary/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/vlumi/photo-diary/compare/v0.4.2...v0.5.0
 [0.4.2]: https://github.com/vlumi/photo-diary/compare/v0.4.1...v0.4.2

--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ Photo Diary is split into separate independent modules, each handling its own su
 
 ### Basic Setup
 
-- Create a reposity directory structure, separate from the code
+- Requires Node.js 22 or newer; npm 10+ recommended
+- Create a photo-repository directory structure, separate from the code
   - Must include the sub-directories `inbox`, `original`, `display`, and `thumbnail`
-  - Configure `PHOTO_ROOT_DIR` on [converter](converter) and [react-app](react-app) to point to this directory
-- Setup [server](server) and [converter](converter) to run as a background process, e.g. using [pm2](https://pm2.keymetrics.io/)
-- Build [react-app](react-app) into [server](server), running in the [server](server) directory:
+  - Configure `PHOTO_ROOT_DIR` on [converter](converter) to point to this directory
+  - Configure `VITE_PHOTO_ROOT_URL` on [react-app](react-app) to point to the public URL that serves `display/` and `thumbnail/` (typically the same nginx host)
+- Run `npm install` in [server](server), [converter](converter), and [react-app](react-app)
+- Set up [server](server) and [converter](converter) to run as background processes, e.g. via [pm2](https://pm2.keymetrics.io/) — both use `npm run prod` which invokes `pm2 start --interpreter tsx`
+- Build the [react-app](react-app) into [server](server) for production, running in the [server](server) directory:
   - `npm run build:ui`
 
 ## Features

--- a/converter/README.md
+++ b/converter/README.md
@@ -17,8 +17,21 @@ The root directory is passed using the `PHOTO_ROOT_DIR` environment variable, wi
 
 ## Requirements
 
-- [Node.js](https://nodejs.org) stack
-  - [npm](https://www.npmjs.com/) (tested on 6.14.5)
-  - [Node.js](https://nodejs.org) (tested on 14.5.0)
-- Dependencies
-  - [ImageMagick](https://imagemagick.org) (tested on 7.0.10)
+- [Node.js](https://nodejs.org) 22 or newer; npm 10+ recommended
+- No external CLI dependencies — image resizing is done via [sharp](https://sharp.pixelplumbing.com/) (libvips bindings shipped via npm)
+
+## Running Instructions
+
+The converter is TypeScript and runs via tsx (no build step). Common scripts:
+
+```sh
+npm run dev        # tsx watch index.ts
+npm start          # tsx index.ts
+npm run prod       # pm2 start --interpreter tsx index.ts (NODE_ENV=prod)
+npm test           # tsx --test tests/**/*.test.ts
+npm run typecheck  # tsc --noEmit
+npm run lint       # eslint .
+npm run dumpexif   # tsx bin/dump-exif.ts — utility for inspecting a photo's EXIF
+```
+
+Set `PHOTO_ROOT_DIR` either in a `.env` next to `index.ts` or inline before the command.

--- a/converter/package-lock.json
+++ b/converter/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary-converter",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary-converter",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",

--- a/converter/package.json
+++ b/converter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary-converter",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "main": "index.ts",

--- a/react-app/README.md
+++ b/react-app/README.md
@@ -1,54 +1,63 @@
 # Photo Diary React App
 
-This is a web application for the Photo Diary, implemented using React.
+The front-end SPA for the Photo Diary, served by the [server](../server) in production and developed against a [Vite](https://vite.dev) dev server. Written in TypeScript with strict mode.
 
 ## Requirements
 
-- Recent [Node.js](https://nodejs.org) stack
-  - [npm](https://www.npmjs.com/) (tested on 8.1.2)
-- Dependencies
-  - Photo Diary server
-  - Check `package.json` for more detailed dependencies
+- [Node.js](https://nodejs.org) 22 or newer; npm 10+ recommended
+- A running Photo Diary [server](../server) — the dev server proxies `/api/*` to `http://localhost:4200`
 
 ## Running Instructions
 
-The front-end server can be started as:
+```sh
+npm install
+npm run dev        # Vite dev server on http://localhost:3000
+npm run build      # Production build into build/ (Rolldown)
+npm run preview    # Serve the production build locally
+npm test           # vitest run
+npm run typecheck  # tsc --noEmit
+npm run lint       # eslint .
+```
 
-```
-node start
-```
-
-The server will by default start on port `3000`. Use the environment variable `PORT` to change the port, e.g.
-
-```
-PORT=3001 node start
-```
+For production the build is copied into [server](../server)/build/ via `npm run build:ui` (from the server directory) and served by the server.
 
 ### Environment Variables
 
-- `REACT_APP_PHOTO_ROOT_URL` \*
-  - The URL to the physical photos, with the following sub-directories
-    - `display` – Display-size, large photos
-    - `thumbnail` – Thumbnail-size, small photos
-- `PORT` (default: 3000)
-- `REACT_APP_THEME`
-  - The built-in color theme to use, configured in `themes.css`, with currently the following available:
-    - `blue` (default)
+Configured in `react-app/.env` (or a per-environment file like `.env.production`). Vite only exposes variables prefixed with `VITE_` to the client.
+
+- `VITE_PHOTO_ROOT_URL` \*
+  - The public URL serving the physical photos, with the following sub-directories:
+    - `display/` – display-size photos
+    - `thumbnail/` – thumbnail-size photos
+  - Can be overridden at runtime by the instance metadata `cdn` value served from the server's `/api/v1/meta` endpoint.
+- `VITE_THEME` (default: `blue`)
+  - Built-in color theme. Defined in `src/lib/theme.ts`. Currently available:
+    - `blue`
     - `red`
     - `grayscale`
-- `REACT_APP_DEFAULT_GALLERY`
-  - If the default gallery is set, accessing the gallery list will instead redirect to the gallery.
-- `REACT_APP_FIRST_WEEKDAY`
-  - The first day of the week, e.g. `1` = Monday, `0` = Sunday
+    - `bw`
+    - `alert`
+- `VITE_DEFAULT_LANGUAGE` (default: `en`)
+  - Initial UI language before a stored selection takes over. Supported: `en`, `fi`, `ja`.
+- `VITE_DEFAULT_GALLERY`
+  - If set, accessing `/g` (or the site root, which redirects to `/g`) redirects to this gallery instead of the gallery list.
+- `VITE_INITIAL_GALLERY_VIEW` (default: `month`)
+  - The view to land on when entering a gallery: `year` / `month` / `day` / `photo`.
+- `VITE_FIRST_WEEKDAY` (default: `1` — Monday)
+  - The first day of the week for the year-view calendar grid. `1` = Monday, `0` = Sunday.
 
-## Features
-
-TBD
+\* Required; everything else falls back to the listed default.
 
 ## Structure
 
-TBD
-
-### Components
-
-TBD
+- `src/index.tsx` — entry, mounts `<App>` inside `HelmetProvider` and `React.StrictMode`
+- `src/App.tsx` — routes (`react-router-dom` 7), top menu, country-locale registration, persisted-user bootstrap
+- `src/components/` — UI components
+  - `Gallery/` — gallery shell + `Year/Month/Day/Photo/Filters/Stats` sub-views
+  - `MapContainer.tsx` — Leaflet map wrapper used by the various Footer components
+  - `TopMenu.tsx`, `Login.tsx`, `Logout.tsx` — auth-aware top bar
+- `src/models/` — `PhotoModel`, `GalleryModel`, `UserModel` (functional constructors returning typed closures)
+- `src/services/` — thin `fetch` wrappers around the server's `/api/v1/*` endpoints
+- `src/lib/` — pure helpers (`calendar`, `collection`, `color`, `config`, `filter`, `format`, `i18n`, `stats`, `theme`, `keypress`, `scroll`, `token`, `api`)
+  - `stats.tsx` is the largest module — aggregates photo statistics into chart-ready data and table rows
+- `src/setupTests.ts` — vitest setup (registers `@testing-library/jest-dom` matchers)

--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary-app",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary-app",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary-app",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/server/README.md
+++ b/server/README.md
@@ -4,19 +4,25 @@ This server implements the RESTful API of the Photo Diary
 
 ## Requirements
 
-- Recent [Node.js](https://nodejs.org) stack
-  - [npm](https://www.npmjs.com/) (tested on 7.23.0)
-  - [Node.js](https://nodejs.org) (tested on 16.13.1)
-- Dependencies
-  - [Express](https://expressjs.com/)
-  - Check `package.json` for more detailed dependencies
+- [Node.js](https://nodejs.org) 22 or newer; npm 10+ recommended
+- Dependencies (see `package.json` for the full list)
+  - [Express](https://expressjs.com/) 5
+  - [better-sqlite3](https://github.com/WiseLibs/better-sqlite3) for the default SQLite driver
+  - [jose](https://github.com/panva/jose) for JWT signing/verification
+  - [tsx](https://github.com/privatenumber/tsx) as the TypeScript runtime (no separate build step)
 
 ## Running Instructions
 
-The back-end server can be started as:
+The server is TypeScript and runs via tsx (no build step). Common scripts:
 
-```
-node index.js
+```sh
+npm run dev        # tsx watch index.ts (NODE_ENV=dev)
+npm start          # tsx index.ts       (NODE_ENV=dev)
+npm run prod       # pm2 start --interpreter tsx index.ts (NODE_ENV=prod)
+npm test           # vitest run
+npm run typecheck  # tsc --noEmit
+npm run lint       # eslint .
+npm run build:ui   # builds the react-app and copies it into server/build/ for prod
 ```
 
 ### Environment Variables
@@ -27,12 +33,14 @@ Certain parameters are passed through environment veriables. These can be either
 - `DB_DRIVER` \*
   - The driver to use for the backend DB connection.
   - Currently implemented:
-    - `sqlite3` – Latest schema with all current features implemented
+    - `sqlite3` – Default driver, backed by better-sqlite3 (synchronous API)
     - `dummy` – data hard-coded into the driver, for testing purposes only
 - `DB_OPTS` (\* depends on `DB_DRIVER`)
   - This parameter will be passed to the `DB_DRIVER` during connection.
     - `sqlite3` – Path to the DB file
     - `dummy` – Not used
+- `SECRET` \*
+  - HMAC secret used to sign JWT tokens issued at login. Required — the server refuses to start without it.
 - `PHOTO_ROOT_DIR` \*
   - The path to the physical photos, with the following sub-directories
     - `inbox` – New photos to be added, or their extracted JSON files
@@ -46,9 +54,9 @@ Certain parameters are passed through environment veriables. These can be either
   - `npm run dev`
   - `npm run prod`
 - With the variables inlined:
-  - `DB_DRIVER=dummy npm run dev`
-  - `DB_DRIVER=sqlite3 DB_OPTS=/path/to/gallery.sqlite3 npm start`
-  - `DB_DRIVER=sqlite3 DB_OPTS=/path/to/gallery.sqlite3 npm prod`
+  - `SECRET=test DB_DRIVER=dummy npm run dev`
+  - `SECRET=… DB_DRIVER=sqlite3 DB_OPTS=/path/to/gallery.sqlite3 npm start`
+  - `SECRET=… DB_DRIVER=sqlite3 DB_OPTS=/path/to/gallery.sqlite3 npm run prod`
 
 ## Public API
 
@@ -98,7 +106,7 @@ The required access level is listed in brackets at the end of each resource meth
   - `GET` – Verify the current authenticatio ntoken **[any]**
   - `DELETE` – Logout, revoke all tokens for the current user **[any]**
   - `DELETE ../:userId` – Logout, revoke all tokens for the user **[admin]**
-- `/user`
+- `/users`
   - `GET` – List all users **[admin]**
   - `POST` – Create a new user **[admin]**
     1. `user`

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary-server",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary-server",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary-server",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
## Summary

Release-prep umbrella for v0.6.0.

**Version bumps:** `0.5.1` → `0.6.0` across server, converter, and react-app `package.json` (and the three lockfiles).

**CHANGELOG:**
- Date the existing `[Unreleased]` section as `[0.6.0] - 2026-05-19`
- Add a fresh empty `[Unreleased]` heading above it
- Add the v0.6.0 compare link
- Fix the long-standing typo where `[Unreleased]` pointed at `olivierlacan/keep-a-changelog/compare/...` instead of `vlumi/photo-diary/compare/...`

**READMEs** had drifted significantly during the renewal. Top-level: `PHOTO_ROOT_DIR` is set on the converter, `VITE_PHOTO_ROOT_URL` on the react-app — they were conflated. Bumped the Node baseline to 22 and called out the pm2 + tsx prod entry.

`server/README.md`: drop Node 16 / npm 7 references, drop the `node index.js` invocation (TypeScript now), document the actual npm scripts, add the `SECRET` env var (server refuses to start without it), correct `/user` → `/users` REST path. Note better-sqlite3 as the SQLite driver.

`converter/README.md`: drop the ImageMagick CLI dependency line (sharp/libvips ships via npm), bump Node baseline to 22, document the npm scripts including `dumpexif`.

`react-app/README.md`: rewrite. The `REACT_APP_*` env var listing replaced with the actual `VITE_*` set (including the previously-undocumented `VITE_DEFAULT_LANGUAGE` and `VITE_INITIAL_GALLERY_VIEW`), `node start` corrected to `npm run dev`, the `bw` and `alert` themes added to the theme list, and the three `TBD` sections (Features, Structure, Components) replaced with a real Structure outline.

**Deliberately not in this PR:**
- The 15 code TODOs in source — all pre-existing notes (admin endpoint validation, perf caching, optional features); none release-blocking.
- Multi-instance VM deployment ergonomics — captured for the post-renewal backlog; intentionally out of scope for v0.6.0.

## Test plan

- [x] `npm run typecheck` clean on server, converter, react-app
- [x] `npm test` — server 569, converter 3, react-app 945 (all pass)
- [x] `npm run build` clean on react-app
- [ ] Manual sanity-check of the README install/run snippets on a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)