### PR TITLE
Move frontend config from build-time VITE_ vars to runtime defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Replace `mathjs` with inline native `mean`/`stddev` helpers in `stats.tsx`; production bundle drops ~40% (1.5 MB → 876 kB raw, 460 kB → 282 kB gzipped)
 - Drop `react-helmet-async` in favor of React 19's native `<title>`/`<meta>` hoisting (6 call sites)
 - Enumerate AI-training bots explicitly in `robots.txt` (GPTBot, Google-Extended, ClaudeBot, PerplexityBot, CCBot, etc.) for crawlers that ignore the `User-agent: *` wildcard
+- Drop the six `VITE_*` build-time env vars; defaults live in `lib/config.ts` and `Gallery/index.tsx` applies runtime overrides from `/api/v1/meta` (`defaultGallery`, `defaultTheme`, `initialGalleryView`, `firstWeekday`) on top of the existing `cdn` → `PHOTO_ROOT_URL` path, so one frontend build serves any instance
+  - **Breaking (deployment):** per-instance overrides move from `react-app/.env` to the **server's** `.env`. Rename `VITE_DEFAULT_GALLERY` → `DEFAULT_GALLERY`, `VITE_THEME` → `DEFAULT_THEME`, `VITE_INITIAL_GALLERY_VIEW` → `INITIAL_GALLERY_VIEW`, `VITE_FIRST_WEEKDAY` → `FIRST_WEEKDAY` in each deployed instance's `server/.env`. `VITE_PHOTO_ROOT_URL` should already be using the `instance_cdn` meta row. `VITE_DEFAULT_LANGUAGE` doesn't map — change the literal in `lib/config.ts` if you need a different fallback; i18next initializes before meta loads.
+- Drop the six `VITE_*` build-time env vars; defaults are now plain values in `lib/config.ts` and the API meta endpoint's `cdn` continues to override `PHOTO_ROOT_URL` at runtime, so one frontend build serves any instance
+  - **Breaking (deployment):** the per-environment `.env` files no longer need any `VITE_*` entries; they'll be silently ignored. Per-instance branding now flows entirely through the API (`meta.cdn` for the photo root URL; per-`gallery` rows for `theme`, `initial_view`, `hostname`).
 
 ## [0.6.0] - 2026-05-19
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Photo Diary is split into separate independent modules, each handling its own su
 - Create a photo-repository directory structure, separate from the code
   - Must include the sub-directories `inbox`, `original`, `display`, and `thumbnail`
   - Configure `PHOTO_ROOT_DIR` on [converter](converter) to point to this directory
