### PR TITLE
Typed errors slice 2: server/models/*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Server
 
-- Introduce a typed `AppError` class hierarchy (`AccessError`, `NotFoundError`, `LoginError`, `InvalidTokenError`, `NotImplementedError`, `UnavailableError`) in `server/lib/errors.ts`, each carrying its HTTP status. Error-handler middleware now recognises both `instanceof AppError` and the legacy `CONST.ERROR_*` string constants so the rest of the codebase can migrate incrementally. First two consumers migrated: `lib/authorizer.ts` and `lib/middleware/token-filter.ts`. Wire-shape unchanged. (in progress — #219)
+- Introduce a typed `AppError` class hierarchy (`AccessError`, `NotFoundError`, `LoginError`, `InvalidTokenError`, `NotImplementedError`, `UnavailableError`) in `server/lib/errors.ts`, each carrying its HTTP status. Error-handler middleware now recognises both `instanceof AppError` and the legacy `CONST.ERROR_*` string constants so the rest of the codebase can migrate incrementally. Migrated consumers so far: `lib/authorizer.ts`, `lib/middleware/token-filter.ts`, and the five `models/*.ts` files (token + the four mutation-stub models). Wire-shape unchanged. (in progress — #219)
 
 ## [0.7.4] - 2026-05-22
 

--- a/server/models/gallery.ts
+++ b/server/models/gallery.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import CONST from "../lib/constants.js";
+import { NotImplementedError } from "../lib/errors.js";
 import logger from "../lib/logger.js";
 import db from "../db/index.js";
 
@@ -23,7 +24,7 @@ const getGalleries = async () => {
 };
 const createGallery = async (gallery: Record<string, any>) => {
   logger.debug("Creating gallery", gallery);
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const getGallery = async (galleryId: string) => {
   logger.debug("Getting gallery", galleryId);
@@ -46,9 +47,9 @@ const getGallery = async (galleryId: string) => {
 };
 const updateGallery = async (gallery: Record<string, any>) => {
   logger.debug("Updating gallery", gallery);
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const deleteGallery = async (galleryId: string) => {
   logger.debug("Deleting gallery", galleryId);
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };

--- a/server/models/meta.ts
+++ b/server/models/meta.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import CONST from "../lib/constants.js";
+import { NotImplementedError } from "../lib/errors.js";
 import logger from "../lib/logger.js";
 import db from "../db/index.js";
 
@@ -24,13 +24,13 @@ const getMeta = async (key: string) => {
 };
 const createMeta = async (meta: Record<string, any>) => {
   logger.debug("Creating meta", meta);
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const updateMeta = async (meta: Record<string, any>) => {
   logger.debug("Updating meta", meta);
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const deleteMeta = async (key: string) => {
   logger.debug("Deleting meta", key);
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };

--- a/server/models/photo.ts
+++ b/server/models/photo.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import CONST from "../lib/constants.js";
+import { NotImplementedError } from "../lib/errors.js";
 import logger from "../lib/logger.js";
 import db from "../db/index.js";
 
@@ -23,7 +23,7 @@ const getPhotos = async () => {
 
 const createPhoto = async (photo: Record<string, any>) => {
   logger.debug("Creating photo", photo);
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 
 const getPhoto = async (photoId: string) => {
@@ -33,10 +33,10 @@ const getPhoto = async (photoId: string) => {
 
 const updatePhoto = async (photo: Record<string, any>) => {
   logger.debug("Updating photo", photo);
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 
 const deletePhoto = async (photoId: string) => {
   logger.debug("Deleting photo", photoId);
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };

--- a/server/models/token.ts
+++ b/server/models/token.ts
@@ -1,8 +1,8 @@
 import { SignJWT, jwtVerify, decodeJwt } from "jose";
 import bcrypt from "bcrypt";
 
-import CONST from "../lib/constants.js";
 import config from "../lib/config/index.js";
+import { LoginError, NotImplementedError } from "../lib/errors.js";
 import logger from "../lib/logger.js";
 import db from "../db/index.js";
 
@@ -43,7 +43,7 @@ type Credentials = { id: string; password: string };
 type StoredUser = { id: string; password: string; secret: string };
 
 const revokeToken = async (_userId: string): Promise<void> => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 
 export default () => {
@@ -65,7 +65,7 @@ const checkUserPassword = async (
     bcrypt.compare(credentials.password, user.password, (error, result) => {
       if (error || !result) {
         logger.debug(`Invalid password for "${credentials.id}"`);
-        reject(CONST.ERROR_LOGIN);
+        reject(new LoginError());
       }
       logger.debug(`Password check succeeded for "${credentials.id}"`);
       resolve();
@@ -88,7 +88,7 @@ const authenticateUser = async (credentials: Credentials): Promise<void> => {
     // Make sure the secret is up-to-date
     secrets[user.id] = user.secret;
   } catch {
-    throw CONST.ERROR_LOGIN;
+    throw new LoginError();
   }
 };
 const verifyToken = async (token: string) => {
@@ -100,7 +100,7 @@ const verifyToken = async (token: string) => {
     encodeSecret(getSecret(decoded.id))
   );
   if (!payload || payload.id !== decoded.id) {
-    throw CONST.ERROR_LOGIN;
+    throw new LoginError();
   }
   return payload as { id: string; isAdmin?: boolean };
 };

--- a/server/models/user.ts
+++ b/server/models/user.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import CONST from "../lib/constants.js";
+import { NotImplementedError } from "../lib/errors.js";
 import logger from "../lib/logger.js";
 import db from "../db/index.js";
 
@@ -24,13 +24,13 @@ const getUser = async (id: string) => {
 };
 const createUser = async (user: Record<string, any>) => {
   logger.debug("Creating user", user);
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const updateUser = async (user: Record<string, any>) => {
   logger.debug("Updating user", user);
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const deleteUser = async (id: string) => {
   logger.debug("Deleting user", id);
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };


### PR DESCRIPTION
Second slice of #219. Migrates the 16 throw sites in the model layer from `CONST.ERROR_*` strings to the typed `AppError` subclasses introduced in #224. The legacy strings remain in place for the still-unmigrated db / dummy / controllers / fallback-route call sites; the error-handler keeps recognising both shapes.

## What's in it

| File | Sites | Subclasses used |
| --- | --- | --- |
| `models/token.ts` | 4 | `NotImplementedError` (revokeToken), `LoginError` × 3 (bcrypt mismatch, authenticateUser catch, verifyToken's payload-id mismatch) |
| `models/meta.ts` | 3 | `NotImplementedError` × 3 (create/update/delete mutation stubs) |
| `models/photo.ts` | 3 | `NotImplementedError` × 3 (create/update/delete mutation stubs) |
| `models/user.ts` | 3 | `NotImplementedError` × 3 (create/update/delete mutation stubs) |
| `models/gallery.ts` | 3 | `NotImplementedError` × 3 (create/update/delete mutation stubs) |

`CONST` import dropped in `meta.ts`, `photo.ts`, `user.ts`, `token.ts` (no other uses). Kept in `gallery.ts` because the read paths still need `CONST.SPECIAL_GALLERIES` / `CONST.SPECIAL_GALLERY_PREFIX`.

## Verified

- `npm run typecheck --workspace=server` — clean
- `npm run lint --workspace=server` — clean
- `npm test --workspace=server` — 606/606
- `grep -c ERROR_ server/models/*.ts` — 0 across all model files

## Remaining

After this lands, ~36 throw sites remaining across:

- `server/db/sqlite3/index.ts`, `server/db/sqlite3/schema.ts`, `server/db/dummy.ts`
- `server/controllers/tokens-v1.ts`
- `server/lib/middleware/fallback-route.ts`

Plus a final cleanup PR to retire the `CONST.ERROR_*` aliases once nothing references them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)