### PR TITLE
Replace uuid with built-in crypto.randomUUID()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Server
+
+- Replace the `uuid` dep with the built-in `crypto.randomUUID()`
+
 ## [0.6.0] - 2026-05-19
 
 ### Features

--- a/server/bin/add-user.ts
+++ b/server/bin/add-user.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S npx tsx
 
+import { randomUUID } from "node:crypto";
+
 import bcrypt from "bcrypt";
-import { v4 as uuidv4 } from "uuid";
 
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -47,7 +48,7 @@ if (argv.l) {
     db.loadUser(userId)
       .then(async (user) => {
         const u = user as { id: string };
-        db.updateUser(u.id, { password: hash, secret: uuidv4() }).catch(
+        db.updateUser(u.id, { password: hash, secret: randomUUID() }).catch(
           (error) => {
             logger.error("Failed:", error);
           }
@@ -55,7 +56,7 @@ if (argv.l) {
         logger.info(`Existing user "${userId}" found and updated.`);
       })
       .catch(async () => {
-        db.createUser({ id: userId, password: hash, secret: uuidv4() }).catch(
+        db.createUser({ id: userId, password: hash, secret: randomUUID() }).catch(
           (error) => {
             logger.error("Failed:", error);
           }

--- a/server/db/dummy.ts
+++ b/server/db/dummy.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 
 import CONST from "../lib/constants.js";
 
@@ -231,47 +231,47 @@ const dbDump = JSON.stringify({
     admin: {
       id: "admin",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
-      secret: uuidv4(),
+      secret: randomUUID(),
     },
     gallery1Admin: {
       id: "gallery1Admin",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
-      secret: uuidv4(),
+      secret: randomUUID(),
     },
     gallery2Admin: {
       id: "gallery2Admin",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
-      secret: uuidv4(),
+      secret: randomUUID(),
     },
     gallery1User: {
       id: "gallery1User",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
-      secret: uuidv4(),
+      secret: randomUUID(),
     },
     gallery12User: {
       id: "gallery12User",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
-      secret: uuidv4(),
+      secret: randomUUID(),
     },
     plainUser: {
       id: "plainUser",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
-      secret: uuidv4(),
+      secret: randomUUID(),
     },
     publicUser: {
       id: "publicUser",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
-      secret: uuidv4(),
+      secret: randomUUID(),
     },
     simpleUser: {
       id: "simpleUser",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
-      secret: uuidv4(),
+      secret: randomUUID(),
     },
     blockedUser: {
       id: "blockedUser",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
-      secret: uuidv4(),
+      secret: randomUUID(),
     },
   },
   accessControl: {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,7 +19,6 @@
         "http-status-codes": "^2.3.0",
         "jose": "^6.2.3",
         "morgan": "^1.10.1",
-        "uuid": "^14.0.0",
         "yargs": "^18.0.0"
       },
       "devDependencies": {
@@ -4961,19 +4960,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/server/package.json
+++ b/server/package.json
@@ -29,7 +29,6 @@
     "http-status-codes": "^2.3.0",
     "jose": "^6.2.3",
     "morgan": "^1.10.1",
-    "uuid": "^14.0.0",
     "yargs": "^18.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #164.

Two call sites — [server/bin/add-user.ts](server/bin/add-user.ts) and [server/db/dummy.ts](server/db/dummy.ts) — used uuid only for plain v4 generation. Node 19+ ships `crypto.randomUUID()` which produces RFC 4122 v4 UUIDs natively, and our `engines.node` is `>=22`, so this is a safe drop-in. Drops `uuid` from the server's package surface.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 569 tests pass
- [x] `npm ls uuid` returns empty (transitive only via other deps, no direct dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)