### PR TITLE
Loosen Referrer-Policy so OSM tiles load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenStreetMap tile fetches were blocked with 403 (`osm.wiki/Blocked`) after 0.7.2 added helmet — its default `Referrer-Policy: no-referrer` stripped the `Referer` header on every outbound request, which OSM's volunteer-run tile servers reject as bot traffic. Overridden to `strict-origin-when-cross-origin` (modern browser default) so the browser sends just the origin on cross-origin requests, satisfying OSM without leaking the full URL.
+
 ## [0.7.3] - 2026-05-22
 
 ### Fixed

--- a/server/app.ts
+++ b/server/app.ts
@@ -25,7 +25,21 @@ app.set("trust proxy", 1);
 // DENY, Referrer-Policy, Permissions-Policy, …). CSP is left off — the
 // default policy would break the bundle's inline styles / dynamic imports
 // and warrants its own audit before being enabled.
-app.use(helmet({ contentSecurityPolicy: false }));
+//
+// `Referrer-Policy` overridden from helmet's default `no-referrer` to
+// `strict-origin-when-cross-origin` (modern browser default since 2020):
+// the no-referrer default strips the `Referer` header on every outbound
+// request, which breaks the leaflet map widget — OSM's volunteer-run tile
+// servers reject referrer-less requests as bot traffic (osm.wiki/Blocked).
+// `strict-origin-when-cross-origin` sends just the origin
+// (https://gallery.example.com) on cross-origin HTTPS requests, satisfying
+// OSM's check without leaking the full request URL.
+app.use(
+  helmet({
+    contentSecurityPolicy: false,
+    referrerPolicy: { policy: "strict-origin-when-cross-origin" },
+  })
+);
 app.use(compression());
 app.use(express.json());
 // Discourage indexing and AI scraping on every response. robots.txt is the


### PR DESCRIPTION
Regression from the helmet middleware in 0.7.2 (#209). helmet's default `Referrer-Policy: no-referrer` strips the `Referer` header on every outbound request the browser makes. The leaflet map widget loads tiles from OSM's volunteer-run tile servers (`tile.openstreetmap.org`), which now reject referrer-less requests as bot traffic and return 403 with `osm.wiki/Blocked` — so the map widget has been broken on every deploy that upgraded to 0.7.2+.

## Fix

Override the policy to `strict-origin-when-cross-origin`, which has been the **modern browser default since 2020**:

```ts
app.use(
  helmet({
    contentSecurityPolicy: false,
    referrerPolicy: { policy: "strict-origin-when-cross-origin" },
  })
);
```

The browser now sends just the origin (`https://gallery.example.com`) on cross-origin HTTPS requests — satisfies OSM's check without leaking the full request URL. Same-origin requests still get the full URL; http→https downgrades still drop it entirely.

## Test plan

- [x] `npm run typecheck --workspace=server` — clean
- [x] `npm run lint --workspace=server` — clean
- [x] `npm test --workspace=server` — 606/606
- [x] Local smoke: `curl -I http://localhost:4200/api/v1/galleries` returns `Referrer-Policy: strict-origin-when-cross-origin`.
- [ ] **VM smoke**: pull on prod, restart pm2, reload a gallery with map photos in the browser — tiles should load instead of showing the 403/blocked overlay.

## Should-have-caught

The 0.7.2 security audit was pure backend review; browser-side fetches the bundle makes (map tiles, any other third-party resource) weren't exercised. Worth noting for future audits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)