### PR TITLE
Make server bin scripts directly runnable

### DIFF
--- a/react-app/package-lock.json
+++ b/react-app/package-lock.json
@@ -7667,24 +7667,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",

--- a/server/README.md
+++ b/server/README.md
@@ -58,6 +58,18 @@ Certain parameters are passed through environment veriables. These can be either
   - `SECRET=… DB_DRIVER=sqlite3 DB_OPTS=/path/to/gallery.sqlite3 npm start`
   - `SECRET=… DB_DRIVER=sqlite3 DB_OPTS=/path/to/gallery.sqlite3 npm run prod`
 
+### Management scripts
+
+Scripts under `bin/` add or update users, galleries, and photos in the DB. They are executable and use a `#!/usr/bin/env -S npx tsx` shebang, so from the `server/` directory they can be run directly:
+
+```sh
+./bin/add-user.ts [options]
+./bin/add-gallery.ts [options]
+./bin/add-photo.ts [options] [json-or-jpg-files]
+```
+
+Each script takes `--help` to list its flags. They read the same `.env` as the server, so `SECRET`, `DB_DRIVER`, and `DB_OPTS` need to be set the same way.
+
 ## Public API
 
 ### Access control

--- a/server/bin/add-gallery.ts
+++ b/server/bin/add-gallery.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S npx tsx
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import yargs from "yargs";

--- a/server/bin/add-photo.ts
+++ b/server/bin/add-photo.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S npx tsx
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import fs from "node:fs";
 import path from "node:path";

--- a/server/bin/add-user.ts
+++ b/server/bin/add-user.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S npx tsx
 
 import bcrypt from "bcrypt";
 import { v4 as uuidv4 } from "uuid";


### PR DESCRIPTION
## Summary

Tiny follow-up to #156. The TS migration moved the bin scripts from `.js` to `.ts`, but the shebang stayed `#!/usr/bin/env node`, which can't execute TypeScript. Switch to `#!/usr/bin/env -S npx tsx` (the `-S` flag lets env pass `npx tsx` through as a single command + argument). `add-gallery.ts` also picked up the executable bit (the other two already had it).

From `server/`, `./bin/add-user.ts --help` now works directly without the `npx tsx ...` prefix.

Documents the direct-run path under a new "Management scripts" section in `server/README.md`.

`react-app/package-lock.json` carries a tiny unrelated prune (npm 11 dropped an optional `yaml` peer entry on the last fresh install) that was sitting in the same working tree.

## Test plan

- [x] `./bin/add-user.ts` runs and prints the yargs help

🤖 Generated with [Claude Code](https://claude.com/claude-code)