### PR TITLE
Align hide_map cascade with the access cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Resolve the bundled-frontend static directory from `import.meta.dirname` (with `STATIC_DIR` override) so the server can be started from any working directory — needed for the multi-instance deploy where the code lives at a shared path and each instance has its own CWD.
 - Rename the `acl` table to `user_gallery` and its `level` column to `access_level` (migration 004) — the original names became misleading once the table grew non-access columns like `hide_map`. (closes #185)
 - Add `server/bin/access.ts` (`list` / `level` / `unset` / `hide-map` subcommands) for managing `user_gallery` rows without direct SQL; also fixes `loadUserAccessControl` to filter out `access_level=NULL` rows so privacy-only rows don't break access fall-through to `:all`. (closes #186)
+- Align the `hide_map` cascade with the access cascade — both now walk gallery-first (`requested → :public → :all` for non-special galleries, `requested → :all` for special ones) with user-beats-guest at each level, replacing the previous user-first ordering. (closes #189)
 
 ### Frontend
 

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -88,10 +88,11 @@ export default {
   deleteUserGallery: async (userId: string, galleryId: string): Promise<void> => {
     await db.deleteUserGallery(userId, galleryId);
   },
-  // Resolve the privacy cascade for (userId, galleryId): looks at the
-  // four `user_gallery` rows ((user, gallery), (:guest, gallery),
-  // (user, :all), (:guest, :all)) in most-specific-first order, returning
-  // the first non-null `hide_map`. Undefined when no level has an opinion.
+  // Resolve the privacy cascade for (userId, galleryId): gallery-first
+  // walk matching the access cascade — `requested → :public → :all` for
+  // non-special galleries (skipping :public for :public/:private/:all
+  // requests), with user-beats-guest at each gallery level. Returns the
+  // first non-null `hide_map` encountered; undefined when nothing matches.
   resolveHideMap: async (
     userId: string,
     galleryId: string

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -189,28 +189,45 @@ const deleteUserGallery = async (
     galleryId,
   ]);
 };
-// Resolve the privacy cascade for (userId, galleryId) in one query. Returns
-// the most specific `user_gallery` row's `hide_map` (1, 0, or null) considering
-// the four-cell hierarchy: (user, gallery) > (':guest', gallery) >
-// (user, ':all') > (':guest', ':all'). Rows with null `hide_map` are skipped
-// so a less-specific row's non-null value can win. Returns undefined when
-// no row at any level has a non-null `hide_map`.
+// Resolve the privacy cascade for (userId, galleryId) in one query. Matches
+// the gallery-first ordering of the access cascade (see authorizer.ts):
+//
+//   For a non-special gallery request, priority is
+//     (user, gallery) > (:guest, gallery)
+//   > (user, :public) > (:guest, :public)
+//   > (user, :all)    > (:guest, :all)
+//
+//   For a special-gallery request (:public, :private, :all), the :public
+//   step is dropped — :private isn't a subset of :public, and :public/:all
+//   shouldn't fall through themselves:
+//     (user, gallery) > (:guest, gallery) > (user, :all) > (:guest, :all)
+//
+// Rows with null `hide_map` are skipped so a less-specific row's non-null
+// value can win. Returns undefined when no row at any level has a non-null
+// `hide_map`.
 const resolveHideMap = async (
   userId: string,
   galleryId: string
 ): Promise<number | undefined> => {
+  const isSpecial = galleryId.startsWith(":");
+  const galleryWhere = isSpecial
+    ? "gallery_id IN (?, ':all')"
+    : "gallery_id IN (?, ':public', ':all')";
+  const galleryOrder = isSpecial
+    ? "CASE WHEN gallery_id = ? THEN 0 ELSE 1 END"
+    : "CASE WHEN gallery_id = ? THEN 0 WHEN gallery_id = ':public' THEN 1 ELSE 2 END";
   const row = db
     .prepare(
       `SELECT hide_map FROM user_gallery
        WHERE (user_id = ? OR user_id = ':guest')
-         AND (gallery_id = ? OR gallery_id = ':all')
+         AND ${galleryWhere}
          AND hide_map IS NOT NULL
        ORDER BY
-         CASE WHEN user_id = ? THEN 0 ELSE 1 END,
-         CASE WHEN gallery_id = ? THEN 0 ELSE 1 END
+         ${galleryOrder},
+         CASE WHEN user_id = ? THEN 0 ELSE 1 END
        LIMIT 1`
     )
-    .get(userId, galleryId, userId, galleryId) as
+    .get(userId, galleryId, galleryId, userId) as
     | { hide_map: number }
     | undefined;
   return row?.hide_map;

--- a/server/tests/lib/privacy.test.ts
+++ b/server/tests/lib/privacy.test.ts
@@ -1,13 +1,19 @@
 import Database from "better-sqlite3";
 
-// Tests the 4-cell ACL cascade resolution against a fresh in-memory SQLite,
-// bypassing the dummy driver (which doesn't model user_gallery rows).
+// Tests the hide_map cascade resolution against a fresh in-memory SQLite,
+// bypassing the dummy driver (which doesn't model user_gallery rows). Mirrors
+// the access cascade's gallery-first ordering (see authorizer.ts).
 //
-// Cascade priority (most specific wins):
-//   1. (user_id, gallery_id)
-//   2. (user_id, ':all')
-//   3. (':guest', gallery_id)
-//   4. (':guest', ':all')
+// Cascade priority for a non-special gallery request:
+//   1. (user_id,   gallery_id)
+//   2. (':guest',  gallery_id)
+//   3. (user_id,   ':public')
+//   4. (':guest',  ':public')
+//   5. (user_id,   ':all')
+//   6. (':guest',  ':all')
+//
+// For a :public, :private, or :all request, the :public fall-through is
+// skipped — those aren't subsets of :public.
 
 const setupDb = (rows: Array<[string, string, number | null]>) => {
   const db = new Database(":memory:");
@@ -34,18 +40,25 @@ const resolve = (
   userId: string,
   galleryId: string
 ): number | undefined => {
+  const isSpecial = galleryId.startsWith(":");
+  const galleryWhere = isSpecial
+    ? "gallery_id IN (?, ':all')"
+    : "gallery_id IN (?, ':public', ':all')";
+  const galleryOrder = isSpecial
+    ? "CASE WHEN gallery_id = ? THEN 0 ELSE 1 END"
+    : "CASE WHEN gallery_id = ? THEN 0 WHEN gallery_id = ':public' THEN 1 ELSE 2 END";
   const row = db
     .prepare(
       `SELECT hide_map FROM user_gallery
        WHERE (user_id = ? OR user_id = ':guest')
-         AND (gallery_id = ? OR gallery_id = ':all')
+         AND ${galleryWhere}
          AND hide_map IS NOT NULL
        ORDER BY
-         CASE WHEN user_id = ? THEN 0 ELSE 1 END,
-         CASE WHEN gallery_id = ? THEN 0 ELSE 1 END
+         ${galleryOrder},
+         CASE WHEN user_id = ? THEN 0 ELSE 1 END
        LIMIT 1`
     )
-    .get(userId, galleryId, userId, galleryId) as
+    .get(userId, galleryId, galleryId, userId) as
     | { hide_map: number }
     | undefined;
   return row?.hide_map;
@@ -72,13 +85,26 @@ describe("hide_map ACL cascade", () => {
     expect(resolve(db, "alice", "travel")).toBe(1);
   });
 
-  test("(user, :all) > (:guest, gallery) — user-match beats gallery-match", () => {
+  test("(:guest, gallery) > (user, :all) — gallery-match beats :all-match across users", () => {
     const db = setupDb([
       [":guest", "dailybw", 1],
       ["alice", ":all", 0],
     ]);
-    expect(resolve(db, "alice", "dailybw")).toBe(0);
+    // Gallery-first: (:guest, dailybw) is more specific by gallery than
+    // (alice, :all), so guest's per-gallery setting wins even for alice.
+    expect(resolve(db, "alice", "dailybw")).toBe(1);
     // bob has no rows, falls through to (:guest, dailybw)
+    expect(resolve(db, "bob", "dailybw")).toBe(1);
+    // For "travel" (no gallery-specific row), alice falls through to (alice, :all)
+    expect(resolve(db, "alice", "travel")).toBe(0);
+  });
+
+  test("(user, gallery) > (:guest, gallery) — user beats guest at the same gallery level", () => {
+    const db = setupDb([
+      [":guest", "dailybw", 1],
+      ["alice", "dailybw", 0],
+    ]);
+    expect(resolve(db, "alice", "dailybw")).toBe(0);
     expect(resolve(db, "bob", "dailybw")).toBe(1);
   });
 
@@ -112,5 +138,51 @@ describe("hide_map ACL cascade", () => {
     ]);
     expect(resolve(db, ":guest", "dailybw")).toBe(0);
     expect(resolve(db, ":guest", "other")).toBe(1);
+  });
+
+  test(":public is in the fall-through for non-special gallery requests", () => {
+    const db = setupDb([[":guest", ":public", 1]]);
+    // Specific gallery → falls through :public → hide
+    expect(resolve(db, ":guest", "dailybw")).toBe(1);
+    expect(resolve(db, "alice", "dailybw")).toBe(1);
+    // :public request → matches directly
+    expect(resolve(db, ":guest", ":public")).toBe(1);
+  });
+
+  test("specific (:guest, gallery) beats (:guest, :public)", () => {
+    const db = setupDb([
+      [":guest", ":public", 1],
+      [":guest", "dailybw", 0],
+    ]);
+    expect(resolve(db, ":guest", "dailybw")).toBe(0);
+    // Other galleries still get the :public-level hide
+    expect(resolve(db, ":guest", "travel")).toBe(1);
+  });
+
+  test("(:guest, :public) beats (:guest, :all)", () => {
+    const db = setupDb([
+      [":guest", ":all", 0],
+      [":guest", ":public", 1],
+    ]);
+    expect(resolve(db, ":guest", "dailybw")).toBe(1);
+    // :all wins when the request is :private (no :public fall-through)
+    expect(resolve(db, ":guest", ":private")).toBe(0);
+    // :all wins when the request is :all itself
+    expect(resolve(db, ":guest", ":all")).toBe(0);
+  });
+
+  test(":private request skips the :public fall-through", () => {
+    const db = setupDb([[":guest", ":public", 1]]);
+    // :public being hidden shouldn't affect :private (they're disjoint sets)
+    expect(resolve(db, ":guest", ":private")).toBeUndefined();
+  });
+
+  test("(user, :public) beats (:guest, :public) at the same gallery level", () => {
+    const db = setupDb([
+      [":guest", ":public", 1],
+      ["alice", ":public", 0],
+    ]);
+    expect(resolve(db, "alice", "dailybw")).toBe(0);
+    expect(resolve(db, "bob", "dailybw")).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #189. The natural follow-up to #186/#188 — same `user_gallery` rows, now resolved the same way for both access and privacy.

## What changed

`resolveHideMap` was walking a 4-cell, user-first hierarchy and didn't consult `:public` at all. Two problems with that:

1. `(:guest, :public, hide_map=1)` (a perfectly reasonable "hide map for guests browsing anything published" config) only applied to the `:public` listing itself, not to any specific gallery — even though the access cascade already treats specific galleries as subsets of `:public`.
2. The user-first ordering meant a user-level `:all` setting beat any guest's per-gallery setting, which diverged from how access resolves. Operators looking at the same rows for both purposes had to keep two mental models.

The cascade now matches the access cascade exactly:

| Request | Cascade priority (most specific wins) |
| --- | --- |
| **non-special gallery** | `(user, gallery) > (:guest, gallery) > (user, :public) > (:guest, :public) > (user, :all) > (:guest, :all)` |
| **`:public`, `:private`, `:all`** | `(user, gallery) > (:guest, gallery) > (user, :all) > (:guest, :all)` (skip `:public`) |

The `:public` step is skipped for special-gallery requests because `:private` photos aren't a subset of `:public`, and `:public`/`:all` shouldn't fall through to themselves. Same logic the authorizer encodes via `isSpecialGallery()`.

SQL builds the gallery-id IN-list and ORDER BY case statement conditionally on whether the requested gallery starts with `:`.

## Behavior change for existing rows

The user-first ordering is gone. One concrete consequence: if alice has `(alice, :all, show)` and `(:guest, dailybw, hide)` is also set, alice now sees the map hidden on dailybw (gallery-specific guest setting wins because gallery is more specific than `:all`). Previously alice's `:all` override won.

Operators who relied on the old behavior to give a specific user a global override can still get the same effect by setting `(alice, dailybw, show)` directly — the gallery-level user row beats the gallery-level guest row.

## Tests

`server/tests/lib/privacy.test.ts` updated:

- Header comment rewritten to document the new gallery-first ordering.
- "(user, :all) > (:guest, gallery)" flipped to "(:guest, gallery) > (user, :all) — gallery-match beats :all-match across users" (assertion direction reversed; the old test codified the bug).
- New test: "(user, gallery) > (:guest, gallery) — user beats guest at the same gallery level"
- New test: ":public is in the fall-through for non-special gallery requests"
- New test: "specific (:guest, gallery) beats (:guest, :public)"
- New test: "(:guest, :public) beats (:guest, :all)"
- New test: ":private request skips the :public fall-through"
- New test: "(user, :public) beats (:guest, :public) at the same gallery level"

## Test plan

- [x] `npm run typecheck --workspace=server` — clean
- [x] `npm run lint --workspace=server` — clean
- [x] `npm test --workspace=server` — 593/593 passing (587 + 6 new privacy tests)
- [x] End-to-end smoke against a real SQLite via `bin/access.ts`: set `(:guest, :public, view, hide_map=hide)`, then query the SQL directly for guest on `:public` (= 1, hidden), guest on `dailybw` (= 1, hidden via :public fall-through), and guest on `:private` (= undefined, no fall-through). All three correct.
- [x] **VM smoke test**: pull this branch on prod, refresh `(:guest, :public, hide=1)` if needed, navigate to a specific gallery as a guest and confirm the map is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)