### PR TITLE
Request logger: timestamp + client IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Login rate-limit now skips successful requests — only failed login attempts count toward the per-IP limit, so a typo'ing operator who then gets it right isn't throttled (only sustained guessing is). The per-IP keying still needs nginx to forward `X-Forwarded-For` for it to actually distinguish clients (already in the README's recommended nginx block).
 
+### Server
+
+- Request logger now prepends a local-time timestamp (`[YYYY-MM-DD HH:MM:SS.mmm]`, matching lib/logger.ts so request lines interleave cleanly with the rest of the log) and includes the client IP (`:remote-addr`, resolved through `req.ip` so trust-proxy unwrapping applies) — also makes it visible which address the per-IP rate-limiter is keying off; an operator seeing `127.0.0.1` on every line knows the nginx vhost is missing `proxy_set_header X-Forwarded-For …`.
+
 ## [0.7.2] - 2026-05-22
 
 ### Fixed

--- a/server/lib/middleware/request-logger.ts
+++ b/server/lib/middleware/request-logger.ts
@@ -4,6 +4,25 @@ import morgan from "morgan";
 
 morgan.token<Request>("userId", (request) => request.user?.id ?? "");
 
+// `:localtime` matches the format used by lib/logger.ts ([YYYY-MM-DD
+// HH:MM:SS.mmm] in local time) so request lines interleave cleanly with the
+// rest of the log file. morgan's built-in `:date[iso]` would work but uses
+// UTC, which is annoying to correlate against the logger's local-time lines.
+morgan.token("localtime", () => {
+  const d = new Date();
+  const pad = (n: number, w = 2) => String(n).padStart(w, "0");
+  return (
+    `${pad(d.getFullYear(), 4)}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
+    `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`
+  );
+});
+
+// `:remote-addr` resolves through `req.ip`, which respects `trust proxy`.
+// When nginx is in front and forwards `X-Forwarded-For`, this is the real
+// client IP; otherwise it falls back to the socket address (127.0.0.1 in
+// the typical reverse-proxy case). Also tells operators what address the
+// per-IP rate-limiter is keying off — if every line shows 127.0.0.1,
+// the nginx vhost is missing the `proxy_set_header X-Forwarded-For …` line.
 export default morgan(
-  ":method :url :status :res[content-length] - :response-time ms :userId"
+  "[:localtime] :remote-addr :method :url :status :res[content-length] - :response-time ms :userId"
 );


### PR DESCRIPTION
Tiny follow-up to the rate-limit work in #209 / #213. Two morgan format changes:

- `[:localtime]` prefix using a custom token that mimics `lib/logger.ts`'s format (`[YYYY-MM-DD HH:MM:SS.mmm]` in local time). morgan's built-in `:date[iso]` uses UTC, which is annoying to correlate against the logger's local-time lines. Now both interleave cleanly:

  ```
  [2026-05-22 13:21:58.912] INFO: Server running on port 4200
  [2026-05-22 13:22:01.208] ::1 GET /api/v1/galleries 200 117 - 1.120 ms :guest
  ```

- `:remote-addr` for the client IP. With `app.set("trust proxy", 1)` (in place since #209), that token resolves through `req.ip` — so the logged value is the real client IP when nginx forwards `X-Forwarded-For`, and the socket address otherwise.

## Why the IP is useful (beyond the obvious)

1. **Visibility into rate-limiter keying.** The per-IP login rate-limit (#203 / #213) is only as good as the IP we see. If every log line shows `127.0.0.1`, the operator knows their nginx vhost is missing `proxy_set_header X-Forwarded-For …` — without this column, that misconfig would silently make the rate-limiter useless with no visible signal.
2. **Triage.** Correlating events ("when did this 403 happen, and from where") works better with a per-line IP than cross-referencing nginx's access log.

## Test plan

- [x] `npm run typecheck --workspace=server` — clean
- [x] `npm run lint --workspace=server` — clean
- [x] `npm test --workspace=server` — 606/606 (request-logger is `/* istanbul ignore file */` so no test coverage delta)
- [x] Local smoke: started the server, ran `curl http://localhost:4200/api/v1/galleries` (logged `::1` with timestamp) and `curl -H "X-Forwarded-For: 203.0.113.42" http://localhost:4200/api/v1/galleries` (logged `203.0.113.42`). Trust-proxy unwrapping verified. Timestamp format matches the surrounding pino-style log lines.
- [x] **Live smoke**: pull on prod, hit the API from a non-host IP, confirm pm2 log shows the real client IP. If it still shows `127.0.0.1`, the nginx vhost needs the `proxy_set_header X-Forwarded-For` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)