-  - Configure `VITE_PHOTO_ROOT_URL` on [react-app](react-app) to point to the public URL that serves `display/` and `thumbnail/` (typically the same nginx host)
+  - Configure the instance's `cdn` value (via the `/api/v1/meta` table) to the public URL that serves `display/` and `thumbnail/` (typically the same nginx host). This overrides the frontend's `/` default at runtime — the bundle itself ships no per-instance config.
 - Run `npm install` in [server](server), [converter](converter), and [react-app](react-app)
 - Set up [server](server) and [converter](converter) to run as background processes, e.g. via [pm2](https://pm2.keymetrics.io/) — both use `npm run prod` which invokes `pm2 start --interpreter tsx`
 - Build the [react-app](react-app) into [server](server) for production, running in the [server](server) directory:

--- a/react-app/README.md
+++ b/react-app/README.md
@@ -21,36 +21,28 @@ npm run lint       # eslint .
 
 For production the build is copied into [server](../server)/build/ via `npm run build:ui` (from the server directory) and served by the server.
 
-### Environment Variables
+### Configuration
 
-Configured in `react-app/.env` (or a per-environment file like `.env.production`). Vite only exposes variables prefixed with `VITE_` to the client.
+The frontend has no build-time environment variables — one build serves every instance. Defaults live as plain values in [`src/lib/config.ts`](src/lib/config.ts) and per-instance behavior comes from the API at boot.
 
-- `VITE_PHOTO_ROOT_URL` \*
-  - The public URL serving the physical photos, with the following sub-directories:
-    - `display/` – display-size photos
-    - `thumbnail/` – thumbnail-size photos
-  - Can be overridden at runtime by the instance metadata `cdn` value served from the server's `/api/v1/meta` endpoint.
-- `VITE_THEME` (default: `blue`)
-  - Built-in color theme. Defined in `src/lib/theme.ts`. Currently available:
-    - `blue`
-    - `red`
-    - `grayscale`
-    - `bw`
-    - `alert`
-- `VITE_DEFAULT_LANGUAGE` (default: `en`)
-  - Initial UI language before a stored selection takes over. Supported: `en`, `fi`, `ja`.
-- `VITE_DEFAULT_GALLERY`
-  - If set, accessing `/g` (or the site root, which redirects to `/g`) redirects to this gallery instead of the gallery list.
-- `VITE_INITIAL_GALLERY_VIEW` (default: `month`)
-  - The view to land on when entering a gallery: `year` / `month` / `day` / `photo`.
-- `VITE_FIRST_WEEKDAY` (default: `1` — Monday)
-  - The first day of the week for the year-view calendar grid. `1` = Monday, `0` = Sunday.
+Set these on the **server's** `.env` (per instance) to override the defaults; the server returns them through `/api/v1/meta` and the frontend applies them when the meta loads:
 
-\* Required; everything else falls back to the listed default.
+- `DEFAULT_GALLERY` — gallery to redirect to from `/g` when no other heuristic (single-gallery, hostname match) picks one
+- `DEFAULT_THEME` — fallback theme when a gallery row has no `theme` set
+- `INITIAL_GALLERY_VIEW` — `year` / `month` / `day` / `photo` fallback when a gallery row has no `initial_view` set
+- `FIRST_WEEKDAY` — `0` (Sunday) or `1` (Monday); affects the year-view calendar grid
+
+Per-gallery values (`theme`, `initial_view`, `hostname`) on each gallery row in the DB take precedence over the instance-level defaults above.
+
+`PHOTO_ROOT_URL` is overridden the same way via the `instance_cdn` meta row (set with `bin/` tools or directly in the DB).
+
+`DEFAULT_LANGUAGE` is the one value that **can't** be overridden at runtime — i18next initializes at module load, before the meta fetch. Edit the literal in `config.ts` if you need a different fallback language for new visitors. Users' own selections are persisted via the `lang` localStorage key.
+
+Available themes: `blue`, `red`, `grayscale`, `bw`, `alert` (defined in `src/lib/theme.ts`). Supported languages: `en`, `fi`, `ja`.
 
 ## Structure
 
-- `src/index.tsx` — entry, mounts `<App>` inside `HelmetProvider` and `React.StrictMode`
+- `src/index.tsx` — entry, mounts `<App>` inside `React.StrictMode`
 - `src/App.tsx` — routes (`react-router-dom` 7), top menu, country-locale registration, persisted-user bootstrap
 - `src/components/` — UI components
   - `Gallery/` — gallery shell + `Year/Month/Day/Photo/Filters/Stats` sub-views

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -45,6 +45,11 @@ interface Meta {
   cdn?: string;
   name?: string;
   description?: string;
+  // Optional per-instance overrides served from the server's `process.env`.
+  defaultGallery?: string;
+  defaultTheme?: string;
+  initialGalleryView?: string;
+  firstWeekday?: string | number;
 }
 type ActiveTheme = ReturnType<typeof theme.setTheme>;
 
@@ -121,6 +126,12 @@ const Gallery = ({
         const m = returnedMeta as Meta;
         setMeta(m);
         config.PHOTO_ROOT_URL = m.cdn || config.PHOTO_ROOT_URL;
+        if (m.defaultGallery) config.DEFAULT_GALLERY = m.defaultGallery;
+        if (m.defaultTheme) config.DEFAULT_THEME = m.defaultTheme;
+        if (m.initialGalleryView)
+          config.INITIAL_GALLERY_VIEW = m.initialGalleryView;
+        if (m.firstWeekday !== undefined)
+          config.FIRST_WEEKDAY = Number(m.firstWeekday);
       })
       .catch((error: Error) => setError(error.message));
   }, []);

