### PR TITLE
Code-split Stats and Photo subtrees out of the main bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Replace string-constant error throws with a typed `AppError` class hierarchy (`AccessError`, `NotFoundError`, `LoginError`, `InvalidTokenError`, `NotImplementedError`, `UnavailableError`) in `server/lib/errors.ts`. Each subclass carries its HTTP status; the error-handler middleware reads `.status` and echoes `.message` as the JSON response. The legacy `CONST.ERROR_*` string constants and the dual-path switch in error-handler.ts are now retired (no remaining throw sites referenced them). Wire-shape unchanged for every existing endpoint. (closes #219)
 
+### Frontend
+
+- Code-split the `Stats` and `Photo` subtrees out of the main bundle via `React.lazy`. Stats pulls in the aggregate-charts logic; Photo pulls in `react-leaflet` for the per-photo map. Calendar-only browsing no longer downloads either. Main-bundle size 859 kB → 642 kB raw (276 kB → 204 kB gzipped, a 26% reduction). Suspense fallback lives at the Gallery component's root. (closes #162)
+
 ## [0.7.4] - 2026-05-22
 
 ### Fixed

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -10,13 +10,18 @@ import galleryPhotosService from "../../services/gallery-photos";
 import Title from "./Title";
 import Filters from "./Filters";
 import ListBody from "./ListBody";
-import Stats from "./Stats";
 import Empty from "./Empty";
 import Full from "./Full";
 import Year from "./Year";
 import Month from "./Month";
 import Day from "./Day";
-import Photo from "./Photo";
+// `Stats` and `Photo` are the two big subtrees by bundle weight (Stats pulls
+// in the aggregate-charts logic; Photo pulls in `react-leaflet` for the
+// per-photo map). React.lazy puts each in its own chunk so a user browsing
+// the calendar never has to download the stats or single-photo code paths
+// until they actually navigate to one. Suspense fallback below.
+const Stats = React.lazy(() => import("./Stats"));
+const Photo = React.lazy(() => import("./Photo"));
 
 import GalleryModel, { type Gallery as GalleryT } from "../../models/GalleryModel";
 import PhotoModel, { type Photo as PhotoT } from "../../models/PhotoModel";
@@ -466,7 +471,9 @@ const Gallery = ({
   return (
     <>
       <Global styles={globalStyles(activeTheme)} />
-      {renderContent()}
+      <React.Suspense fallback={<div>{t("loading")}</div>}>
+        {renderContent()}
+      </React.Suspense>
     </>
   );
 };


### PR DESCRIPTION
Closes #162. First slice of the 0.8 frontend renewal after the #219 typed-Error work.

## The change

`Stats` and `Photo` are the two biggest subtrees by bundle weight — Stats pulls in the aggregate-charts logic, Photo pulls in `react-leaflet` for the per-photo map. Replaced their static imports in [`components/Gallery/index.tsx`](react-app/src/components/Gallery/index.tsx) with `React.lazy`, putting each in its own chunk. Gallery's render gets a single `<React.Suspense>` boundary at the root that catches both during their dynamic-load gap.

```diff
-import Stats from "./Stats";
-import Photo from "./Photo";
+const Stats = React.lazy(() => import("./Stats"));
+const Photo = React.lazy(() => import("./Photo"));
```

## Bundle effect

Before:

```
build/assets/index-D9627caD.js   859.26 kB │ gzip: 275.94 kB
```

After:

```
build/assets/index-D8uy2hA5.js   642.20 kB │ gzip: 203.64 kB
build/assets/Stats-BI0k19rx.js   210.50 kB │ gzip:  72.15 kB
build/assets/Photo-DYJCnlYU.js     6.65 kB │ gzip:   2.50 kB
```

Main-bundle drop: ~26% gzipped. Calendar-only browsing no longer downloads either chunk; the Stats chunk only fetches when a visitor navigates to `/g/:id/stats`, the Photo chunk only when they open a single photo.

## What's not in scope

Photo's chunk is unexpectedly small (6.65 kB) because `react-leaflet` is still eagerly imported by the `Year`/`Month`/`Day` footers' inline maps, so leaflet itself stays in the main bundle. Splitting leaflet further would need Suspense boundaries on each calendar footer with a same-size fallback to avoid layout shift on scroll-into-view — left as a follow-up the [#221](https://github.com/vlumi/photo-diary/issues/221) bundle audit can weigh in on. The calendar UX risk (map "popping in" or causing a content jump) isn't obviously worth the additional download deferral.

Vite's "chunks larger than 500 kB" warning still fires for the main chunk but the threshold is now within reach for #221 to close out (or for the audit to decide to raise the warning threshold and call it done).

## Verified

- `npm run typecheck --workspace=react-app` — clean
- `npm run lint --workspace=react-app` — clean
- `npm test --workspace=react-app` — passing
- `npm run build --workspace=react-app` — chunks as documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)