### PR TITLE
Prepare for v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-21
+
 ### Features
 
 - Privacy toggle for the map and photo coordinates. Set via the `user_gallery` table's new `hide_map` column — the four-cell cascade picks the most specific row with a non-null value: `(user, gallery)` > `(user, ':all')` > `(':guest', gallery)` > `(':guest', ':all')`. Both layers fire: the server strips `coord_lat`/`coord_lon`/`coord_alt` from the photo payload when hidden (so there's no data to leak), and the gallery payload gains a `hideMap` boolean that the frontend uses to skip rendering the map widget. Schema migration 003 adds the column; existing deploys pick it up automatically on next server start. To hide for unauthenticated visitors only: `UPDATE user_gallery SET hide_map = 1 WHERE user_id = ':guest' AND gallery_id = ':all'`. (closes #159)
@@ -206,7 +208,8 @@
 
 ## Initial commit - 2020-07-04
 
-[Unreleased]: https://github.com/vlumi/photo-diary/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/vlumi/photo-diary/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/vlumi/photo-diary/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/vlumi/photo-diary/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/vlumi/photo-diary/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/vlumi/photo-diary/compare/v0.4.2...v0.5.0

--- a/bin/instance.ts
+++ b/bin/instance.ts
@@ -104,7 +104,7 @@ const parseEnv = (content: string): Record<string, string> => {
 const readVersion = (codeRoot: string): string => {
   try {
     const pkg = JSON.parse(
-      fs.readFileSync(path.join(codeRoot, "server", "package.json"), "utf8")
+      fs.readFileSync(path.join(codeRoot, "package.json"), "utf8")
     ) as { version?: string };
     return pkg.version ?? "unknown";
   } catch {

--- a/converter/package.json
+++ b/converter/package.json
@@ -1,6 +1,5 @@
 {
   "name": "photo-diary-converter",
-  "version": "0.6.0",
   "description": "",
   "type": "module",
   "main": "index.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "photo-diary",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
+      "version": "0.7.0",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -17,7 +19,6 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -11266,22 +11267,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yargs": {
       "version": "18.0.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
@@ -11323,7 +11308,6 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "0.6.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -11643,7 +11627,6 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "photo-diary",
+  "version": "0.7.0",
   "private": true,
   "description": "Personal photo gallery — monorepo root",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "photo-diary",
   "version": "0.7.0",
   "private": true,
-  "description": "Personal photo gallery — monorepo root",
+  "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",
   "type": "module",
   "engines": {

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -1,6 +1,5 @@
 {
   "name": "photo-diary-app",
-  "version": "0.6.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,5 @@
 {
   "name": "photo-diary-server",
-  "version": "0.6.0",
   "description": "",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
0.7 is feature-complete (#194 went to 1.0, #162 to 0.8). 15 issues closed; this prep PR is just the version bookkeeping.

## Changes

- **Version moves to the root** `package.json` as the single source of truth. The three workspaces (`server`, `converter`, `react-app`) have always moved in lockstep, and none publish to npm, so per-workspace versions weren't serving anything external.
- **`bin/instance.ts:readVersion()`** now reads `<codeRoot>/package.json` instead of `<codeRoot>/server/package.json`. The operator-facing `v0.7.0` string in instance.ts's output (and the DB-backup-on-upgrade naming) still works correctly — verified end-to-end.
- **Lockfile** picks up the version field move and drops an extraneous `yaml` entry npm had been carrying.
- **CHANGELOG**: rename `[Unreleased]` → `[0.7.0] - 2026-05-21`, add a fresh empty `[Unreleased]` heading above, and add the v0.7.0 compare link in the footer.
- **Root description**: was the generic "Personal photo gallery — monorepo root"; now leads with the project name, "Photo Diary — personal photo gallery (monorepo root)", so anything that displays this field identifies the project.

## What 0.7 ships

Highlights from the [0.7.0] section of the CHANGELOG:

- **Cross-package**: rename/relocate the operator scripts (#184); npm workspaces + monorepo layout (#158); `bin/instance.ts` bootstrap/doctor/upgrade flow (#158); nginx deploy + per-gallery vhost docs (#179).
- **Server**: `acl` → `user_gallery` rename with `access_level` column (#185); `bin/access.ts` for managing access rows + privacy without direct SQL (#186); user-first cascade ordering for both access and `hide_map` (#189); `bin/user.ts` restructured as subcommands with delete + `--keep-secret` (#161); DB migration runner with `meta.schema_version` cursor (#169); AI-scraper-signal headers (#173).
- **Frontend**: privacy toggle for the map and photo coordinates (#159); runtime config via `/api/v1/meta` instead of `VITE_*` build vars (#168); drop `mathjs` and `react-helmet-async` (#166, #165).

## Test plan

- [x] `npm run typecheck --workspaces` — clean
- [x] `npm run lint --workspaces` — clean
- [x] `npm test --workspaces` — 945/945 (601 server + 344 frontend)
- [x] Smoke against a fresh instance: migrations run cleanly through 001 → 004, schema lands at v4, all four `bin/<name>.ts` scripts work, `readVersion()` reports `v0.7.0` from the root package.json.
- [ ] **VM smoke test**: pull this branch on a staging host, run `bin/instance.ts <name>` against an existing instance, confirm the upgrade path picks up the new version string.

After this merges: tag `v0.7.0`, publish the GitHub release pointing at the CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)