### PR TITLE
Typed errors slice 3: server/db/*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Server
 
-- Introduce a typed `AppError` class hierarchy (`AccessError`, `NotFoundError`, `LoginError`, `InvalidTokenError`, `NotImplementedError`, `UnavailableError`) in `server/lib/errors.ts`, each carrying its HTTP status. Error-handler middleware now recognises both `instanceof AppError` and the legacy `CONST.ERROR_*` string constants so the rest of the codebase can migrate incrementally. Migrated consumers so far: `lib/authorizer.ts`, `lib/middleware/token-filter.ts`, and the five `models/*.ts` files (token + the four mutation-stub models). Wire-shape unchanged. (in progress — #219)
+- Introduce a typed `AppError` class hierarchy (`AccessError`, `NotFoundError`, `LoginError`, `InvalidTokenError`, `NotImplementedError`, `UnavailableError`) in `server/lib/errors.ts`, each carrying its HTTP status. Error-handler middleware now recognises both `instanceof AppError` and the legacy `CONST.ERROR_*` string constants so the rest of the codebase can migrate incrementally. Migrated consumers so far: `lib/authorizer.ts`, `lib/middleware/token-filter.ts`, the five `models/*.ts` files, and the three db-layer files (`db/sqlite3/index.ts`, `db/sqlite3/schema.ts`, `db/dummy.ts`). Wire-shape unchanged. (in progress — #219)
 
 ## [0.7.4] - 2026-05-22
 

--- a/server/db/dummy.ts
+++ b/server/db/dummy.ts
@@ -2,9 +2,10 @@
 import { randomUUID } from "node:crypto";
 
 import CONST from "../lib/constants.js";
+import { NotFoundError, NotImplementedError } from "../lib/errors.js";
 
 const notImplemented = async (): Promise<never> => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 
 /**
@@ -62,32 +63,32 @@ const loadMetas = async () => {
   return Object.values(db.meta);
 };
 const createMeta = async () => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const loadMeta = async (key: string) => {
   if (!(key in db.meta)) {
-    throw CONST.ERROR_NOT_FOUND;
+    throw new NotFoundError();
   }
   return db.meta[key];
 };
 const updateMeta = async () => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 
 const loadUsers = async () => {
   return Object.values(db.users);
 };
 const createUser = async () => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const loadUser = async (id: string) => {
   if (!(id in db.users)) {
-    throw CONST.ERROR_NOT_FOUND;
+    throw new NotFoundError();
   }
   return db.users[id];
 };
 const updateUser = async () => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 
 const resolveAccessLevel = async (
@@ -114,16 +115,16 @@ const loadGalleries = async () => {
   return Object.values(db.galleries).sort();
 };
 const createGallery = async () => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const loadGallery = async (galleryId: string) => {
   if (!(galleryId in db.galleries)) {
-    throw CONST.ERROR_NOT_FOUND;
+    throw new NotFoundError();
   }
   return db.galleries[galleryId];
 };
 const updateGallery = async () => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 
 const comparePhotos = (a: any, b: any) =>
@@ -147,7 +148,7 @@ const loadGalleryPhotos = async (galleryId: string) => {
     }
     default: {
       if (!(galleryId in db.galleries)) {
-        throw CONST.ERROR_NOT_FOUND;
+        throw new NotFoundError();
       }
       const photos = db.galleryPhotos[galleryId]
         .map((photoId: string) => db.photos[photoId])
@@ -157,7 +158,7 @@ const loadGalleryPhotos = async (galleryId: string) => {
   }
 };
 const linkGalleryPhoto = async () => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const loadGalleryPhoto = async (galleryId: string, photoId: string) => {
   const handleGalleryAll = async () => {
@@ -171,7 +172,7 @@ const loadGalleryPhoto = async (galleryId: string, photoId: string) => {
       .map((id: string) => db.photos[id])
       .sort(comparePhotos);
     if (photos.length === 0) {
-      throw CONST.ERROR_NOT_FOUND;
+      throw new NotFoundError();
     }
     return photos[0];
   };
@@ -183,19 +184,19 @@ const loadGalleryPhoto = async (galleryId: string, photoId: string) => {
       .map((id: string) => db.photos[id])
       .sort(comparePhotos);
     if (photos.length === 0) {
-      throw CONST.ERROR_NOT_FOUND;
+      throw new NotFoundError();
     }
     return photos[0];
   };
   const handleGallery = async () => {
     if (!(galleryId in db.galleries)) {
-      throw CONST.ERROR_NOT_FOUND;
+      throw new NotFoundError();
     }
     const photos = db.galleryPhotos[galleryId]
       .filter((id: string) => id === photoId)
       .map((id: string) => db.photos[id]);
     if (photos.length === 0) {
-      throw CONST.ERROR_NOT_FOUND;
+      throw new NotFoundError();
     }
     return photos[0];
   };
@@ -212,29 +213,29 @@ const loadGalleryPhoto = async (galleryId: string, photoId: string) => {
   }
 };
 const unlinkGalleryPhoto = async () => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const unlinkAllPhotos = async () => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const unlinkAllGalleries = async () => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 
 const loadPhotos = async () => {
   return db.photos;
 };
 const createPhoto = async () => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 const loadPhoto = async (photoId: string) => {
   if (!(photoId in db.photos)) {
-    throw CONST.ERROR_NOT_FOUND;
+    throw new NotFoundError();
   }
   return db.photos[photoId];
 };
 const updatePhoto = async () => {
-  throw CONST.ERROR_NOT_IMPLEMENTED;
+  throw new NotImplementedError();
 };
 
 const dbDump = JSON.stringify({

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -1,6 +1,7 @@
 import Database from "better-sqlite3";
 
 import CONST from "../../lib/constants.js";
+import { NotFoundError } from "../../lib/errors.js";
 import config from "../../lib/config/index.js";
 import logger from "../../lib/logger.js";
 import { migrate } from "./migrate.js";
@@ -86,7 +87,7 @@ const loadMeta = async (key: string) => {
   const row = db.prepare(SCHEMA.meta.buildSelectByIdQuery()).get(key) as
     | MetaRow
     | undefined;
-  if (!row) throw CONST.ERROR_NOT_FOUND;
+  if (!row) throw new NotFoundError();
   return SCHEMA.meta.mapRow(row);
 };
 const updateMeta = async (key: string, meta: Partial<MetaRow>) => {
@@ -107,7 +108,7 @@ const loadUser = async (userId: string) => {
   const row = db.prepare(SCHEMA.user.buildSelectByIdQuery()).get(userId) as
     | UserRow
     | undefined;
-  if (!row) throw CONST.ERROR_NOT_FOUND;
+  if (!row) throw new NotFoundError();
   return SCHEMA.user.mapRow(row);
 };
 const updateUser = async (userId: string, user: Partial<User>) => {
@@ -261,7 +262,7 @@ const loadGallery = async (galleryId: string) => {
   const row = db
     .prepare(SCHEMA.gallery.buildSelectByIdQuery())
     .get(galleryId) as GalleryRow | undefined;
-  if (!row) throw CONST.ERROR_NOT_FOUND;
+  if (!row) throw new NotFoundError();
   return SCHEMA.gallery.mapRow(row);
 };
 const updateGallery = async (galleryId: string, gallery: GalleryInput) => {
@@ -345,7 +346,7 @@ const loadGalleryPhoto = async (galleryId: string, photoId: string) => {
     ? stmt.all(photoId)
     : stmt.all(galleryId, photoId)) as PhotoRow[];
   if (rows.length === 0) {
-    throw CONST.ERROR_NOT_FOUND;
+    throw new NotFoundError();
   }
   return schema.mapRow(rows[0], 0);
 };
@@ -379,7 +380,7 @@ const loadPhoto = async (photoId: string) => {
   const row = db.prepare(SCHEMA.photo.buildSelectByIdQuery()).get(photoId) as
     | PhotoRow
     | undefined;
-  if (!row) throw CONST.ERROR_NOT_FOUND;
+  if (!row) throw new NotFoundError();
   return SCHEMA.photo.mapRow(row, 0);
 };
 const updatePhoto = async (photoId: string, photo: PhotoInput) => {

--- a/server/db/sqlite3/schema.ts
+++ b/server/db/sqlite3/schema.ts
@@ -1,4 +1,4 @@
-import CONST from "../../lib/constants.js";
+import { NotImplementedError } from "../../lib/errors.js";
 
 // Raw DB row shapes (one per table). Mirror the SELECT column list exactly.
 export interface MetaRow {
@@ -191,7 +191,7 @@ export default () => {
         row.access_level,
       ],
       mapInsert: (): unknown[] => {
-        throw CONST.ERROR_NOT_IMPLEMENTED;
+        throw new NotImplementedError();
       },
       buildCreateQuery: () => buildCreateQuery(SCHEMA.userGallery),
       buildSelectByIdQuery: () => buildSelectByIdQuery(SCHEMA.userGallery),
@@ -241,7 +241,7 @@ export default () => {
     },
     galleryPhoto: {
       mapRow: (): GalleryPhoto => {
-        throw CONST.ERROR_NOT_IMPLEMENTED;
+        throw new NotImplementedError();
       },
       mapInsert: (link: GalleryPhoto): unknown[] => [link.galleryId, link.photoId],
 


### PR DESCRIPTION
Third slice of #219. Migrates the db-layer throw sites (sqlite3 + dummy drivers + the schema query-builder) from `CONST.ERROR_*` strings to the typed `AppError` subclasses introduced in #224.

## What's in it

| File | Sites | Subclasses used |
| --- | --- | --- |
| `db/sqlite3/index.ts` | 5 | `NotFoundError` × 5 (`loadMeta`, `loadUser`, `loadGallery`, `loadGalleryPhoto`, `loadPhoto`) |
| `db/sqlite3/schema.ts` | 2 | `NotImplementedError` × 2 (the `mapInsert` / `mapRow` placeholders on userGallery + galleryPhoto schemas) |
| `db/dummy.ts` | 23 | `NotImplementedError` × 9 (mutation ops the dummy doesn't model), `NotFoundError` × 14 (id-not-in-fixture paths) |

`CONST` import dropped in `schema.ts` (no other uses). Kept in `sqlite3/index.ts` and `dummy.ts` because both still need `CONST.SPECIAL_GALLERY_*` sentinels for the gallery-id switches.

## Verified

- `npm run typecheck --workspace=server` — clean
- `npm run lint --workspace=server` — clean
- `npm test --workspace=server` — 606/606
- `grep -c ERROR_ server/db/**/*.ts` — 0 across all three files

## Remaining

After this lands, ~5 throw sites remaining:

- `server/controllers/tokens-v1.ts`
- `server/lib/middleware/fallback-route.ts`

Then a final cleanup PR retires the `CONST.ERROR_*` aliases + the dual-path branch in the error-handler middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)