### PR TITLE
Rename acl → user_gallery, level → access_level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Privacy toggle for the map and photo coordinates. Set via the existing `acl` table's new `hide_map` column — the four-cell cascade picks the most specific row with a non-null value: `(user, gallery)` > `(user, ':all')` > `(':guest', gallery)` > `(':guest', ':all')`. Both layers fire: the server strips `coord_lat`/`coord_lon`/`coord_alt` from the photo payload when hidden (so there's no data to leak), and the gallery payload gains a `hideMap` boolean that the frontend uses to skip rendering the map widget. Schema migration 003 adds the column; existing deploys pick it up automatically on next server start. To hide for unauthenticated visitors only: `UPDATE acl SET hide_map = 1 WHERE user_id = ':guest' AND gallery_id = ':all'`. (closes #159)
+- Privacy toggle for the map and photo coordinates. Set via the `user_gallery` table's new `hide_map` column — the four-cell cascade picks the most specific row with a non-null value: `(user, gallery)` > `(user, ':all')` > `(':guest', gallery)` > `(':guest', ':all')`. Both layers fire: the server strips `coord_lat`/`coord_lon`/`coord_alt` from the photo payload when hidden (so there's no data to leak), and the gallery payload gains a `hideMap` boolean that the frontend uses to skip rendering the map widget. Schema migration 003 adds the column; existing deploys pick it up automatically on next server start. To hide for unauthenticated visitors only: `UPDATE user_gallery SET hide_map = 1 WHERE user_id = ':guest' AND gallery_id = ':all'`. (closes #159)
 
 ### Cross-package
 
@@ -21,6 +21,7 @@
 - Send `X-Robots-Tag: noindex, noai, noimageai` on every response, including served photo files
 - Add a DB migration runner that uses `meta.schema_version` as the cursor; runs at server startup against the better-sqlite3 driver. Bootstraps fresh DBs from `db/sqlite3/migrations/001_baseline.sql`, then advances to v2 via `002_fix_gallery_photo_fk.sql` which rebuilds `gallery_photo` with the correct singular FK references (the long-standing `photos`/`galleries` typo). Drops the obsolete `schema/sqlite3.ddl`, `schema/migrate/sqlite3_from_0.ddl`, and `migrate_legacy_to_sqlite3.sh`.
 - Resolve the bundled-frontend static directory from `import.meta.dirname` (with `STATIC_DIR` override) so the server can be started from any working directory — needed for the multi-instance deploy where the code lives at a shared path and each instance has its own CWD.
+- Rename the `acl` table to `user_gallery` and its `level` column to `access_level` (migration 004) — the original names became misleading once the table grew non-access columns like `hide_map`. (closes #185)
 
 ### Frontend
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Photo Diary is split into separate independent modules, each handling its own su
   - The directory layout is fixed: the `photos/` subdirectory of the instance dir holds the photo repository, and the SQLite DB file lives at `<instance>/db.sqlite3`. Symlink the subdirectories (or the whole instance dir) if you need them on a different disk.
 - Set `DB_DRIVER=sqlite3` in [server](server)/`.env`. The DB file is created at `<instance>/db.sqlite3` on first server start; the migration runner bootstraps the schema and applies any pending migrations on every start
 - Start [server](server) and [converter](converter) as background processes, e.g. via [pm2](https://pm2.keymetrics.io/) — both use `npm run prod` which invokes `pm2 start --interpreter tsx`
-- Seed the first user and at least one gallery via the operator scripts surfaced as `<instance>/bin/<name>.ts` symlinks (created by `bin/instance.ts`). E.g. `./bin/user.ts -u alice -p ...` and `./bin/gallery.ts --id dailybw --title "Daily B&W"`. To give the user admin access, insert an ACL row directly: `INSERT INTO acl (user_id, gallery_id, level) VALUES ('alice', ':all', 2)` (level 2 = admin, level 1 = view). See [server/README.md](server/README.md) for the management scripts and the access-control model in detail.
+- Seed the first user and at least one gallery via the operator scripts surfaced as `<instance>/bin/<name>.ts` symlinks (created by `bin/instance.ts`). E.g. `./bin/user.ts -u alice -p ...` and `./bin/gallery.ts --id dailybw --title "Daily B&W"`. To give the user admin access, insert a `user_gallery` row directly: `INSERT INTO user_gallery (user_id, gallery_id, access_level) VALUES ('alice', ':all', 2)` (access level 2 = admin, 1 = view). See [server/README.md](server/README.md) for the management scripts and the access-control model in detail.
 - Set the instance's `cdn` value (via `UPDATE meta SET value='https://photos.example.com/' WHERE key='instance_cdn'` or the `/api/v1/meta` API) to the public URL that serves `display/` and `thumbnail/` (typically the same nginx host). This overrides the frontend's `/` default at runtime — the bundle itself ships no per-instance config
 
 ### Dev Mode
@@ -185,7 +185,7 @@ The `bin/instance.ts` upgrade flow already creates `db.sqlite3.pre-<version>` sn
 | Converter logs "Invalid photo-repository directory structure" | The `photos/{inbox,original,display,thumbnail}/` subdirs aren't all present — re-run `./bin/instance.ts <name>` (or `bin/instance.ts <name>` from the code root) to recreate any missing ones (idempotent). |
 | `no such table: …` after upgrade | A migration didn't apply. Check `sqlite3 db.sqlite3 "SELECT value FROM meta WHERE key='schema_version'"` and the server log on startup for "Applying N DB migration(s)". |
 | Frontend loads but `/api/v1/galleries` 401s | The user's token expired or the `SECRET` changed across restarts — login again. |
-| Map widget missing where you expected it | The `hide_map` ACL cascade is hiding it; check `SELECT * FROM acl WHERE hide_map IS NOT NULL` and the privacy doc in the server README. |
+| Map widget missing where you expected it | The `hide_map` cascade is hiding it; check `SELECT * FROM user_gallery WHERE hide_map IS NOT NULL` and the privacy doc in the server README. |
 
 ## Features
 

--- a/bin/instance.ts
+++ b/bin/instance.ts
@@ -306,7 +306,7 @@ if (mode === "new") {
   console.log(`  ./bin/gallery.ts --id ${name} --title "${name}"`);
   console.log("  # Grant admin access via SQL (no flag for it on user yet):");
   console.log(
-    "  #   sqlite3 db.sqlite3 \"INSERT INTO acl (user_id, gallery_id, level) VALUES ('<username>', ':all', 2)\""
+    "  #   sqlite3 db.sqlite3 \"INSERT INTO user_gallery (user_id, gallery_id, access_level) VALUES ('<username>', ':all', 2)\""
   );
 } else if (mode === "upgrade") {
   console.log("Upgrade prepared. Restart pm2 to activate:");

--- a/server/README.md
+++ b/server/README.md
@@ -89,12 +89,12 @@ Bootstrap, doctor, or upgrade a Photo Diary instance directory in one command. D
 | `-u <id>`, `--user <id>` | User ID to create or update. |
 | `-p <pw>`, `--password <pw>` | Password (will be bcrypt-hashed before storage). |
 
-Either `--list` or both `--user` and `--password` are required. Running with `-u`/`-p` updates the user if it exists, creates it otherwise. Setting an admin level is a separate step — the script doesn't touch the ACL. Grant access manually:
+Either `--list` or both `--user` and `--password` are required. Running with `-u`/`-p` updates the user if it exists, creates it otherwise. Setting an admin level is a separate step — the script doesn't touch the `user_gallery` table. Grant access manually:
 
 ```sh
 sqlite3 db.sqlite3 \
-  "INSERT INTO acl (user_id, gallery_id, level) VALUES ('alice', ':all', 2)"
-# level: 0 = none, 1 = view, 2 = admin
+  "INSERT INTO user_gallery (user_id, gallery_id, access_level) VALUES ('alice', ':all', 2)"
+# access_level: 0 = none, 1 = view, 2 = admin
 ```
 
 #### `gallery.ts [options]`

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -72,9 +72,9 @@ export default {
     return await db.loadUserAccessControl(userId);
   },
   // Resolve the privacy cascade for (userId, galleryId): looks at the
-  // four ACL rows ((user, gallery), (:guest, gallery), (user, :all),
-  // (:guest, :all)) in most-specific-first order, returning the first
-  // non-null `hide_map`. Undefined when no level has an opinion.
+  // four `user_gallery` rows ((user, gallery), (:guest, gallery),
+  // (user, :all), (:guest, :all)) in most-specific-first order, returning
+  // the first non-null `hide_map`. Undefined when no level has an opinion.
   resolveHideMap: async (
     userId: string,
     galleryId: string

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -6,7 +6,6 @@ import logger from "../../lib/logger.js";
 import { migrate } from "./migrate.js";
 
 import schemaFactory, {
-  type AclRow,
   type Gallery,
   type GalleryInput,
   type GalleryPhoto,
@@ -15,6 +14,7 @@ import schemaFactory, {
   type PhotoInput,
   type PhotoRow,
   type User,
+  type UserGalleryRow,
   type UserRow,
 } from "./schema.js";
 
@@ -117,18 +117,18 @@ const deleteUser = async (userId: string) => deleteById(SCHEMA.user, userId);
 const loadUserAccessControl = async (
   userId: string
 ): Promise<Record<string, number>> => {
-  const schema = SCHEMA.acl;
+  const schema = SCHEMA.userGallery;
   // TODO: cache in memory
   const stmt = db.prepare(schema.buildSelectQuery(["user_id IN (?)"]));
-  const userRows = stmt.all([userId]) as AclRow[];
-  const guestRows = stmt.all([":guest"]) as AclRow[];
+  const userRows = stmt.all([userId]) as UserGalleryRow[];
+  const guestRows = stmt.all([":guest"]) as UserGalleryRow[];
   return {
     ...Object.fromEntries(guestRows.map(schema.mapRow)),
     ...Object.fromEntries(userRows.map(schema.mapRow)),
   };
 };
-// Resolve the privacy cascade for (userId, galleryId) in one query.
-// Returns the most specific ACL row's `hide_map` (1, 0, or null) considering
+// Resolve the privacy cascade for (userId, galleryId) in one query. Returns
+// the most specific `user_gallery` row's `hide_map` (1, 0, or null) considering
 // the four-cell hierarchy: (user, gallery) > (':guest', gallery) >
 // (user, ':all') > (':guest', ':all'). Rows with null `hide_map` are skipped
 // so a less-specific row's non-null value can win. Returns undefined when
@@ -139,7 +139,7 @@ const resolveHideMap = async (
 ): Promise<number | undefined> => {
   const row = db
     .prepare(
-      `SELECT hide_map FROM acl
+      `SELECT hide_map FROM user_gallery
        WHERE (user_id = ? OR user_id = ':guest')
          AND (gallery_id = ? OR gallery_id = ':all')
          AND hide_map IS NOT NULL

--- a/server/db/sqlite3/migrations/004_rename_acl_to_user_gallery.sql
+++ b/server/db/sqlite3/migrations/004_rename_acl_to_user_gallery.sql
@@ -1,0 +1,16 @@
+-- Rename `acl` → `user_gallery` and `level` → `access_level`.
+--
+-- The table grew beyond pure access control with migration 003 (hide_map for
+-- the privacy cascade), and more per-pair preferences are likely. Its real
+-- shape is "for this (user, gallery) cell, what's true about that pair" — the
+-- `user_gallery` name matches that intent and pairs nicely with the existing
+-- `gallery_photo` link table. `access_level` makes the column's semantics
+-- explicit too: the integer is the level *of access*, not a generic level
+-- (which would read oddly next to a `hide_map` privacy column).
+--
+-- Both ALTERs are SQLite-native (no table rebuild needed).
+
+ALTER TABLE acl RENAME TO user_gallery;
+ALTER TABLE user_gallery RENAME COLUMN level TO access_level;
+
+UPDATE meta SET value='4' WHERE key='schema_version';

--- a/server/db/sqlite3/schema.ts
+++ b/server/db/sqlite3/schema.ts
@@ -10,10 +10,10 @@ export interface UserRow {
   password: string;
   secret: string;
 }
-export interface AclRow {
+export interface UserGalleryRow {
   user_id: string;
   gallery_id: string;
-  level: number;
+  access_level: number;
   // Privacy toggle: 1 = hide map/coordinates, 0 = show; NULL inherits the
   // next outer level (gallery override → instance default).
   hide_map: number | null;
@@ -65,7 +65,7 @@ export interface PhotoRow {
 // App-side shapes (what mapRow returns / mapInsert and mapToRow take).
 export type Meta = Record<string, string>;
 export type User = UserRow;
-export type Acl = [galleryId: string, level: number];
+export type UserGalleryAccess = [galleryId: string, accessLevel: number];
 export interface Gallery {
   id: string;
   title: string;
@@ -185,21 +185,24 @@ export default () => {
       buildDeleteQuery: (conditions?: Conditions) =>
         buildDeleteQuery(SCHEMA.user, conditions),
     },
-    acl: {
-      mapRow: (row: AclRow): Acl => [row.gallery_id, row.level],
+    userGallery: {
+      mapRow: (row: UserGalleryRow): UserGalleryAccess => [
+        row.gallery_id,
+        row.access_level,
+      ],
       mapInsert: (): unknown[] => {
         throw CONST.ERROR_NOT_IMPLEMENTED;
       },
-      buildCreateQuery: () => buildCreateQuery(SCHEMA.acl),
-      buildSelectByIdQuery: () => buildSelectByIdQuery(SCHEMA.acl),
-      buildUpdateByIdQuery: (data: Partial<AclRow>) =>
-        buildUpdateByIdQuery(SCHEMA.acl, data),
-      buildDeleteByIdQuery: () => buildDeleteByIdQuery(SCHEMA.acl),
+      buildCreateQuery: () => buildCreateQuery(SCHEMA.userGallery),
+      buildSelectByIdQuery: () => buildSelectByIdQuery(SCHEMA.userGallery),
+      buildUpdateByIdQuery: (data: Partial<UserGalleryRow>) =>
+        buildUpdateByIdQuery(SCHEMA.userGallery, data),
+      buildDeleteByIdQuery: () => buildDeleteByIdQuery(SCHEMA.userGallery),
 
       buildSelectQuery: (conditions?: Conditions) =>
-        buildSelectQuery(SCHEMA.acl, conditions),
+        buildSelectQuery(SCHEMA.userGallery, conditions),
       buildDeleteQuery: (conditions?: Conditions) =>
-        buildDeleteQuery(SCHEMA.acl, conditions),
+        buildDeleteQuery(SCHEMA.userGallery, conditions),
     },
     gallery: {
       mapRow: (row: GalleryRow): Gallery => ({
@@ -383,9 +386,11 @@ const userMapToRow = (user: Partial<User>): Record<string, unknown> => {
   if ("secret" in user) result.secret = user.secret;
   return result;
 };
-const aclMapToRow = (acl: Partial<AclRow>): Record<string, unknown> => {
+const userGalleryMapToRow = (
+  userGallery: Partial<UserGalleryRow>
+): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
-  if ("level" in acl) result.level = acl.level;
+  if ("access_level" in userGallery) result.access_level = userGallery.access_level;
   return result;
 };
 const galleryMapToRow = (
@@ -481,12 +486,12 @@ const SCHEMA = {
     order: ["id ASC"],
     mapToRow: userMapToRow as (data: Record<string, unknown>) => Record<string, unknown>,
   },
-  acl: {
-    table: "acl",
-    columns: ["user_id", "gallery_id", "level", "hide_map"],
+  userGallery: {
+    table: "user_gallery",
+    columns: ["user_id", "gallery_id", "access_level", "hide_map"],
     primaryKey: ["user_id", "gallery_id"],
     order: ["user_id ASC", "gallery_id ASC"],
-    mapToRow: aclMapToRow as (data: Record<string, unknown>) => Record<string, unknown>,
+    mapToRow: userGalleryMapToRow as (data: Record<string, unknown>) => Record<string, unknown>,
   },
   gallery: {
     table: "gallery",

--- a/server/lib/privacy.ts
+++ b/server/lib/privacy.ts
@@ -3,9 +3,9 @@ import db from "../db/index.js";
 /**
  * Resolves the privacy cascade for the map / photo coordinates.
  *
- * The cascade lives entirely in the `acl` table, leveraging the existing
- * `:guest` user and `:all` gallery sentinels. The most specific ACL row
- * with a non-null `hide_map` wins:
+ * The cascade lives entirely in the `user_gallery` table, leveraging the
+ * existing `:guest` user and `:all` gallery sentinels. The most specific
+ * row with a non-null `hide_map` wins:
  *
  *   1. (userId,  galleryId) — per-user, per-gallery
  *   2. (:guest,  galleryId) — per-gallery default

--- a/server/tests/db/sqlite3/migrate.test.ts
+++ b/server/tests/db/sqlite3/migrate.test.ts
@@ -33,24 +33,26 @@ describe("migrate", () => {
   test("fresh DB runs every migration and lands at the highest version", () => {
     const db = open();
     migrate(db);
-    expect(schemaVersion(db)).toBe(3);
+    expect(schemaVersion(db)).toBe(4);
     expect(tableNames(db)).toEqual(
       expect.arrayContaining([
-        "acl",
         "gallery",
         "gallery_photo",
         "meta",
         "photo",
         "user",
+        "user_gallery",
       ])
     );
     // 002 rebuilt gallery_photo with singular FK refs.
     expect(gallerPhotoFkRefs(db).sort()).toEqual(["gallery", "photo"]);
-    // 003 added hide_map to acl.
-    const aclCols = (db.pragma("table_info(acl)") as { name: string }[]).map(
-      (r) => r.name
-    );
-    expect(aclCols).toContain("hide_map");
+    // 003 added hide_map; 004 renamed acl → user_gallery and level → access_level.
+    const userGalleryCols = (
+      db.pragma("table_info(user_gallery)") as { name: string }[]
+    ).map((r) => r.name);
+    expect(userGalleryCols).toContain("hide_map");
+    expect(userGalleryCols).toContain("access_level");
+    expect(userGalleryCols).not.toContain("level");
   });
 
   test("re-running on an up-to-date DB is a no-op", () => {
@@ -97,7 +99,7 @@ describe("migrate", () => {
 
     migrate(db);
 
-    expect(schemaVersion(db)).toBe(3);
+    expect(schemaVersion(db)).toBe(4);
     expect(gallerPhotoFkRefs(db).sort()).toEqual(["gallery", "photo"]);
     const rows = db.prepare("SELECT * FROM gallery_photo").all();
     expect(rows).toEqual([{ gallery_id: "g1", photo_id: "p1" }]);

--- a/server/tests/db/sqlite3/schema.test.ts
+++ b/server/tests/db/sqlite3/schema.test.ts
@@ -70,70 +70,81 @@ describe("User", () => {
     ));
 });
 
-describe("ACL", () => {
-  const cols = ["user_id", "gallery_id", "level", "hide_map"].join(",");
+describe("UserGallery", () => {
+  const cols = ["user_id", "gallery_id", "access_level", "hide_map"].join(",");
   test("Build create query", () =>
-    expect(schema.acl.buildCreateQuery()).toBe(
-      `INSERT INTO acl (${cols}) VALUES (?,?,?,?)`
+    expect(schema.userGallery.buildCreateQuery()).toBe(
+      `INSERT INTO user_gallery (${cols}) VALUES (?,?,?,?)`
     ));
   test("Build select by id query", () =>
-    expect(schema.acl.buildSelectByIdQuery()).toBe(
-      `SELECT ${cols} FROM acl WHERE user_id = ? AND gallery_id = ? ORDER BY user_id ASC,gallery_id ASC`
+    expect(schema.userGallery.buildSelectByIdQuery()).toBe(
+      `SELECT ${cols} FROM user_gallery WHERE user_id = ? AND gallery_id = ? ORDER BY user_id ASC,gallery_id ASC`
     ));
   test("Build update by id query: nothing", () =>
-    expect(schema.acl.buildUpdateByIdQuery({})).toStrictEqual({
+    expect(schema.userGallery.buildUpdateByIdQuery({})).toStrictEqual({
       query: undefined,
       values: undefined,
     }));
   test("Build update by id query: user_id", () =>
-    expect(schema.acl.buildUpdateByIdQuery({ user_id: "foo" })).toStrictEqual({
+    expect(
+      schema.userGallery.buildUpdateByIdQuery({ user_id: "foo" })
+    ).toStrictEqual({
       query: undefined,
       values: undefined,
     }));
   test("Build update by id query: gallery_id", () =>
     expect(
-      schema.acl.buildUpdateByIdQuery({ gallery_id: "foo" })
+      schema.userGallery.buildUpdateByIdQuery({ gallery_id: "foo" })
     ).toStrictEqual({
       query: undefined,
       values: undefined,
     }));
   test("Build update by id query: user_id, gallery_id", () =>
     expect(
-      schema.acl.buildUpdateByIdQuery({ user_id: "foo", gallery_id: "bar" })
+      schema.userGallery.buildUpdateByIdQuery({
+        user_id: "foo",
+        gallery_id: "bar",
+      })
     ).toStrictEqual({ query: undefined, values: undefined }));
-  test("Build update by id query: level", () =>
-    expect(schema.acl.buildUpdateByIdQuery({ level: 2 })).toStrictEqual({
-      query: "UPDATE acl SET level=? WHERE user_id = ? AND gallery_id = ?",
+  test("Build update by id query: access_level", () =>
+    expect(
+      schema.userGallery.buildUpdateByIdQuery({ access_level: 2 })
+    ).toStrictEqual({
+      query:
+        "UPDATE user_gallery SET access_level=? WHERE user_id = ? AND gallery_id = ?",
       values: [2],
     }));
   test("Build update by id query: all", () =>
     expect(
-      schema.acl.buildUpdateByIdQuery({
+      schema.userGallery.buildUpdateByIdQuery({
         user_id: "foo",
         gallery_id: "bar",
-        level: 2,
+        access_level: 2,
       })
     ).toStrictEqual({
-      query: "UPDATE acl SET level=? WHERE user_id = ? AND gallery_id = ?",
+      query:
+        "UPDATE user_gallery SET access_level=? WHERE user_id = ? AND gallery_id = ?",
       values: [2],
     }));
   test("Build delete by id query", () =>
-    expect(schema.acl.buildDeleteByIdQuery()).toBe(
-      "DELETE FROM acl WHERE user_id = ? AND gallery_id = ?"
+    expect(schema.userGallery.buildDeleteByIdQuery()).toBe(
+      "DELETE FROM user_gallery WHERE user_id = ? AND gallery_id = ?"
     ));
   test("Build select all query", () =>
-    expect(schema.acl.buildSelectQuery()).toBe(
-      `SELECT ${cols} FROM acl ORDER BY user_id ASC,gallery_id ASC`
+    expect(schema.userGallery.buildSelectQuery()).toBe(
+      `SELECT ${cols} FROM user_gallery ORDER BY user_id ASC,gallery_id ASC`
     ));
   test("Build select by condition query", () =>
-    expect(schema.acl.buildSelectQuery(["id = ?"])).toBe(
-      `SELECT ${cols} FROM acl WHERE id = ? ORDER BY user_id ASC,gallery_id ASC`
+    expect(schema.userGallery.buildSelectQuery(["id = ?"])).toBe(
+      `SELECT ${cols} FROM user_gallery WHERE id = ? ORDER BY user_id ASC,gallery_id ASC`
     ));
   test("Build delete all query", () =>
-    expect(schema.acl.buildDeleteQuery()).toBe("DELETE FROM acl"));
+    expect(schema.userGallery.buildDeleteQuery()).toBe(
+      "DELETE FROM user_gallery"
+    ));
   test("Build delete by condition query", () =>
-    expect(schema.acl.buildDeleteQuery(["id = ?"])).toBe(
-      "DELETE FROM acl WHERE id = ?"
+    expect(schema.userGallery.buildDeleteQuery(["id = ?"])).toBe(
+      "DELETE FROM user_gallery WHERE id = ?"
     ));
 });
 

--- a/server/tests/lib/privacy.test.ts
+++ b/server/tests/lib/privacy.test.ts
@@ -1,7 +1,7 @@
 import Database from "better-sqlite3";
 
 // Tests the 4-cell ACL cascade resolution against a fresh in-memory SQLite,
-// bypassing the dummy driver (which doesn't model ACL rows).
+// bypassing the dummy driver (which doesn't model user_gallery rows).
 //
 // Cascade priority (most specific wins):
 //   1. (user_id, gallery_id)
@@ -12,16 +12,16 @@ import Database from "better-sqlite3";
 const setupDb = (rows: Array<[string, string, number | null]>) => {
   const db = new Database(":memory:");
   db.exec(`
-    CREATE TABLE acl (
+    CREATE TABLE user_gallery (
       user_id TEXT,
       gallery_id TEXT,
-      level INTEGER,
+      access_level INTEGER,
       hide_map INTEGER,
       PRIMARY KEY(user_id, gallery_id)
     );
   `);
   const insert = db.prepare(
-    "INSERT INTO acl (user_id, gallery_id, level, hide_map) VALUES (?, ?, 1, ?)"
+    "INSERT INTO user_gallery (user_id, gallery_id, access_level, hide_map) VALUES (?, ?, 1, ?)"
   );
   for (const [user_id, gallery_id, hide_map] of rows) {
     insert.run(user_id, gallery_id, hide_map);
@@ -36,7 +36,7 @@ const resolve = (
 ): number | undefined => {
   const row = db
     .prepare(
-      `SELECT hide_map FROM acl
+      `SELECT hide_map FROM user_gallery
        WHERE (user_id = ? OR user_id = ':guest')
          AND (gallery_id = ? OR gallery_id = ':all')
          AND hide_map IS NOT NULL


### PR DESCRIPTION
Closes #185.

## What changed

The `acl` table grew non-access columns with #159's `hide_map` privacy toggle, and is likely to grow more per-pair preferences over time. The original name was understating what the table holds; renaming it to `user_gallery` matches the table's real shape — *"for this (user, gallery) cell, what's true about that pair"* — and pairs nicely with the existing `gallery_photo` link table. `access_level` makes the column's semantics explicit too, since "level" reads ambiguously next to a `hide_map` column.

| Was | Now |
| --- | --- |
| `acl` table | `user_gallery` table |
| `level` column | `access_level` column |
| `AclRow` type | `UserGalleryRow` |
| `Acl` tuple type | `UserGalleryAccess` |
| `schema.acl` factory entry | `schema.userGallery` |
| `aclMapToRow` helper | `userGalleryMapToRow` |

## Migration

[`004_rename_acl_to_user_gallery.sql`](server/db/sqlite3/migrations/004_rename_acl_to_user_gallery.sql) does both renames via SQLite-native `ALTER TABLE … RENAME` operations — no rebuild, no FK recreation. Existing deploys pick it up automatically on next server start. The migration runner advances `meta.schema_version` from 3 → 4.

## What didn't change

`server/lib/authorizer.ts` keeps its local `type Acl = Record<string, number>` and `acl` variable names. That value is the in-memory ACL concept (galleryId → access level) — genuinely is an access control list, and isn't bound to the table name. Renaming it would be churn without a readability win.

## Docs

- [README](README.md) — admin-grant SQL snippet and the troubleshooting row for the `hide_map` cascade
- [server/README](server/README.md) — access-control section's grant example
- [bin/instance.ts](bin/instance.ts) — the "Next steps" output line showing the admin-grant SQL
- [CHANGELOG](CHANGELOG.md) — new entry under Server; the existing #159 entry updated to reference `user_gallery` instead of `acl`

## Test plan

- [x] `npm run typecheck --workspace=server` — clean
- [x] `npm run lint --workspace=server` — clean
- [x] `npm test --workspace=server` — 581/581 passing (migrate test now checks v4 and asserts the `user_gallery` table is present with `access_level` + `hide_map`; the v1 → v4 upgrade test still preserves seeded data through the rename)
- [x] Smoke test: `bin/instance.ts smoke --base /tmp/…` runs all four migrations cleanly, schema lands at v4, `sqlite3 db.sqlite3 ".schema user_gallery"` shows the renamed table with `access_level` and `hide_map`, `gallery.ts --id sample --title Sample` creates a gallery successfully against the renamed schema.
- [x] **VM upgrade smoke test**: pull this branch on the prod host, restart pm2, confirm the migration runs and the existing instance keeps working (login, gallery view, map widget all still functional).

Unblocks #186 (access-table bin script — will use the new names from day one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)