### PR TITLE
v0.7.1: restore workspace version + add npm run version:sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-05-21
+
+### Fixed
+
+- Restore the per-workspace `version` field that 0.7.0 had removed (pm2 reads version from the script's own package.json, not the monorepo root, so `pm2 list` showed no version after the 0.7.0 upgrade); root stays canonical, with a new `npm run version:sync` script propagating it to the workspaces.
+
 ## [0.7.0] - 2026-05-21
 
 ### Features
@@ -208,7 +214,8 @@
 
 ## Initial commit - 2020-07-04
 
-[Unreleased]: https://github.com/vlumi/photo-diary/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/vlumi/photo-diary/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/vlumi/photo-diary/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/vlumi/photo-diary/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/vlumi/photo-diary/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/vlumi/photo-diary/compare/v0.5.0...v0.5.1

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.7.0
+V=0.7.1
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -106,7 +106,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.7.0/bin/instance.ts dailybw
+/opt/photo-diary/0.7.1/bin/instance.ts dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The script can be invoked from any working directory; the instance dir is derived from the name (and the `--base <dir>` flag, default `/var/photo-diary`, if you want instances under a different parent). Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).

--- a/bin/sync-versions.mjs
+++ b/bin/sync-versions.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+// Propagate the root `package.json`'s `version` to each workspace's
+// `package.json`. Tools like pm2 read the version from the package.json in
+// the script's own directory (not the monorepo root), so the workspaces
+// need their own copy of the version. Root stays the canonical place to
+// bump; this script keeps the workspaces in lockstep.
+//
+// Usage: `npm run version:sync` (or `node bin/sync-versions.mjs` directly).
+// `npm install` after will refresh the lockfile to match.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const WORKSPACES = ["server", "converter", "react-app"];
+
+const rootPkg = JSON.parse(readFileSync(join(ROOT, "package.json"), "utf8"));
+const version = rootPkg.version;
+if (!version) {
+  console.error("Root package.json has no `version` field.");
+  process.exit(1);
+}
+
+for (const ws of WORKSPACES) {
+  const path = join(ROOT, ws, "package.json");
+  const pkg = JSON.parse(readFileSync(path, "utf8"));
+  if (pkg.version === version) {
+    console.log(`✓ ${ws}: already at ${version}`);
+    continue;
+  }
+  pkg.version = version;
+  writeFileSync(path, JSON.stringify(pkg, null, 2) + "\n");
+  console.log(`✓ ${ws}: → ${version}`);
+}

--- a/converter/package.json
+++ b/converter/package.json
@@ -33,5 +33,6 @@
     "tsx": "^4.22.2",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4"
-  }
+  },
+  "version": "0.7.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -19,6 +19,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -11308,6 +11309,7 @@
     },
     "react-app": {
       "name": "photo-diary-app",
+      "version": "0.7.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -11627,6 +11629,7 @@
     },
     "server": {
       "name": "photo-diary-server",
+      "version": "0.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",
@@ -15,7 +15,8 @@
   ],
   "scripts": {
     "setup": "npm install && npm run build",
-    "build": "npm run build --workspace=react-app && rm -rf server/build && cp -r react-app/build server/build"
+    "build": "npm run build --workspace=react-app && rm -rf server/build && cp -r react-app/build server/build",
+    "version:sync": "node bin/sync-versions.mjs && npm install --package-lock-only"
   },
   "repository": {
     "type": "git",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -56,5 +56,6 @@
   "repository": {
     "type": "git",
     "url": "github:vlumi/photo-diary"
-  }
+  },
+  "version": "0.7.1"
 }

--- a/server/package.json
+++ b/server/package.json
@@ -51,5 +51,6 @@
   "repository": {
     "type": "git",
     "url": "github:vlumi/photo-diary"
-  }
+  },
+  "version": "0.7.1"
 }


### PR DESCRIPTION
Hotfix for 0.7.0.

## The regression

0.7.0's release-prep (#196) moved `version` from the three workspace `package.json` files to the root, on the (correct) reasoning that npm workspaces don't auto-cascade root → workspaces and that lockstep versions only need one canonical home.

What we missed: **pm2 reads the version it shows in `pm2 list` from the package.json in the script's own directory** (e.g. `server/package.json` for the server process), not from the monorepo root. So after the 0.7.0 upgrade, `pm2 list` showed no version for the server and converter processes.

## Fix

- Root `package.json` stays the canonical place to bump.
- New [`bin/sync-versions.mjs`](bin/sync-versions.mjs) reads root's `version` and writes it to each workspace's `package.json`. Idempotent — exits with `✓ already at <v>` per workspace when nothing changes.
- New `npm run version:sync` chains the script with `npm install --package-lock-only` so the lockfile picks up the workspace bumps without a full reinstall.

Release flow becomes:

```sh
# bump root package.json's version manually
npm run version:sync          # propagates to workspaces + lockfile
git commit ...
```

Four files stay in lockstep, but release prep only touches the root by hand.

## Test plan

- [x] `npm run typecheck --workspaces` — clean
- [x] `npm run lint --workspaces` — clean
- [x] `npm test --workspaces` — 945/945
- [x] Smoke: `bin/instance.ts smoke …` reports `v0.7.1` (root is canonical, still works)
- [x] Verified all four `package.json` files agree at 0.7.1 after running `version:sync`
- [x] **VM smoke**: pull on prod, restart pm2 for the upgraded instance, confirm `pm2 list` now shows the version

After merge: tag `v0.7.1` and publish the release pointing at the CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)