### PR TITLE
Prepare for v0.7.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-05-22
+
 ### Fixed
 
 - Apply the `hide_map` cascade on `GET /api/v1/galleries/:id` and `/api/v1/photos` (`/`, `/:id`); previously only `/gallery-photos/...` masked the embedded photos' coordinates, so `hide_map=1` leaked coords through the other two routes. (closes #201)
@@ -232,7 +234,8 @@
 
 ## Initial commit - 2020-07-04
 
-[Unreleased]: https://github.com/vlumi/photo-diary/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/vlumi/photo-diary/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/vlumi/photo-diary/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/vlumi/photo-diary/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/vlumi/photo-diary/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/vlumi/photo-diary/compare/v0.5.1...v0.6.0

--- a/converter/package.json
+++ b/converter/package.json
@@ -34,5 +34,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4"
   },
-  "version": "0.7.1"
+  "version": "0.7.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -19,7 +19,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -11319,7 +11319,7 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -11639,7 +11639,7 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -57,5 +57,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.7.1"
+  "version": "0.7.2"
 }

--- a/server/package.json
+++ b/server/package.json
@@ -52,5 +52,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.7.1"
+  "version": "0.7.2"
 }


### PR DESCRIPTION
0.7.2 is a security-themed patch. Nine tickets total — the audit-driven security fixes plus the operator-script polish that piggybacked on it.

## Changes

- Root `package.json` bumped to 0.7.2.
- `npm run version:sync` propagated to the three workspaces; lockfile refreshed.
- CHANGELOG: rename `[Unreleased]` → `[0.7.2] - 2026-05-22`, add a fresh empty `[Unreleased]` heading above, and the v0.7.2 compare link in the footer.

## What 0.7.2 ships

From the CHANGELOG's `[0.7.2]` section:

**Fixed**
- Privacy cascade now masks coordinates on `GET /api/v1/galleries/:id` and `/api/v1/photos` — was silently leaking coords through those two routes when `hide_map=1`. (closes #201)
- Login credentials, JWT secrets, and tokens stripped from debug-level logs; only the user ID is logged now. (closes #202)

**Server**
- `helmet` for baseline security headers (HSTS, nosniff, frameguard, Referrer-Policy, Permissions-Policy; CSP off pending bundle audit). (closes #204)
- Rate-limit `POST /api/v1/tokens` to 10 attempts per IP per 15 minutes. (closes #203)
- Drop the open `cors()` middleware — none of the documented deploy patterns need cross-origin API access. (closes #205)
- Tighten token-secret reload from 60s → 5s so `bin/user.ts passwd` rotations take effect quickly. (closes #206)

**Operator scripts**
- `user.ts passwd <id> [password]` prompts with no echo when the positional is omitted — avoids leaking the password into shell history and `ps`. (closes #200)
- `bin/instance.ts` infers the instance from cwd, reads the logical name from `.env`'s `INSTANCE_NAME` (falls back to dir basename), and migrated to yargs for `--help` consistency. (closes #198)
- Upgrade flow now recommends `pm2 delete && start-prod.sh` instead of `pm2 restart` — restart preserves cached metadata and silently kept the old code running. (closes #199)

## Test plan

- [x] `npm run typecheck --workspaces` — clean
- [x] `npm run lint --workspaces` — clean
- [x] `npm test --workspaces` — 945/945 (601 server + 344 frontend)
- [x] Smoke: `bin/instance.ts smoke --base /tmp/...` reports `Code root: ... (v0.7.2)`
- [x] **VM smoke**: pull on prod, follow the upgrade flow (`pm2 delete` + `start-prod.sh`), confirm `pm2 list` shows v0.7.2 and the new headers fire (`curl -I https://...` → see HSTS, nosniff, etc.).

After this merges: tag `v0.7.2`, publish the GitHub release pointing at the CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)