### PR TITLE
Strengthen AI-scraper opt-out signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 ### Server
 
 - Replace the `uuid` dep with the built-in `crypto.randomUUID()`
+- Send `X-Robots-Tag: noindex, noai, noimageai` on every response, including served photo files
 
 ### Frontend
 
 - Replace `mathjs` with inline native `mean`/`stddev` helpers in `stats.tsx`; production bundle drops ~40% (1.5 MB → 876 kB raw, 460 kB → 282 kB gzipped)
 - Drop `react-helmet-async` in favor of React 19's native `<title>`/`<meta>` hoisting (6 call sites)
+- Enumerate AI-training bots explicitly in `robots.txt` (GPTBot, Google-Extended, ClaudeBot, PerplexityBot, CCBot, etc.) for crawlers that ignore the `User-agent: *` wildcard
 
 ## [0.6.0] - 2026-05-19
 

--- a/react-app/public/robots.txt
+++ b/react-app/public/robots.txt
@@ -1,2 +1,51 @@
 User-agent: *
 Disallow: /
+
+# Explicit AI-training-bot disallows. The wildcard above is enough for any
+# crawler that respects it; these stanzas cover bots that only react to their
+# own User-agent line.
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: OAI-SearchBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: PerplexityBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: meta-externalagent
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Amazonbot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /

--- a/server/app.ts
+++ b/server/app.ts
@@ -18,6 +18,13 @@ export const app = express();
 app.use(cors());
 app.use(compression());
 app.use(express.json());
+// Discourage indexing and AI scraping on every response. robots.txt is the
+// authoritative signal; this header covers non-HTML resources (photo files)
+// and reaches scrapers that honor X-Robots-Tag values like `noai`/`noimageai`.
+app.use((_req, res, next) => {
+  res.setHeader("X-Robots-Tag", "noindex, noai, noimageai");
+  next();
+});
 app.use(express.static("build"));
 app.use("/g", express.static("build"));
 app.use("/g/*splat", express.static("build"));


### PR DESCRIPTION
Closes #173.

[react-app/public/robots.txt](react-app/public/robots.txt) already has `User-agent: * / Disallow: /`, which binds every well-behaved crawler. Two belt-and-suspenders additions:

- **Explicit per-bot stanzas** for the major AI-training bots in `robots.txt` (GPTBot, OAI-SearchBot, ChatGPT-User, Google-Extended, ClaudeBot, anthropic-ai, Claude-Web, PerplexityBot, CCBot, Bytespider, meta-externalagent, Applebot-Extended, Amazonbot, Omgilibot, Diffbot). Some bots only react to their own `User-agent` line and ignore the wildcard.
- **`X-Robots-Tag: noindex, noai, noimageai` header** on every response via [server/app.ts](server/app.ts) middleware. Covers non-HTML resources (the photos themselves, which are served directly by the server) and reaches scrapers that honor the header's `noai`/`noimageai` extensions even though those aren't W3C-standardized.

Out of scope: bad-faith scrapers that ignore robots.txt and headers — that's a network-edge problem (Cloudflare's "Block AI Scrapers" toggle, fail2ban, etc.), not an application-layer one.

## Test plan

- [x] `npm --prefix server run typecheck` — clean
- [x] `npm --prefix server run lint` — clean
- [x] `npm --prefix server test` — 569 tests pass
- [ ] Optional: `curl -I https://your-deploy/api/v1/meta` → `X-Robots-Tag` header is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)