### PR TITLE
Typed AppError hierarchy (first migration slice for #219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Server
+
+- Introduce a typed `AppError` class hierarchy (`AccessError`, `NotFoundError`, `LoginError`, `InvalidTokenError`, `NotImplementedError`, `UnavailableError`) in `server/lib/errors.ts`, each carrying its HTTP status. Error-handler middleware now recognises both `instanceof AppError` and the legacy `CONST.ERROR_*` string constants so the rest of the codebase can migrate incrementally. First two consumers migrated: `lib/authorizer.ts` and `lib/middleware/token-filter.ts`. Wire-shape unchanged. (in progress — #219)
+
 ## [0.7.4] - 2026-05-22
 
 ### Fixed

--- a/server/lib/authorizer.ts
+++ b/server/lib/authorizer.ts
@@ -1,4 +1,5 @@
 import CONST from "./constants.js";
+import { AccessError } from "./errors.js";
 import db from "../db/index.js";
 
 export default () => {
@@ -14,7 +15,7 @@ export default () => {
 // access level under the user-first cascade (see `resolveAccessLevel` in
 // db/sqlite3/index.ts), compare to the required threshold, throw on miss.
 // Catch-all so any underlying error (DB miss, etc.) reads as a uniform
-// ERROR_ACCESS to callers rather than leaking driver-specific failures.
+// AccessError to callers rather than leaking driver-specific failures.
 
 const requireLevel = async (
   userId: string,
@@ -24,10 +25,11 @@ const requireLevel = async (
   try {
     const level = await db.resolveAccessLevel(userId, galleryId);
     if (level === undefined || level < required) {
-      throw CONST.ERROR_ACCESS;
+      throw new AccessError(undefined, { userId, galleryId, required });
     }
-  } catch {
-    throw CONST.ERROR_ACCESS;
+  } catch (e) {
+    if (e instanceof AccessError) throw e;
+    throw new AccessError(undefined, { userId, galleryId, required });
   }
 };
 

--- a/server/lib/errors.ts
+++ b/server/lib/errors.ts
@@ -1,0 +1,72 @@
+/**
+ * Typed Error hierarchy for the server. Replaces the string-constant style
+ * (`throw CONST.ERROR_ACCESS`) with `instanceof`-checkable subclasses, each
+ * carrying its HTTP status as a class property and an optional context
+ * payload for diagnostics.
+ *
+ * Migration is incremental — the error-handler middleware understands both
+ * forms during the transition; `CONST.ERROR_*` strings stay aliased to the
+ * same `.message` text so they keep mapping to the same HTTP status. The
+ * preferred form for new code is `throw new <SpecificError>(message?, ctx?)`.
+ *
+ * Usage:
+ *   throw new NotFoundError();
+ *   throw new NotFoundError(`Gallery "${id}" not found`);
+ *   throw new AccessError("Admin required on this gallery", { galleryId });
+ */
+
+export class AppError extends Error {
+  status: number = 500;
+  constructor(
+    message?: string,
+    public context?: Record<string, unknown>
+  ) {
+    super(message ?? "Internal server error");
+    this.name = this.constructor.name;
+  }
+}
+
+export class NotFoundError extends AppError {
+  override status = 404;
+  constructor(message = "Not found", context?: Record<string, unknown>) {
+    super(message, context);
+  }
+}
+
+export class LoginError extends AppError {
+  override status = 401;
+  constructor(message = "Login failed", context?: Record<string, unknown>) {
+    super(message, context);
+  }
+}
+
+export class InvalidTokenError extends AppError {
+  override status = 401;
+  constructor(message = "Invalid token", context?: Record<string, unknown>) {
+    super(message, context);
+  }
+}
+
+export class AccessError extends AppError {
+  override status = 403;
+  constructor(message = "Access denied", context?: Record<string, unknown>) {
+    super(message, context);
+  }
+}
+
+export class NotImplementedError extends AppError {
+  override status = 501;
+  constructor(message = "Not implemented", context?: Record<string, unknown>) {
+    super(message, context);
+  }
+}
+
+export class UnavailableError extends AppError {
+  override status = 503;
+  constructor(
+    message = "Service not available",
+    context?: Record<string, unknown>
+  ) {
+    super(message, context);
+  }
+}

--- a/server/lib/middleware/error-handler.ts
+++ b/server/lib/middleware/error-handler.ts
@@ -2,10 +2,27 @@ import type { ErrorRequestHandler } from "express";
 import * as HttpStatus from "http-status-codes";
 
 import CONST from "../constants.js";
+import { AppError } from "../errors.js";
 import logger from "../logger.js";
 
+// Two error shapes co-exist during the typed-Error migration (#219):
+//
+// 1. `AppError` subclasses with a `.status` property. Preferred for new code
+//    and the migration target.
+// 2. Legacy `CONST.ERROR_*` string constants. Still works via the switch
+//    below — kept for the duration of the migration so a partial rollout
+//    doesn't break anything.
+//
+// New-style errors get their `.message` echoed as the response payload; old
+// string-style throws echo the string as-is. The wire shape stays the same.
 const errorHandler: ErrorRequestHandler = (error, _request, response, _next) => {
   logger.debug(error);
+
+  if (error instanceof AppError) {
+    response.status(error.status).send({ error: error.message });
+    return;
+  }
+
   switch (error) {
     case CONST.ERROR_NOT_FOUND:
       response.status(HttpStatus.NOT_FOUND).send({ error });

--- a/server/lib/middleware/token-filter.ts
+++ b/server/lib/middleware/token-filter.ts
@@ -1,6 +1,7 @@
 import type { Request, RequestHandler } from "express";
 
 import CONST from "../constants.js";
+import { InvalidTokenError } from "../errors.js";
 import tokenFactory from "../../models/token.js";
 import logger from "../logger.js";
 
@@ -41,7 +42,7 @@ const tokenFilter: RequestHandler = (request, _response, next) => {
     })
     .catch((error) => {
       logger.debug("Token verification failed", error);
-      next(CONST.ERROR_INVALID_TOKEN);
+      next(new InvalidTokenError());
     });
 };
 

--- a/server/tests/lib/authorizer.test.ts
+++ b/server/tests/lib/authorizer.test.ts
@@ -1,5 +1,6 @@
 import CONST from "../../lib/constants.js";
 import authorizerFactory from "../../lib/authorizer.js";
+import { AccessError } from "../../lib/errors.js";
 import dbOriginal from "../../db/index.js";
 
 vi.mock("../../db/index.js", () => ({
@@ -23,7 +24,7 @@ type Authorize = (user: string, gallery?: any) => Promise<unknown>;
 const fail = (authorize: Authorize, user: string, gallery?: string) => {
   expect.assertions(1);
   return authorize(user, gallery).catch((e) =>
-    expect(e).toBe(CONST.ERROR_ACCESS)
+    expect(e).toBeInstanceOf(AccessError)
   );
 };
 


### PR DESCRIPTION
First slice of #219. Adds the typed-Error infrastructure + teaches the error-handler middleware to recognise both forms; migrates the two smallest consumers (authorizer + token-filter) to demonstrate the pattern. The rest of the codebase keeps working unchanged through the legacy `CONST.ERROR_*` string-constant path.

Migrating in slices was specifically called out in the ticket — partial rollouts shouldn't break anything, and each follow-up PR stays small.

## What's in it

- **New** [`server/lib/errors.ts`](server/lib/errors.ts) with `AppError extends Error` plus subclasses:
  - `NotFoundError` (404)
  - `LoginError` (401)
  - `InvalidTokenError` (401)
  - `AccessError` (403)
  - `NotImplementedError` (501)
  - `UnavailableError` (503)

  Each subclass's default message matches the old string constant exactly, so the JSON response stays byte-identical when a throw site flips. Constructor takes optional `(message?, context?)` — context is a plain object stashed for diagnostics, not exposed in the wire response.

- **Updated** [`server/lib/middleware/error-handler.ts`](server/lib/middleware/error-handler.ts) — checks `instanceof AppError` first (uses `.status` + `.message`), falls back to the existing `CONST.ERROR_*` switch for not-yet-migrated callers.

- **Migrated** to typed errors:
  - [`server/lib/authorizer.ts`](server/lib/authorizer.ts) — `requireLevel` now throws `new AccessError(undefined, { userId, galleryId, required })`. Context attaches the lookup info for debugging without changing the response shape.
  - [`server/lib/middleware/token-filter.ts`](server/lib/middleware/token-filter.ts) — single `next(CONST.ERROR_INVALID_TOKEN)` becomes `next(new InvalidTokenError())`.

## Verified

- `npm run typecheck --workspace=server` — clean
- `npm run lint --workspace=server` — clean
- `npm test --workspace=server` — 606/606 (one test updated from `toBe(CONST.ERROR_ACCESS)` to `toBeInstanceOf(AccessError)`)
- Local smoke against the dummy driver:
  - Bad token → `{"error":"Invalid token"}` + 401 ✓
  - Blocked user → `{"error":"Access denied"}` + 403 ✓
  - Byte-identical to pre-migration

## Remaining

52 throw sites across 11 files. Follow-up PRs, one file or small cluster at a time:

- `server/controllers/tokens-v1.ts`
- `server/models/{token,meta,photo,gallery,user}.ts`
- `server/db/{sqlite3/index,sqlite3/schema,dummy}.ts`
- `server/lib/middleware/fallback-route.ts`

Each will be small. The `CONST.ERROR_*` aliases stay until the last throw site flips, then they get retired in a final cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)