--- a/react-app/src/lib/config.ts
+++ b/react-app/src/lib/config.ts
@@ -1,40 +1,51 @@
-/**
- * The root URL for accessing the photo files. The display-sized photos should be inside `display`, and the thumbnails inside `thumbnail` directory.
- *
- * This can be overridden with the instance metadata `cdn`.
- */
-const env = import.meta.env;
-let PHOTO_ROOT_URL = env.VITE_PHOTO_ROOT_URL || "/";
-/**
- * The default language to choose if the user has not selected one.
- */
-const DEFAULT_LANGUAGE = env.VITE_DEFAULT_LANGUAGE || "en";
-/**
- * see "themes.css"
- */
-const DEFAULT_THEME = env.VITE_THEME || "blue";
-/**
- * The default gallery to redirect to when accessing the galleries end-point.
- */
-const DEFAULT_GALLERY = env.VITE_DEFAULT_GALLERY || undefined;
-/**
- * The view to redirect to from the gallery root end-point, to the last element of the respective view.
- *
- * One of "year", "month", "day", "photo"
- */
-const INITIAL_GALLERY_VIEW = env.VITE_INITIAL_GALLERY_VIEW || "month";
-/**
- * The first day of the week for the calendar grid of the year view.
- *
- * 1 = Monday, 0 = Sunday
- */
-const FIRST_WEEKDAY: number = env.VITE_FIRST_WEEKDAY
-  ? Number(env.VITE_FIRST_WEEKDAY)
-  : 1;
+// Frontend config defaults. Per-instance behavior comes from the API at
+// boot — `/api/v1/meta` returns server-side env overrides for `cdn`,
+// `defaultGallery`, `defaultTheme`, `initialGalleryView`, and `firstWeekday`,
+// which `Gallery/index.tsx` applies to the values below. Per-gallery `theme`
+// and `initialView` from each gallery row take precedence over these defaults.
+//
+// `DEFAULT_LANGUAGE` is read by i18next at module load (before meta fetches),
+// so it can't be overridden at runtime — change the literal here if you need
+// a different fallback language for new visitors. Users' own selections are
+// persisted via the `lang` localStorage key.
+
+// Overridden at runtime by `meta.cdn`. Display-sized photos go under `display`,
+// thumbnails under `thumbnail`.
+let PHOTO_ROOT_URL = "/";
+
+const DEFAULT_LANGUAGE = "en";
+
+// Overridden at runtime by `meta.defaultTheme`. See `themes.css`. Used when a
+// gallery has no theme set.
+let DEFAULT_THEME = "blue";
+
+// Overridden at runtime by `meta.defaultGallery`. The default gallery to
+// redirect to at `/g` when no other heuristic (single-gallery, hostname match)
+// picks one.
+let DEFAULT_GALLERY: string | undefined = undefined;
+
+// Overridden at runtime by `meta.initialGalleryView`. One of
+// "year" | "month" | "day" | "photo". Used when a gallery has no
+// `initial_view` set.
+let INITIAL_GALLERY_VIEW = "month";
+
+// Overridden at runtime by `meta.firstWeekday`. The first day of the week for
+// the calendar grid of the year view. 1 = Monday, 0 = Sunday.
+let FIRST_WEEKDAY = 1;
 
 let lang = DEFAULT_LANGUAGE;
 
-export default {
+interface Config {
+  PHOTO_ROOT_URL: string;
+  DEFAULT_LANGUAGE: string;
+  DEFAULT_GALLERY: string | undefined;
+  DEFAULT_THEME: string;
+  INITIAL_GALLERY_VIEW: string;
+  FIRST_WEEKDAY: number;
+  lang: string;
+}
+
+const config: Config = {
   PHOTO_ROOT_URL,
 
   DEFAULT_LANGUAGE,
@@ -45,3 +56,5 @@ export default {
 
   lang,
 };
+
+export default config;

--- a/server/controllers/meta-v1.ts
+++ b/server/controllers/meta-v1.ts
@@ -24,14 +24,28 @@ const cleanMeta = (meta: Record<string, unknown>): Record<string, unknown> => {
     }, {});
 };
 
