### PR TITLE
Prepare for v0.7.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-05-22
+
 ### Fixed
 
 - Login rate-limit now skips successful requests — only failed login attempts count toward the per-IP limit, so a typo'ing operator who then gets it right isn't throttled (only sustained guessing is). The per-IP keying still needs nginx to forward `X-Forwarded-For` for it to actually distinguish clients (already in the README's recommended nginx block).
@@ -242,7 +244,8 @@
 
 ## Initial commit - 2020-07-04
 
-[Unreleased]: https://github.com/vlumi/photo-diary/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/vlumi/photo-diary/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/vlumi/photo-diary/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/vlumi/photo-diary/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/vlumi/photo-diary/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/vlumi/photo-diary/compare/v0.6.0...v0.7.0

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.7.2
+V=0.7.3
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -106,7 +106,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.7.2/bin/instance.ts dailybw
+/opt/photo-diary/0.7.3/bin/instance.ts dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The script can be invoked from any working directory; the instance dir is derived from the name (and the `--base <dir>` flag, default `/var/photo-diary`, if you want instances under a different parent). Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).

--- a/converter/package.json
+++ b/converter/package.json
@@ -34,5 +34,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4"
   },
-  "version": "0.7.2"
+  "version": "0.7.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -19,7 +19,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -11319,7 +11319,7 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -11639,7 +11639,7 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -57,5 +57,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.7.2"
+  "version": "0.7.3"
 }

--- a/server/package.json
+++ b/server/package.json
@@ -52,5 +52,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.7.2"
+  "version": "0.7.3"
 }


### PR DESCRIPTION
Quick patch with two operator-relevant follow-ups to the 0.7.2 security work.

## Changes

- Root `package.json` bumped to 0.7.3.
- `npm run version:sync` propagated to the three workspaces; lockfile refreshed.
- CHANGELOG sliced (`[Unreleased]` → `[0.7.3] - 2026-05-22`, fresh empty `[Unreleased]` above, v0.7.3 compare link).
- README install-command example bumped to `V=0.7.3` (bundled here rather than chasing it as a follow-up like 0.7.1/0.7.2).

## What 0.7.3 ships

From the `[0.7.3]` section:

**Fixed**
- Login rate-limit now skips successful requests — only failed attempts count toward the per-IP limit, so a typo'ing operator who then gets it right isn't throttled. (#213)

**Server**
- Request logger prepends `[YYYY-MM-DD HH:MM:SS.mmm]` local-time timestamp (matching `lib/logger.ts`) and includes the client IP via `:remote-addr`. Operators can see at a glance which IP the rate-limiter is keying off — `127.0.0.1` on every line means nginx is missing `proxy_set_header X-Forwarded-For`. (#214)

## Test plan

- [x] `npm run typecheck --workspaces` — clean
- [x] `npm run lint --workspaces` — clean
- [x] `npm test --workspaces` — 945/945
- [x] Smoke: `bin/instance.ts smoke --base /tmp/...` reports `Code root: ... (v0.7.3)`.
- [ ] **VM smoke**: pull on prod, restart pm2 (via the `pm2 delete && start-prod.sh` flow), confirm log lines start with `[timestamp] <real-IP>` and that the right IP shows up after a request from a non-host address.

After merge: tag `v0.7.3` and publish the release pointing at the CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)