### PR TITLE
Fix two critical security issues (privacy bypass + secret logs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Apply the `hide_map` cascade on `GET /api/v1/galleries/:id` and `/api/v1/photos` (`/`, `/:id`); previously only `/gallery-photos/...` masked the embedded photos' coordinates, so `hide_map=1` leaked coords through the other two routes. (closes #201)
+- Stop logging credentials, JWT secrets, and tokens in debug-level statements (`tokens-v1.ts`, `models/token.ts`); only the user ID is logged now. Prevents plaintext password leaks into pm2 logs whenever `DEBUG=true` is flipped to triage a login issue. (closes #202)
+
 ## [0.7.1] - 2026-05-21
 
 ### Fixed

--- a/server/controllers/galleries-v1.ts
+++ b/server/controllers/galleries-v1.ts
@@ -1,7 +1,7 @@
 import express from "express";
 
 import authorizerFactory from "../lib/authorizer.js";
-import { shouldHideMap } from "../lib/privacy.js";
+import { shouldHideMap, maskCoordinates } from "../lib/privacy.js";
 import modelFactory from "../models/gallery.js";
 
 const authorizer = authorizerFactory();
@@ -72,12 +72,18 @@ router.get("/:galleryId", async (request, response) => {
     request.user.id,
     request.params.galleryId
   );
-  const gallery = await model.getGallery(request.params.galleryId);
+  const gallery = (await model.getGallery(request.params.galleryId)) as Record<
+    string,
+    unknown
+  > & { photos?: unknown[] };
   const hideMap = await shouldHideMap(
     request.user.id,
     request.params.galleryId
   );
-  response.json({ ...(gallery as Record<string, unknown>), hideMap });
+  if (hideMap && gallery.photos) {
+    maskCoordinates(gallery.photos as Parameters<typeof maskCoordinates>[0]);
+  }
+  response.json({ ...gallery, hideMap });
 });
 /**
  * Update gallery properties

--- a/server/controllers/photos-v1.ts
+++ b/server/controllers/photos-v1.ts
@@ -1,6 +1,8 @@
 import express from "express";
 
+import CONST from "../lib/constants.js";
 import authorizerFactory from "../lib/authorizer.js";
+import { shouldHideMap, maskCoordinates } from "../lib/privacy.js";
 import modelFactory from "../models/photo.js";
 
 const authorizer = authorizerFactory();
@@ -19,6 +21,17 @@ export default { init, router };
 router.get("/", async (request, response) => {
   await authorizer.authorizeView(request.user.id);
   const photos = await model.getPhotos();
+  // No per-gallery scope here — resolve the user's :all-level preference.
+  // `Object.values` covers both the array shape (real sqlite driver) and the
+  // {photoId: photo} dict shape the dummy driver returns; either way we get
+  // an iterable of photo objects that `maskCoordinates` can mutate in place.
+  if (await shouldHideMap(request.user.id, CONST.SPECIAL_GALLERY_ALL)) {
+    maskCoordinates(
+      Object.values(photos as Record<string, unknown>) as Parameters<
+        typeof maskCoordinates
+      >[0]
+    );
+  }
   response.json(photos);
 });
 /**
@@ -37,6 +50,9 @@ router.post("/", async (request, response) => {
 router.get("/:photoId", async (request, response) => {
   await authorizer.authorizeView(request.user.id);
   const photo = await model.getPhoto(request.params.photoId);
+  if (await shouldHideMap(request.user.id, CONST.SPECIAL_GALLERY_ALL)) {
+    maskCoordinates([photo] as Parameters<typeof maskCoordinates>[0]);
+  }
   response.json(photo);
 });
 /**

--- a/server/controllers/tokens-v1.ts
+++ b/server/controllers/tokens-v1.ts
@@ -25,7 +25,7 @@ router.get("/", (request, response) => {
  * Login, creating a new token.
  */
 router.post("/", async (request, response, next) => {
-  logger.debug("Login", request.body);
+  logger.debug(`Login attempt for "${request.body?.id}"`);
   const credentials = {
     id: request.body.id,
     password: request.body.password,

--- a/server/db/dummy.ts
+++ b/server/db/dummy.ts
@@ -368,9 +368,9 @@ const dbDump = JSON.stringify({
           country: "jp",
           place: "",
           coordinates: {
-            latitude: undefined,
-            longitude: undefined,
-            altitude: undefined,
+            latitude: 35.6595,
+            longitude: 139.7005,
+            altitude: 36.5,
           },
         },
       },

--- a/server/models/token.ts
+++ b/server/models/token.ts
@@ -58,14 +58,14 @@ const checkUserPassword = async (
   credentials: Credentials,
   user: StoredUser
 ): Promise<void> => {
-  logger.debug("Check password", credentials, user);
+  logger.debug(`Check password for "${credentials.id}"`);
   return new Promise((resolve, reject) => {
     bcrypt.compare(credentials.password, user.password, (error, result) => {
       if (error || !result) {
-        logger.debug("Invalid password", credentials);
+        logger.debug(`Invalid password for "${credentials.id}"`);
         reject(CONST.ERROR_LOGIN);
       }
-      logger.debug("success!", error, result);
+      logger.debug(`Password check succeeded for "${credentials.id}"`);
       resolve();
     });
   });
@@ -79,7 +79,7 @@ const createToken = async (id: string, isAdmin: boolean): Promise<string> => {
     .sign(encodeSecret(getSecret(id)));
 };
 const authenticateUser = async (credentials: Credentials): Promise<void> => {
-  logger.debug("Authenticating user", credentials);
+  logger.debug(`Authenticating user "${credentials.id}"`);
   try {
     const user = (await db.loadUser(credentials.id)) as StoredUser;
     await checkUserPassword(credentials, user);
@@ -91,7 +91,7 @@ const authenticateUser = async (credentials: Credentials): Promise<void> => {
 };
 const verifyToken = async (token: string) => {
   const decoded = decodeJwt(token) as { id: string };
-  logger.debug("Verifying token", token, secrets[decoded.id]);
+  logger.debug(`Verifying token for "${decoded.id}"`);
 
   const { payload } = await jwtVerify(
     token,

--- a/server/tests/api/galleries.test.ts
+++ b/server/tests/api/galleries.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { init } from "../../app.js";
 import dummyFactory from "../../db/dummy.js";
+import dbFacade from "../../db/index.js";
 import { createApi, loginUser } from "./helper.js";
 
 const db = dummyFactory();
@@ -444,6 +445,44 @@ describe("As gallery12User", () => {
   });
   test("Get invalid", async () => {
     await getGallery(token, "invalid", 403);
+  });
+});
+
+describe("hide_map cascade applied to GET /galleries/:id (regression #201)", () => {
+  let token: string | undefined = undefined;
+  let spy: ReturnType<typeof vi.spyOn>;
+  beforeAll(async () => {
+    token = await loginUser(api, "plainUser");
+  });
+  beforeEach(() => {
+    spy = vi.spyOn(dbFacade, "resolveHideMap").mockResolvedValue(1);
+  });
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  test("strips coordinates from the embedded photos array", async () => {
+    const result = await getGallery(token, "gallery1");
+    expect(result.body.hideMap).toBe(true);
+    // gallery1photo.jpg has explicit fixture coords; verify they're nulled.
+    const photo = result.body.photos.find(
+      (p: any) => p.id === "gallery1photo.jpg"
+    );
+    expect(photo).toBeDefined();
+    expect(photo.taken.location.coordinates.latitude).toBeNull();
+    expect(photo.taken.location.coordinates.longitude).toBeNull();
+    expect(photo.taken.location.coordinates.altitude).toBeNull();
+  });
+
+  test("leaves coords untouched when hide_map is undefined", async () => {
+    spy.mockResolvedValue(undefined);
+    const result = await getGallery(token, "gallery1");
+    expect(result.body.hideMap).toBe(false);
+    const photo = result.body.photos.find(
+      (p: any) => p.id === "gallery1photo.jpg"
+    );
+    expect(photo.taken.location.coordinates.latitude).toBe(35.6595);
+    expect(photo.taken.location.coordinates.longitude).toBe(139.7005);
   });
 });
 

--- a/server/tests/api/photos.test.ts
+++ b/server/tests/api/photos.test.ts
@@ -1,5 +1,6 @@
 import { init } from "../../app.js";
 import dummyFactory from "../../db/dummy.js";
+import dbFacade from "../../db/index.js";
 import { createApi, loginUser } from "./helper.js";
 
 const db = dummyFactory();
@@ -328,6 +329,43 @@ describe("As gallery12User", () => {
   });
   test("Get invalid", async () => {
     await getPhoto(token, "invalid.jpg", 403);
+  });
+});
+
+describe("hide_map cascade applied to GET /photos and /photos/:id (regression #201)", () => {
+  let token: string | undefined = undefined;
+  let spy: ReturnType<typeof vi.spyOn>;
+  beforeAll(async () => {
+    token = await loginUser(api, "admin");
+  });
+  beforeEach(() => {
+    spy = vi.spyOn(dbFacade, "resolveHideMap").mockResolvedValue(1);
+  });
+  afterEach(() => {
+    spy.mockRestore();
+  });
+
+  test("/photos: coords nulled on the listed photos", async () => {
+    const result = await getPhotos(token);
+    const photo = result.body["gallery1photo.jpg"];
+    expect(photo).toBeDefined();
+    expect(photo.taken.location.coordinates.latitude).toBeNull();
+    expect(photo.taken.location.coordinates.longitude).toBeNull();
+    expect(photo.taken.location.coordinates.altitude).toBeNull();
+  });
+
+  test("/photos/:id: coords nulled on the single photo", async () => {
+    const result = await getPhoto(token, "gallery1photo.jpg");
+    expect(result.body.taken.location.coordinates.latitude).toBeNull();
+    expect(result.body.taken.location.coordinates.longitude).toBeNull();
+    expect(result.body.taken.location.coordinates.altitude).toBeNull();
+  });
+
+  test("coords untouched when hide_map is undefined", async () => {
+    spy.mockResolvedValue(undefined);
+    const result = await getPhoto(token, "gallery1photo.jpg");
+    expect(result.body.taken.location.coordinates.latitude).toBe(35.6595);
+    expect(result.body.taken.location.coordinates.longitude).toBe(139.7005);
   });
 });
 


### PR DESCRIPTION
The two **Critical** items from the 0.7.2 security audit. Should ship as soon as possible — both are real, both happen on default-config production deploys.

Closes #201 and #202.

## #201 — privacy cascade bypassed on `/galleries/:id` and `/photos`

[`gallery-photos-v1.ts`](server/controllers/gallery-photos-v1.ts) was already calling `maskCoordinates` when the `hide_map` cascade resolved to hide, but the sibling endpoints in [`galleries-v1.ts`](server/controllers/galleries-v1.ts) (`GET /:id`) and [`photos-v1.ts`](server/controllers/photos-v1.ts) (`GET /` and `GET /:id`) missed it — so the embedded photos in those payloads kept their raw `coord_lat`/`coord_lon`/`coord_alt` even when `hide_map=1`.

Frontend defense-in-depth (the `hideMap` flag plus `photo.hasCoordinates()`) caught the visible map widget on the page, but the coordinates were still in the JSON response — anyone hitting the API directly (curl, devtools, scraper) sees them.

All three call sites now call `shouldHideMap` + `maskCoordinates` consistently. For `/photos` (no per-gallery scope), the resolver uses the user's `:all`-level preference. The mask call wraps in `Object.values(photos)` so it covers both the sqlite driver's array shape and the dummy driver's `{id: photo}` dict shape (a pre-existing inconsistency that I'm not fixing here — separate concern).

## #202 — credentials and JWT signing keys logged at debug level

Five `logger.debug(...)` call sites in [`tokens-v1.ts`](server/controllers/tokens-v1.ts) and [`models/token.ts`](server/models/token.ts) dumped the request body / `credentials` object / token + user secret. `DEBUG` defaults to false in prod, but the moment anyone flips it to triage a login bug, plaintext passwords and signing-key halves land in `~/.pm2/logs/<name>-out.log` for the duration of log retention.

All five lines now log only the user ID — `Login attempt for "alice"` / `Check password for "alice"` / `Verifying token for "alice"` etc. Equivalent triage signal, no sensitive material.

## Tests

Regression tests added in [`tests/api/galleries.test.ts`](server/tests/api/galleries.test.ts) and [`tests/api/photos.test.ts`](server/tests/api/photos.test.ts):
- Spy on `db.resolveHideMap` to force the cascade to resolve to hide.
- Hit each endpoint, assert `latitude`/`longitude`/`altitude` come back `null`.
- Reverse case: with hide_map undefined, coords come back at their fixture values.

One dummy fixture photo (`gallery1photo.jpg`) gains real coordinates (`35.6595, 139.7005, 36.5`) so the assertions have a concrete "before" to mask.

## Test plan

- [x] `npm run typecheck --workspace=server` — clean
- [x] `npm run lint --workspace=server` — clean
- [x] `npm test --workspace=server` — 606/606 (601 + 5 new privacy regression tests)
- [ ] **VM smoke**: pull on prod, set `(:guest, :all, hide_map=1)`, `curl /api/v1/galleries/dailybw | jq '.photos[0].taken.location.coordinates'` — should be `{ "latitude": null, "longitude": null, "altitude": null }` instead of the real values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)