### PR TITLE
Typed errors slice 4 + final cleanup — closes #219

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Server
 
-- Introduce a typed `AppError` class hierarchy (`AccessError`, `NotFoundError`, `LoginError`, `InvalidTokenError`, `NotImplementedError`, `UnavailableError`) in `server/lib/errors.ts`, each carrying its HTTP status. Error-handler middleware now recognises both `instanceof AppError` and the legacy `CONST.ERROR_*` string constants so the rest of the codebase can migrate incrementally. Migrated consumers so far: `lib/authorizer.ts`, `lib/middleware/token-filter.ts`, the five `models/*.ts` files, and the three db-layer files (`db/sqlite3/index.ts`, `db/sqlite3/schema.ts`, `db/dummy.ts`). Wire-shape unchanged. (in progress — #219)
+- Replace string-constant error throws with a typed `AppError` class hierarchy (`AccessError`, `NotFoundError`, `LoginError`, `InvalidTokenError`, `NotImplementedError`, `UnavailableError`) in `server/lib/errors.ts`. Each subclass carries its HTTP status; the error-handler middleware reads `.status` and echoes `.message` as the JSON response. The legacy `CONST.ERROR_*` string constants and the dual-path switch in error-handler.ts are now retired (no remaining throw sites referenced them). Wire-shape unchanged for every existing endpoint. (closes #219)
 
 ## [0.7.4] - 2026-05-22
 

--- a/server/controllers/tokens-v1.ts
+++ b/server/controllers/tokens-v1.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import rateLimit from "express-rate-limit";
 
-import CONST from "../lib/constants.js";
+import { LoginError } from "../lib/errors.js";
 import logger from "../lib/logger.js";
 import authorizerFactory from "../lib/authorizer.js";
 import modelFactory from "../models/token.js";
@@ -48,7 +48,7 @@ router.post("/", loginLimiter, async (request, response, next) => {
     password: request.body.password,
   };
   if (!credentials.id || !credentials.password) {
-    next(CONST.ERROR_LOGIN);
+    next(new LoginError());
     return;
   }
   await model.authenticateUser(credentials);

--- a/server/lib/constants.ts
+++ b/server/lib/constants.ts
@@ -7,13 +7,6 @@ const SESSION_LENGTH_MS = 1000 * 60 * 60 * 24 * 7;
 const API_ROOT = "/api";
 const GUEST_USER = ":guest";
 
-const ERROR_NOT_IMPLEMENTED = "Not implemented";
-const ERROR_NOT_FOUND = "Not found";
-const ERROR_LOGIN = "Login failed";
-const ERROR_INVALID_TOKEN = "Invalid token";
-const ERROR_ACCESS = "Access denied";
-const ERROR_UNAVAILABLE = "Service not available";
-
 const STATS_UNKNOWN = "[unknown]";
 
 const SPECIAL_GALLERY_PREFIX = ":";
@@ -68,13 +61,6 @@ export default {
 
   API_ROOT,
   GUEST_USER,
-
-  ERROR_NOT_IMPLEMENTED,
-  ERROR_NOT_FOUND,
-  ERROR_LOGIN,
-  ERROR_INVALID_TOKEN,
-  ERROR_ACCESS,
-  ERROR_UNAVAILABLE,
 
   STATS_UNKNOWN,
 

--- a/server/lib/errors.ts
+++ b/server/lib/errors.ts
@@ -1,13 +1,13 @@
 /**
- * Typed Error hierarchy for the server. Replaces the string-constant style
- * (`throw CONST.ERROR_ACCESS`) with `instanceof`-checkable subclasses, each
- * carrying its HTTP status as a class property and an optional context
- * payload for diagnostics.
+ * Typed Error hierarchy for the server. Every server-side throw is one of
+ * these subclasses; the error-handler middleware reads `.status` to set the
+ * HTTP response code and echoes `.message` as the JSON `error` field. Each
+ * subclass has a default message that matches the historical
+ * `CONST.ERROR_*` string it replaced, so wire-shape stays stable.
  *
- * Migration is incremental — the error-handler middleware understands both
- * forms during the transition; `CONST.ERROR_*` strings stay aliased to the
- * same `.message` text so they keep mapping to the same HTTP status. The
- * preferred form for new code is `throw new <SpecificError>(message?, ctx?)`.
+ * Constructor takes `(message?, context?)`. The optional context is a plain
+ * object stashed on the instance for diagnostics — useful for logging or
+ * tests, never serialised into the HTTP response.
  *
  * Usage:
  *   throw new NotFoundError();

--- a/server/lib/middleware/error-handler.ts
+++ b/server/lib/middleware/error-handler.ts
@@ -1,20 +1,12 @@
 import type { ErrorRequestHandler } from "express";
 import * as HttpStatus from "http-status-codes";
 
-import CONST from "../constants.js";
 import { AppError } from "../errors.js";
 import logger from "../logger.js";
 
-// Two error shapes co-exist during the typed-Error migration (#219):
-//
-// 1. `AppError` subclasses with a `.status` property. Preferred for new code
-//    and the migration target.
-// 2. Legacy `CONST.ERROR_*` string constants. Still works via the switch
-//    below — kept for the duration of the migration so a partial rollout
-//    doesn't break anything.
-//
-// New-style errors get their `.message` echoed as the response payload; old
-// string-style throws echo the string as-is. The wire shape stays the same.
+// Every server-side throw flows through here. Typed `AppError` subclasses
+// carry their HTTP status; anything else is an unexpected exception and gets
+// a generic 500.
 const errorHandler: ErrorRequestHandler = (error, _request, response, _next) => {
   logger.debug(error);
 
@@ -23,27 +15,7 @@ const errorHandler: ErrorRequestHandler = (error, _request, response, _next) => 
     return;
   }
 
-  switch (error) {
-    case CONST.ERROR_NOT_FOUND:
-      response.status(HttpStatus.NOT_FOUND).send({ error });
-      break;
-    case CONST.ERROR_NOT_IMPLEMENTED:
-      response.status(HttpStatus.NOT_IMPLEMENTED).send({ error });
-      break;
-    case CONST.ERROR_INVALID_TOKEN:
-    case CONST.ERROR_LOGIN:
-      response.status(HttpStatus.UNAUTHORIZED).send({ error });
-      break;
-    case CONST.ERROR_ACCESS:
-      response.status(HttpStatus.FORBIDDEN).send({ error });
-      break;
-    case CONST.ERROR_UNAVAILABLE:
-      response.status(HttpStatus.SERVICE_UNAVAILABLE).send({ error });
-      break;
-    default:
-      response.status(HttpStatus.INTERNAL_SERVER_ERROR).send({ error });
-      break;
-  }
+  response.status(HttpStatus.INTERNAL_SERVER_ERROR).send({ error });
 };
 
 export default errorHandler;

--- a/server/lib/middleware/fallback-route.ts
+++ b/server/lib/middleware/fallback-route.ts
@@ -1,9 +1,9 @@
 import type { RequestHandler } from "express";
 
-import CONST from "../constants.js";
+import { NotFoundError } from "../errors.js";
 
-const fallbackRoute: RequestHandler = (_request, response) => {
-  response.status(404).send({ error: CONST.ERROR_NOT_FOUND });
+const fallbackRoute: RequestHandler = (_request, _response, next) => {
+  next(new NotFoundError());
 };
 
 export default fallbackRoute;


### PR DESCRIPTION
Closes #219. Final slice of the typed-Error migration plus the cleanup PR that retires the legacy string constants.

## What's in it

### Slice 4 — the last two throw sites

- [`server/controllers/tokens-v1.ts`](server/controllers/tokens-v1.ts) — single `next(CONST.ERROR_LOGIN)` becomes `next(new LoginError())`. `CONST` import dropped (no other uses).
- [`server/lib/middleware/fallback-route.ts`](server/lib/middleware/fallback-route.ts) — reshaped to `next(new NotFoundError())`. Previously this middleware wrote the 404 response directly, duplicating the response-shape logic; now it flows through the error-handler like every other error path.

### Final cleanup

With zero throw sites left referencing `CONST.ERROR_*`:

- [`server/lib/constants.ts`](server/lib/constants.ts) — drop the six `ERROR_*` constants (`ERROR_NOT_IMPLEMENTED`, `ERROR_NOT_FOUND`, `ERROR_LOGIN`, `ERROR_INVALID_TOKEN`, `ERROR_ACCESS`, `ERROR_UNAVAILABLE`) and their entries from the default export.
- [`server/lib/middleware/error-handler.ts`](server/lib/middleware/error-handler.ts) — drop the dual-path switch that mapped legacy strings to HTTP statuses. Handler is now ~10 lines: `if (error instanceof AppError) { use .status + .message } else { 500 }`.
- [`server/lib/errors.ts`](server/lib/errors.ts) — tighten the module docstring; the "migration is incremental, both shapes work" caveat is no longer relevant.

## Verified

- `npm run typecheck --workspace=server` — clean
- `npm run lint --workspace=server` — clean
- `npm test --workspace=server` — 606/606
- `grep -rn "CONST\\.ERROR_" server` returns only the one historical mention in `errors.ts`'s docstring.
- End-to-end smoke against the dummy driver — wire shape byte-identical to pre-migration:
  - Bad token → `{"error":"Invalid token"}` + 401
  - Unknown endpoint → `{"error":"Not found"}` + 404
  - Wrong password → `{"error":"Login failed"}` + 401

## #219 done

Final summary of the four slices + cleanup:

| Slice | What | PR |
| --- | --- | --- |
| 1 | `AppError` infra + `authorizer.ts` + `token-filter.ts` | #224 |
| 2 | `models/*` (16 sites across 5 files) | #225 |
| 3 | `db/sqlite3/*` + `dummy.ts` (30 sites across 3 files) | #226 |
| 4 + cleanup | last 2 sites + retire `CONST.ERROR_*` + simplify error-handler | this PR |

Total: 56 throw sites migrated across 13 files. Wire shape never changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)