### PR TITLE
Prepare for v0.7.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-05-22
+
 ### Fixed
 
 - OpenStreetMap tile fetches were blocked with 403 (`osm.wiki/Blocked`) after 0.7.2 added helmet — its default `Referrer-Policy: no-referrer` stripped the `Referer` header on every outbound request, which OSM's volunteer-run tile servers reject as bot traffic. Overridden to `strict-origin-when-cross-origin` (modern browser default) so the browser sends just the origin on cross-origin requests, satisfying OSM without leaking the full URL.
@@ -248,7 +250,8 @@
 
 ## Initial commit - 2020-07-04
 
-[Unreleased]: https://github.com/vlumi/photo-diary/compare/v0.7.3...HEAD
+[Unreleased]: https://github.com/vlumi/photo-diary/compare/v0.7.4...HEAD
+[0.7.4]: https://github.com/vlumi/photo-diary/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/vlumi/photo-diary/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/vlumi/photo-diary/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/vlumi/photo-diary/compare/v0.7.0...v0.7.1

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.7.3
+V=0.7.4
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -106,7 +106,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.7.3/bin/instance.ts dailybw
+/opt/photo-diary/0.7.4/bin/instance.ts dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The script can be invoked from any working directory; the instance dir is derived from the name (and the `--base <dir>` flag, default `/var/photo-diary`, if you want instances under a different parent). Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).

--- a/converter/package.json
+++ b/converter/package.json
@@ -34,5 +34,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4"
   },
-  "version": "0.7.3"
+  "version": "0.7.4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -19,7 +19,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -11319,7 +11319,7 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -11639,7 +11639,7 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -57,5 +57,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.7.3"
+  "version": "0.7.4"
 }

--- a/server/package.json
+++ b/server/package.json
@@ -52,5 +52,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.7.3"
+  "version": "0.7.4"
 }


### PR DESCRIPTION
Quick patch to ship the OSM tile fix (#216). Map widget was broken on every 0.7.2+ deploy from helmet's `no-referrer` default; OSM's volunteer tile servers reject referrer-less requests.

## Changes

- Root `package.json` bumped to 0.7.4.
- `npm run version:sync` propagated to the three workspaces; lockfile refreshed.
- CHANGELOG sliced (`[Unreleased]` → `[0.7.4] - 2026-05-22`).
- README install-command bumped.

## What 0.7.4 ships

**Fixed**
- OpenStreetMap tile fetches were blocked with 403 (`osm.wiki/Blocked`) after 0.7.2 added helmet — its default `Referrer-Policy: no-referrer` stripped the `Referer` header. Overridden to `strict-origin-when-cross-origin` (modern browser default since 2020). (#216)

## Sibling work

Filed #217 on 1.0 for a full **frontend / browser-side security audit** — the 0.7.2 audit was backend-only, and the OSM regression is the canonical example of what got missed. Worth doing once before stable.

## Test plan

- [x] `npm run typecheck --workspaces` — clean
- [x] `npm run lint --workspaces` — clean
- [x] `npm test --workspaces` — 945/945
- [x] Smoke: `bin/instance.ts smoke --base /tmp/...` reports `v0.7.4`.
- [ ] **VM smoke**: pull on prod, restart pm2, reload a gallery with map photos — tiles should load.

After merge: tag `v0.7.4`, publish release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)