+// Per-instance frontend defaults pulled from the server's `process.env`.
+// Each one is optional — the frontend falls back to its hardcoded default in
+// `lib/config.ts` when the key is absent. Edit the per-instance `.env` file
+// to set these (e.g. `DEFAULT_GALLERY=dailybw`).
+const envDefaults = (): Record<string, string> => {
+  const out: Record<string, string> = {};
+  const { DEFAULT_GALLERY, DEFAULT_THEME, INITIAL_GALLERY_VIEW, FIRST_WEEKDAY } =
+    process.env;
+  if (DEFAULT_GALLERY) out.defaultGallery = DEFAULT_GALLERY;
+  if (DEFAULT_THEME) out.defaultTheme = DEFAULT_THEME;
+  if (INITIAL_GALLERY_VIEW) out.initialGalleryView = INITIAL_GALLERY_VIEW;
+  if (FIRST_WEEKDAY) out.firstWeekday = FIRST_WEEKDAY;
+  return out;
+};
+
 /**
  * Get all meta.
  */
 router.get("/", async (request, response) => {
   // Public, no authorization needed
   const meta = await model.getMetas();
-  response.json(cleanMeta(meta));
-//   response.json(meta.map(cleanMeta));
+  response.json({ ...cleanMeta(meta), ...envDefaults() });
 });
 /**
  * Create a meta.


### PR DESCRIPTION
Closes #168.

Hardcode the six former `VITE_*` defaults as plain values in [react-app/src/lib/config.ts](react-app/src/lib/config.ts). Per-instance overrides now flow through the API: [server/controllers/meta-v1.ts](server/controllers/meta-v1.ts) reads `DEFAULT_GALLERY` / `DEFAULT_THEME` / `INITIAL_GALLERY_VIEW` / `FIRST_WEEKDAY` from `process.env` and merges them into `/api/v1/meta`, and [react-app/src/components/Gallery/index.tsx](react-app/src/components/Gallery/index.tsx) applies them to the `config` module after meta loads. The hardcoded defaults stay as fallbacks for instances that don't set the corresponding env var. Same pattern as the existing `cdn` → `PHOTO_ROOT_URL` override.

The win is **one shared frontend build serves any instance** — the unblock for #158. Per-instance branding moves from `react-app/.env` (build-time) to each instance's `server/.env` (runtime), which lines up with the env-file-driven workflow planned for the multi-instance setup.

## Migration for existing deploys

| Was (`react-app/.env`) | Now (`server/.env`) |
|---|---|
| `VITE_DEFAULT_GALLERY=dailybw` | `DEFAULT_GALLERY=dailybw` |
| `VITE_THEME=grayscale` | `DEFAULT_THEME=grayscale` |
| `VITE_INITIAL_GALLERY_VIEW=year` | `INITIAL_GALLERY_VIEW=year` |
| `VITE_FIRST_WEEKDAY=0` | `FIRST_WEEKDAY=0` |
| `VITE_PHOTO_ROOT_URL=…` | already covered by the `instance_cdn` meta row |
| `VITE_DEFAULT_LANGUAGE=fi` | edit the literal in `lib/config.ts` (i18next initializes before meta fetch, so this one can't be runtime-overridden) |

## Test plan

- [x] `npm --prefix react-app run typecheck` — clean
- [x] `npm --prefix react-app run lint` — clean
- [x] `npm --prefix react-app test` — 945 tests pass
- [x] `npm --prefix react-app run build` — clean
- [x] `npm --prefix server run typecheck` — clean
- [x] `npm --prefix server run lint` — clean
- [x] `npm --prefix server test` — 569 tests pass
- [x] **Browser smoke test:** with `DEFAULT_GALLERY=<id>` set in `server/.env`, visiting `/` redirects to `/g/<id>` (was previously only the `VITE_DEFAULT_GALLERY=<id>` build-time behavior). Other overrides take effect after meta loads — easiest to test by hitting `curl http://localhost:4200/api/v1/meta` and confirming the env-derived keys appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)