### PR TITLE
Login rate-limit: skip successful requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Login rate-limit now skips successful requests — only failed login attempts count toward the per-IP limit, so a typo'ing operator who then gets it right isn't throttled (only sustained guessing is). The per-IP keying still needs nginx to forward `X-Forwarded-For` for it to actually distinguish clients (already in the README's recommended nginx block).
+
 ## [0.7.2] - 2026-05-22
 
 ### Fixed

--- a/server/controllers/tokens-v1.ts
+++ b/server/controllers/tokens-v1.ts
@@ -15,13 +15,17 @@ const init = async () => {
 const router = express.Router();
 
 // Per-IP throttle for the login POST. The GET keep-alive and DELETE logout
-// paths aren't rate-limited (they're routine app traffic). 10 attempts per
-// 15-minute window is loose enough not to bother a typo'ing operator and
-// tight enough that brute-force needs a botnet rather than a single IP.
+// paths aren't rate-limited (they're routine app traffic). 10 *failed*
+// attempts per 15-minute window: `skipSuccessfulRequests: true` means a
+// successful login doesn't tick the counter, so a typo'ing operator who then
+// gets it right isn't penalised — only sustained guessing is. Per-IP only;
+// keys off `req.ip`, which requires nginx to forward `X-Forwarded-For` (the
+// README's nginx section shows the headers).
 const loginLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 10,
-  message: { error: "Too many login attempts. Try again later." },
+  skipSuccessfulRequests: true,
+  message: { error: "Too many failed login attempts. Try again later." },
   standardHeaders: true,
   legacyHeaders: false,
 });


### PR DESCRIPTION
Tiny follow-up to #209 (the 0.7.2 security middleware). The audit-landed rate-limiter counted every attempt — including the successful one a typo'ing operator finally lands — which is unnecessarily heavy-handed.

`express-rate-limit` ships `skipSuccessfulRequests: true` exactly for this: when the response status is < 400 the request doesn't tick the counter, so the limit only kicks in for sustained guessing. Toggle one config field.

```ts
const loginLimiter = rateLimit({
  windowMs: 15 * 60 * 1000,
  max: 10,
  skipSuccessfulRequests: true,   // ← added
  message: { error: "Too many failed login attempts. Try again later." },
  standardHeaders: true,
  legacyHeaders: false,
});
```

## On the "doesn't distinguish IPs" half of the report

That's separate: per-IP keying needs nginx to forward `X-Forwarded-For` to the server, otherwise every request keys off `127.0.0.1` and looks like the same client. The README's recommended nginx block already includes the headers:

```nginx
proxy_set_header X-Real-IP         $remote_addr;
proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
proxy_set_header X-Forwarded-Proto $scheme;
```

If the live config doesn't have them, no server-side fix can rescue it — `req.ip` literally has no other source of truth. Worth re-checking your nginx config; this is the same gap I flagged when you shared it earlier.

## Test plan

- [x] `npm run typecheck --workspace=server` — clean
- [x] `npm run lint --workspace=server` — clean
- [x] `npm test --workspace=server` — 606/606 (suite doesn't exercise the rate-limit window directly)
- [ ] **Live smoke**: 5 wrong passwords in a row → 6th attempt 429. 1 wrong + 1 correct + 5 more wrong → 7th attempt 429 (not the 6th).

🤖 Generated with [Claude Code](https://claude.com/claude-code)