### PR TITLE
Operator polish: passwd prompt, instance.ts cwd-infer, pm2 upgrade fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 - Drop the open `cors()` middleware — none of the documented deploy patterns need cross-origin API access, and bearer-token auth already neutralised most CSRF concerns. If a future setup needs it, add a `CORS_ORIGINS` env knob then. (closes #205)
 - Tighten the token-secret reload interval from 60s to 5s, so a `bin/user.ts passwd` rotation (which kills sessions) takes effect quickly. (closes #206)
 
+### Operator scripts
+
+- `bin/user.ts passwd <id> [password]` now prompts for the password with no echo when the positional is omitted — avoids leaking the password into shell history and `ps`. Positional path stays for scripting. (closes #200)
+- `bin/instance.ts` infers the instance from cwd when invoked inside an existing instance dir (recognised by the `.env` + `code`-symlink pair), reading the logical name from `.env`'s `INSTANCE_NAME` (the pm2 process label) and falling back to the dir's basename when missing — so the pm2 commands in the upgrade output reflect what pm2 actually labels the process. Migrated the script's argv parsing to yargs (matching the other operator scripts) for consistent `--help`, validation, and unknown-flag rejection. (closes #198)
+- Upgrade flow now recommends `pm2 delete && start-prod.sh` instead of `pm2 restart` — restart preserves cached script paths and package.json version, so the previous instruction silently kept the old code running after a symlink flip. README and `bin/instance.ts` Next-steps output both updated. (closes #199)
+
 ## [0.7.1] - 2026-05-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -130,15 +130,21 @@ Both `start-prod.sh` scripts source `.env` from the current working directory, t
 
 #### Upgrading an instance
 
-Re-run `bin/instance.ts` from the new version of the code:
+Re-run `bin/instance.ts` from the new version of the code, then **delete + start** pm2 (not `restart`):
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.8.0/bin/instance.ts dailybw   # backs up the DB, flips the symlink
-pm2 restart dailybw dailybw-converter         # migration runner applies any schema bumps
+/opt/photo-diary/0.8.0/bin/instance.ts dailybw          # backs up the DB, flips the symlink
+pm2 delete dailybw dailybw-converter                    # drop cached metadata
+cd /var/photo-diary/dailybw
+./code/server/bin/start-prod.sh                         # migration runner applies any schema bumps
+./code/converter/bin/start-prod.sh
+pm2 save
 ```
 
-The DB backup is named `db.sqlite3.pre-<new-version>` — a plain file copy that assumes the instance is stopped (started instances may have an inconsistent backup). Rollback is manual: `cp db.sqlite3.pre-<version> db.sqlite3`, point `code` back at the older version, restart pm2.
+`pm2 restart` won't pick up the symlink flip — pm2 caches the resolved script path and the package.json version at the original `start` time, so a restart re-execs the *old* paths and `pm2 list` keeps showing the previous version. `delete` + `start-prod.sh` forces re-resolution and is the only reliable upgrade path today.
+
+The DB backup is named `db.sqlite3.pre-<new-version>` — a plain file copy that assumes the instance is stopped (started instances may have an inconsistent backup). Rollback is manual: `cp db.sqlite3.pre-<version> db.sqlite3`, point `code` back at the older version, then the same `pm2 delete && start-prod.sh` cycle.
 
 #### nginx
 

--- a/bin/instance.ts
+++ b/bin/instance.ts
@@ -32,6 +32,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
 // ---- types ---------------------------------------------------------------
 
 interface RequiredKey {
@@ -144,25 +147,95 @@ const appendMissingKeys = (
 
 // ---- args ----------------------------------------------------------------
 
-const args = process.argv.slice(2);
-const name = args[0];
-const baseFlagIndex = args.indexOf("--base");
-const base = baseFlagIndex >= 0 ? args[baseFlagIndex + 1] : "/var/photo-diary";
-const fix = args.includes("--fix");
+// An instance dir is recognisable by the combination of `.env` + the `code`
+// symlink. If both are present and no explicit positional was passed, infer
+// the instance dir from cwd — saves operators retyping the name for doctor
+// / --fix runs they're already cd'd into.
+const looksLikeInstanceDir = (dir: string): boolean => {
+  try {
+    return (
+      fs.statSync(path.join(dir, ".env")).isFile() &&
+      fs.lstatSync(path.join(dir, "code")).isSymbolicLink()
+    );
+  } catch {
+    return false;
+  }
+};
 
-if (!name || name.startsWith("--")) {
+const argv = yargs(hideBin(process.argv))
+  .scriptName("instance.ts")
+  .command(
+    "$0 [name]",
+    "Bootstrap, doctor, or upgrade a Photo Diary instance directory",
+    (y) =>
+      y
+        .positional("name", {
+          describe:
+            "Instance directory name under --base. May be omitted when run from inside an existing instance dir; in that case the dir is inferred from cwd and the logical name is read from .env's INSTANCE_NAME.",
+          type: "string",
+        })
+        .option("base", {
+          describe: "Parent directory for the instance dir",
+          type: "string",
+          default: "/var/photo-diary",
+        })
+        .option("fix", {
+          describe:
+            "Append missing required keys to an existing .env (doesn't touch existing values)",
+          type: "boolean",
+          default: false,
+        })
+  )
+  .alias("help", "h")
+  .strict()
+  .parseSync();
+
+const positional = argv.name as string | undefined;
+const baseFlag = argv.base;
+const fix = argv.fix;
+
+// Resolve `instanceDir` first — it's the structural anchor for everything
+// else (path resolution, locating .env, locating the `code` symlink). The
+// *logical* instance name (used for pm2 process labels, display) comes
+// from `.env`'s INSTANCE_NAME below; only the dir matters for paths.
+let instanceDir: string;
+let inferredFromCwd = false;
+if (positional) {
+  instanceDir = path.resolve(String(baseFlag), positional);
+} else if (looksLikeInstanceDir(process.cwd())) {
+  instanceDir = process.cwd();
+  inferredFromCwd = true;
+} else {
   console.error(
-    "Usage: bin/instance.ts <name> [--base <dir>] [--fix]\n" +
-      "  <name>     directory name under --base (default /var/photo-diary)\n" +
-      "  --fix      append missing required keys to an existing .env (doesn't touch existing values)"
+    "Error: no <name> given and cwd is not an instance dir (no `.env` + `code` symlink)."
   );
+  console.error("Run with --help for usage.");
   process.exit(1);
 }
 
-const instanceDir = path.resolve(base, name);
 const envPath = path.join(instanceDir, ".env");
 const codeLinkPath = path.join(instanceDir, "code");
 const instanceBinDir = path.join(instanceDir, "bin");
+
+// Logical name: prefer `.env`'s INSTANCE_NAME (the pm2 process label),
+// fall back to the dir's basename when there's no .env yet or the key
+// is missing. The default `bin/instance.ts` template seeds INSTANCE_NAME
+// equal to the dir name, so for the common case the two match — but
+// operators may legitimately set them apart.
+const instanceName = (() => {
+  try {
+    return (
+      parseEnv(fs.readFileSync(envPath, "utf8")).INSTANCE_NAME ??
+      path.basename(instanceDir)
+    );
+  } catch {
+    return path.basename(instanceDir);
+  }
+})();
+
+if (inferredFromCwd) {
+  console.log(`(inferred instance "${instanceName}" at ${instanceDir} from cwd)`);
+}
 
 // Routine operator scripts surfaced as `<instance>/bin/<name>.ts` symlinks
 // pointing at `<instance>/code/server/bin/<name>.ts`. `instance` itself is
@@ -199,7 +272,7 @@ if (!envExists) {
 
 // 3. .env
 if (mode === "new") {
-  writeEnvFile(envPath, { instanceDir, name });
+  writeEnvFile(envPath, { instanceDir, name: instanceName });
   console.log(`✓ Created ${envPath} (with a fresh random SECRET)`);
 } else {
   const existing = parseEnv(fs.readFileSync(envPath, "utf8"));
@@ -207,7 +280,7 @@ if (mode === "new") {
   if (missing.length === 0) {
     console.log("✓ .env present and complete");
   } else if (fix) {
-    const added = appendMissingKeys(envPath, existing, { instanceDir, name });
+    const added = appendMissingKeys(envPath, existing, { instanceDir, name: instanceName });
     console.log(`✓ Appended missing keys to .env: ${added.join(", ")}`);
   } else {
     console.log("✗ .env is missing values for:");
@@ -303,21 +376,33 @@ if (mode === "new") {
   console.log("  ./code/server/bin/start-prod.sh");
   console.log("  ./code/converter/bin/start-prod.sh");
   console.log("  ./bin/user.ts passwd <username> <password>");
-  console.log(`  ./bin/gallery.ts ${name} --title "${name}"`);
+  console.log(`  ./bin/gallery.ts ${instanceName} --title "${instanceName}"`);
   console.log("  ./bin/access.ts level <username> :all admin");
 } else if (mode === "upgrade") {
-  console.log("Upgrade prepared. Restart pm2 to activate:");
-  console.log(`  pm2 restart ${name} ${name}-converter`);
-  console.log("  # ...or if not yet running:");
+  console.log("Upgrade prepared. Cycle pm2 to pick up the new version:");
+  console.log(`  pm2 delete ${instanceName} ${instanceName}-converter`);
   console.log(`  cd ${instanceDir}`);
   console.log("  ./code/server/bin/start-prod.sh");
   console.log("  ./code/converter/bin/start-prod.sh");
+  console.log("  pm2 save");
+  console.log();
+  console.log(
+    "(pm2 restart preserves cached metadata — the resolved script path and"
+  );
+  console.log(
+    " package.json version are read at start time — so a symlink flip plus a"
+  );
+  console.log(
+    " plain restart silently keeps you on the old version. delete + start"
+  );
+  console.log(" forces re-resolution.)");
   console.log();
   console.log("Rollback (manual, only if needed):");
-  console.log(`  pm2 stop ${name} ${name}-converter`);
+  console.log(`  pm2 delete ${instanceName} ${instanceName}-converter`);
   console.log("  cp db.sqlite3.pre-<version> db.sqlite3");
   console.log(`  ln -snf <old-code-root> ${codeLinkPath}`);
-  console.log(`  pm2 restart ${name} ${name}-converter`);
+  console.log("  ./code/server/bin/start-prod.sh");
+  console.log("  ./code/converter/bin/start-prod.sh");
 } else {
   console.log("Instance state OK.");
 }

--- a/server/bin/user.ts
+++ b/server/bin/user.ts
@@ -7,13 +7,16 @@
  * Subcommands:
  *
  *   user.ts list
- *   user.ts passwd <id> <password> [--keep-secret]
+ *   user.ts passwd <id> [password] [--keep-secret]
  *   user.ts delete <id> [--yes]
  *
  * `passwd` upserts the user — creates if missing, updates the password if
- * present. By default the user's `secret` is rotated too, which invalidates
- * every existing JWT for them (correct for "password lost / leaked" cases).
- * Pass `--keep-secret` to opt out and keep sessions alive across the change.
+ * present. Omit `[password]` to be prompted interactively without echo
+ * (preferred — avoids leaving the password in shell history or `ps`). When
+ * scripting, pass the password as the positional. By default the user's
+ * `secret` is rotated too, which invalidates every existing JWT for them
+ * (correct for "password lost / leaked" cases). Pass `--keep-secret` to opt
+ * out and keep sessions alive across the change.
  *
  * `delete` cascades to the user's `user_gallery` rows (access + hide_map).
  * Confirmation prompt unless `--yes` is given.
@@ -42,6 +45,72 @@ const confirm = async (prompt: string): Promise<boolean> => {
   } finally {
     rl.close();
   }
+};
+
+// Read a line from stdin without echoing it back to the terminal — for
+// passwords. Node has no built-in no-echo helper, so we flip stdin into raw
+// mode and consume bytes manually until enter / EOF. Handles paste (multi-
+// char chunks), backspace, and Ctrl-C.
+const CTRL_C = String.fromCharCode(0x03); // ETX — abort
+const EOF_CHAR = String.fromCharCode(0x04); // EOT — submit (Ctrl-D)
+const DEL = String.fromCharCode(0x7f); // DEL — backspace on most terminals
+const promptHidden = (prompt: string): Promise<string> => {
+  if (!process.stdin.isTTY) {
+    console.error(
+      "Password not provided and stdin is not a TTY. Pass the password as a positional argument when scripting:"
+    );
+    console.error("  user.ts passwd <id> <password>");
+    process.exit(1);
+  }
+  process.stdout.write(prompt);
+  return new Promise((resolve) => {
+    let value = "";
+    const stdin = process.stdin;
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf8");
+    const cleanup = () => {
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdin.removeListener("data", onData);
+    };
+    const onData = (chunk: Buffer | string) => {
+      for (const ch of chunk.toString()) {
+        if (ch === CTRL_C) {
+          // Ctrl-C: behave like the shell would (abort, no resolve).
+          cleanup();
+          process.stdout.write("\n");
+          process.exit(130);
+        }
+        if (ch === "\r" || ch === "\n" || ch === EOF_CHAR) {
+          cleanup();
+          process.stdout.write("\n");
+          resolve(value);
+          return;
+        }
+        if (ch === DEL || ch === "\b") {
+          value = value.slice(0, -1);
+          continue;
+        }
+        value += ch;
+      }
+    };
+    stdin.on("data", onData);
+  });
+};
+
+const promptForNewPassword = async (): Promise<string> => {
+  const first = await promptHidden("New password: ");
+  if (first.length === 0) {
+    console.error("Password cannot be empty.");
+    process.exit(1);
+  }
+  const second = await promptHidden("Confirm:      ");
+  if (first !== second) {
+    console.error("Passwords do not match. Aborted.");
+    process.exit(1);
+  }
+  return first;
 };
 
 const formatTable = (rows: string[][]): string => {
@@ -79,15 +148,15 @@ await yargs(hideBin(process.argv))
     }
   )
   .command(
-    "passwd <id> <password>",
+    "passwd <id> [password]",
     "Set a user's password (creates the user if missing; rotates secret by default)",
     (y) =>
       y
         .positional("id", { describe: "User ID", type: "string", demandOption: true })
         .positional("password", {
-          describe: "Password (bcrypt-hashed before storage)",
+          describe:
+            "Password; omit to be prompted interactively without echo (preferred — avoids ps/shell-history leaks)",
           type: "string",
-          demandOption: true,
         })
         .option("keep-secret", {
           describe: "Don't rotate the user's secret (keeps existing JWT sessions valid)",
@@ -95,7 +164,8 @@ await yargs(hideBin(process.argv))
           default: false,
         }),
     async (argv) => {
-      const hash = await bcrypt.hash(argv.password, SALT_ROUNDS);
+      const password = argv.password ?? (await promptForNewPassword());
+      const hash = await bcrypt.hash(password, SALT_ROUNDS);
       const existing = await db
         .loadUser(argv.id)
         .then((u) => u as { id: string })


### PR DESCRIPTION
The three **polish** items from 0.7.2. **Stacked on top of #209** (security middleware) — base branch is `chore/security-middleware`. Merge order: #209 first, then this auto-rebases against main.

Closes #198, #199, #200.

## What's in it

### #200 — `user.ts passwd` prompts for the password

`passwd <id> [password]` — when the positional is omitted, the script prompts with no echo, confirms by asking twice, and errors out if entries don't match. Positional path stays for scripting.

```
$ ./bin/user.ts passwd alice
New password: ********
Confirm:      ********
✓ Updated password for "alice"; existing sessions invalidated (secret rotated).
```

Avoids leaking the password into shell history and `ps auxf` for everyone with shell access on the host. Implementation flips stdin into raw mode and consumes bytes per-char (handles paste, Ctrl-C, EOF, DEL/BS). When stdin isn't a TTY and no positional was passed, prints a friendly error pointing at the scripting workflow and exits 1.

### #198 — `instance.ts` infers the instance from cwd, with the *name* read from `.env`

`bin/instance.ts` with no positional, run inside a dir that looks like an instance (`.env` + `code` symlink both present), now treats cwd as the instance dir. The **logical instance name** is read from `.env`'s `INSTANCE_NAME` first (the pm2 process label) and falls back to `basename(cwd)` only if the key is missing — so the pm2 commands in the upgrade output reflect what pm2 actually labels the process with, even when an operator has set `INSTANCE_NAME` to something different from the directory name.

```
$ cd /var/photo-diary/dailybw          # dir name is "dailybw" but INSTANCE_NAME=daily-bw-prod
$ ./code/bin/instance.ts --fix
(inferred instance "daily-bw-prod" at /var/photo-diary/dailybw from cwd)
Instance dir: /var/photo-diary/dailybw
…
```

Explicit positional or `--base` still wins for locating the directory. The logical-name resolution (read INSTANCE_NAME from .env, fall back to basename) also applies to the explicit-positional path now, so the pm2 commands in the upgrade output are consistent regardless of how the operator invoked the script.

### #199 — `pm2 restart` → `pm2 delete && start-prod.sh` for the upgrade flow

The actual bug behind the recent "version not refreshing" report. pm2 caches the resolved script path and the package.json version at the original `start` time, so `pm2 restart` after a `code` symlink flip silently re-execs the old paths — the upgrade *appears* successful (process running, symlink right) but is silently still on the old code.

The upgrade-mode Next-steps output in [`bin/instance.ts`](bin/instance.ts) now prints (using the `INSTANCE_NAME` resolved above):

```
Upgrade prepared. Cycle pm2 to pick up the new version:
  pm2 delete daily-bw-prod daily-bw-prod-converter
  cd /var/photo-diary/dailybw
  ./code/server/bin/start-prod.sh
  ./code/converter/bin/start-prod.sh
  pm2 save

(pm2 restart preserves cached metadata — the resolved script path and
 package.json version are read at start time — so a symlink flip plus a
 plain restart silently keeps you on the old version. delete + start
 forces re-resolution.)
```

[The README's "Upgrading an instance" section](README.md) updated to match, with the same explanation paragraph.

## Test plan

- [x] `npm run typecheck --workspace=server` — clean
- [x] `npm run lint --workspace=server` — clean
- [x] `npm test --workspace=server` — 606/606
- [x] Smoke: `./bin/user.ts passwd alice plaintext` (backwards-compat positional) → works. `./bin/user.ts passwd alice < /dev/null` → clean error, exit 1. Interactive paths inspected manually (echo suppressed, confirm prompt fires).
- [x] Smoke: `./bin/instance.ts` with no args inside instance dir → infers instance, prints "(inferred instance …)". With `INSTANCE_NAME` set to something different from the dir basename, the inferred name reflects the .env value and the upgrade-mode `pm2 delete` commands use it.
- [x] Smoke: upgrade-mode triggered by pointing the `code` symlink at a different path → new Next-steps output reads cleanly with `pm2 delete` + start-prod.sh and the rationale paragraph.
- [ ] **VM smoke**: on next upgrade, follow the new `pm2 delete` flow and confirm `pm2 list` shows the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)