### PR TITLE
Bundle audit: leaflet → shared lazy chunk, document the shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Frontend
 
 - Code-split the `Stats` and `Photo` subtrees out of the main bundle via `React.lazy`. Stats pulls in the aggregate-charts logic; Photo pulls in `react-leaflet` for the per-photo map. Calendar-only browsing no longer downloads either. Main-bundle size 859 kB → 642 kB raw (276 kB → 204 kB gzipped, a 26% reduction). Suspense fallback lives at the Gallery component's root. (closes #162)
+- Bundle audit + `MapContainer` extracted into its own lazy chunk via a `MapContainer.lazy.tsx` wrapper, so leaflet + react-leaflet + markercluster (~60 kB gzipped) are no longer in the main bundle (were previously eagerly imported by Year/Month/Day calendar footers). Each consumer has a Suspense with a fixed-height placeholder so the page doesn't reflow when the map chunk arrives. Main bundle now 444 kB raw / 143 kB gzipped — under vite's 500 kB warning threshold. `react-app/README.md` gains a "Bundle shape" section documenting the chunk layout and the CSS approach (Emotion + a small global `App.css`). `ANALYZE=1 npm run build` writes a `rollup-plugin-visualizer` treemap to `build/bundle-stats.html` for future audits. (closes #221)
 
 ## [0.7.4] - 2026-05-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4126,6 +4126,22 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -4714,6 +4730,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -4730,6 +4776,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -6378,6 +6437,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6435,6 +6510,38 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-map": {
@@ -6636,6 +6743,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isarray": {
@@ -7644,6 +7767,27 @@
         "wrappy": "1"
       }
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7894,6 +8038,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prebuild-install": {
@@ -8461,6 +8618,47 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
+      "integrity": "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^11.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/rollup/node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -8482,6 +8680,19 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safe-array-concat": {
@@ -11245,6 +11456,23 @@
         }
       }
     },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -11355,6 +11583,7 @@
         "eslint-plugin-react": "^7.37.5",
         "globals": "^17.6.0",
         "jsdom": "^27.0.1",
+        "rollup-plugin-visualizer": "^7.0.1",
         "typescript": "^6.0.3",
         "vite": "^8.0.13",
         "vitest": "^3.2.4"

--- a/react-app/README.md
+++ b/react-app/README.md
@@ -53,3 +53,52 @@ Available themes: `blue`, `red`, `grayscale`, `bw`, `alert` (defined in `src/lib
 - `src/lib/` — pure helpers (`calendar`, `collection`, `color`, `config`, `filter`, `format`, `i18n`, `stats`, `theme`, `keypress`, `scroll`, `token`, `api`)
   - `stats.tsx` is the largest module — aggregates photo statistics into chart-ready data and table rows
 - `src/setupTests.ts` — vitest setup (registers `@testing-library/jest-dom` matchers)
+
+## Bundle shape
+
+Production build produces four JS chunks plus a single small entry CSS file and one large per-chunk CSS file for the map:
+
+| Chunk | Raw | gzipped | What |
+| --- | --- | --- | --- |
+| `index-*.js` (main) | ~444 kB | ~143 kB | React + react-dom, react-router, i18next, i18n-iso-countries, Emotion, our `src/` code (gallery shell + calendar views) |
+| `MapContainer-*.js` | ~198 kB | ~60 kB | Leaflet + react-leaflet + leaflet.markercluster — shared lazy chunk loaded on first map render |
+| `Stats-*.js` | ~210 kB | ~72 kB | chart.js + react-chartjs-2 + the stats-aggregation src — loaded on `/g/:id/stats` only |
+| `Photo-*.js` | ~7 kB | ~3 kB | single-photo view src — loaded when opening a photo |
+| `index-*.css` (main) | ~0.4 kB | ~0.2 kB | global tokens + body resets from `App.css` (see "CSS approach" below) |
+| `MapContainer-*.css` | ~17 kB | ~7 kB | leaflet + markercluster stylesheets, follows the MapContainer JS chunk |
+
+Code-splitting boundaries live in [`components/Gallery/index.tsx`](src/components/Gallery/index.tsx) (`Stats` + `Photo` via `React.lazy`) and [`components/MapContainer.lazy.tsx`](src/components/MapContainer.lazy.tsx) (a wrapper that swaps every `MapContainer` import for one shared lazy chunk so leaflet is downloaded only when a map actually renders). Suspense boundaries in each consumer give the map a fixed-height placeholder so the page doesn't reflow when the chunk arrives.
+
+To inspect the chunk composition yourself:
+
+```sh
+ANALYZE=1 npm run build
+open build/bundle-stats.html
+```
+
+That writes a `rollup-plugin-visualizer` treemap (gzipped + brotli sizes) into the build output. The env var is opt-in so regular production builds stay clean.
+
+### Heaviest deps and the case for each
+
+These are the biggest items in the bundle and why they're here (or could go):
+
+| Dep | gz | Notes |
+| --- | --- | --- |
+| `react` + `react-dom` | ~85 kB | unavoidable, framework baseline |
+| `chart.js` | ~89 kB | only in the Stats chunk; the stats page draws several chart types. Replaceable in principle with a smaller lib (uPlot, Chartist) or hand-rolled SVG, but well-tested and the size is paid only by visitors who actually open `/stats`. |
+| `leaflet` + `react-leaflet` + `markercluster` | ~70 kB | shared lazy chunk; only fetched on first map render. Big but functionally hard to substitute for. |
+| `react-router` | ~22 kB | core navigation |
+| `i18next` + `react-i18next` | ~21 kB | i18n runtime |
+| `i18n-iso-countries` (en + fi + ja JSONs) | ~12 kB | three locale dictionaries eagerly imported in `App.tsx`. Lazy-loading only the active language is a clear win (~8 kB gz reclaim) but belongs with the broader i18n architecture pass in #220. |
+| `@emotion/*` (cache + styled + react + serialize + is-prop-valid + stylis) | ~14 kB | CSS-in-JS runtime; see below |
+
+## CSS approach
+
+Two stylesheets in source, two responsibilities:
+
+- **[`src/App.css`](src/App.css)** — global tokens + body resets only (~30 lines). Defines CSS custom properties used by every theme, plus `<body>` font/color/background, anchor color, and a couple of error-state classes. No component styles.
+- **[Emotion](https://emotion.sh)** (`@emotion/styled` + `@emotion/react`'s `css` template + `<Global>`) — everything component-specific. ~38 files use it. Each component owns its visual styles inline via `styled.div` tagged templates; theming flows through props or `useTheme`.
+
+The split is intentional: tokens and global resets in plain CSS (no JS overhead on first paint), component styles in JS-co-located form where they're easiest to maintain. No CSS preprocessor, no CSS modules.
+
+Migration to a different system (vanilla-extract, Tailwind, etc.) is **not currently planned** — Emotion's runtime cost is ~14 kB gz and the consistency win across 38 component files is real. If the bundle audit revisits the question, that's a separate ticket to file.

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-react": "^7.37.5",
     "globals": "^17.6.0",
     "jsdom": "^27.0.1",
+    "rollup-plugin-visualizer": "^7.0.1",
     "typescript": "^6.0.3",
     "vite": "^8.0.13",
     "vitest": "^3.2.4"

--- a/react-app/src/components/Gallery/Day/Footer.tsx
+++ b/react-app/src/components/Gallery/Day/Footer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import MapContainer from "../../MapContainer";
+import MapContainer from "../../MapContainer.lazy";
 
 import Root from "../Footer";
 

--- a/react-app/src/components/Gallery/Month/Footer.tsx
+++ b/react-app/src/components/Gallery/Month/Footer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import MapContainer from "../../MapContainer";
+import MapContainer from "../../MapContainer.lazy";
 import Root from "../Footer";
 
 import type { Gallery } from "../../../models/GalleryModel";

--- a/react-app/src/components/Gallery/Photo/Footer.tsx
+++ b/react-app/src/components/Gallery/Photo/Footer.tsx
@@ -6,7 +6,7 @@ import EpochAge from "../EpochAge";
 import EpochDayIndex from "../EpochDayIndex";
 import FlagIcon from "../../FlagIcon";
 import Link from "../Link";
-import MapContainer from "../../MapContainer";
+import MapContainer from "../../MapContainer.lazy";
 import Root from "../Footer";
 
 import config from "../../../lib/config";

--- a/react-app/src/components/Gallery/Stats/index.tsx
+++ b/react-app/src/components/Gallery/Stats/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import styled from "@emotion/styled";
 
 import Topic from "./Topic";
-import MapContainer from "../../MapContainer";
+import MapContainer from "../../MapContainer.lazy";
 
 import stats, { type UniqueValues } from "../../../lib/stats";
 

--- a/react-app/src/components/Gallery/Year/Footer.tsx
+++ b/react-app/src/components/Gallery/Year/Footer.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import MapContainer from "../../MapContainer";
+import MapContainer from "../../MapContainer.lazy";
 import Root from "../Footer";
 
 import type { Gallery } from "../../../models/GalleryModel";

--- a/react-app/src/components/MapContainer.lazy.tsx
+++ b/react-app/src/components/MapContainer.lazy.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+import type { Photo } from "../models/PhotoModel";
+
+// Lazy boundary for the real MapContainer. Pulls `react-leaflet` + `leaflet`
+// out of every chunk that imports it — without this, leaflet ends up in the
+// main bundle (because the Year/Month/Day footers import MapContainer) plus
+// duplicated in the Stats and Photo chunks. Centralizing the lazy import
+// gives rollup one shared MapContainer chunk that every consumer pulls.
+//
+// Suspense fallback is a fixed-height placeholder that matches the map's
+// default render height (or the explicit `height` prop) so the page doesn't
+// reflow when the map arrives.
+const MapContainer = React.lazy(() => import("./MapContainer"));
+
+const Placeholder = styled.div<{ $height?: number }>`
+  width: 100%;
+  height: ${(props) => (props.$height ? props.$height : 400)}px;
+  padding: 0;
+  margin: 10px 0;
+`;
+
+interface Props {
+  positions: Photo[];
+  height?: number;
+  maxZoom?: number;
+  drawLine?: boolean;
+}
+
+const LazyMapContainer = (props: Props): React.ReactElement => (
+  <React.Suspense fallback={<Placeholder $height={props.height} />}>
+    <MapContainer {...props} />
+  </React.Suspense>
+);
+
+export default LazyMapContainer;

--- a/react-app/vite.config.js
+++ b/react-app/vite.config.js
@@ -1,9 +1,23 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { visualizer } from "rollup-plugin-visualizer";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    // ANALYZE=1 npm run build → writes build/bundle-stats.html for the
+    // bundle audit (#221). No-op otherwise so production builds stay clean.
+    process.env.ANALYZE
+      ? visualizer({
+        filename: "build/bundle-stats.html",
+        template: "treemap",
+        gzipSize: true,
+        brotliSize: true,
+        open: false,
+      })
+      : null,
+  ].filter(Boolean),
   server: {
     port: 3000,
     open: true,


### PR DESCRIPTION
Closes #221. Audits the React app's bundle composition after #228's `Stats`/`Photo` code-split, extracts leaflet into a shared lazy chunk to remove it from the main bundle, and documents the shape so future audits can pick up where this one left off.

## Findings

Wired up `rollup-plugin-visualizer` (opt-in via `ANALYZE=1 npm run build`, writes `build/bundle-stats.html`). Inspected the chunks:

**Main bundle (post-#228, 642 kB raw / 204 kB gz):**
- `react-dom`: 85 kB gz — framework baseline, unavoidable
- `leaflet`: 57.6 kB gz — heavy, eagerly loaded by Year/Month/Day calendar footers
- `(src)`: 48 kB gz — our own gallery shell + calendar views
- `react-router`: 21.5 kB gz, `i18next`: 17.6 kB gz, `i18n-iso-countries`: 12.1 kB gz, `leaflet.markercluster`: 10.8 kB gz

**Stats chunk (72 kB gz):** dominated by `chart.js` (89 kB gz / 376 kB raw)

**Photo chunk (3 kB gz):** small because leaflet was deduplicated back into the main bundle

## Concrete pares applied

New [`MapContainer.lazy.tsx`](react-app/src/components/MapContainer.lazy.tsx) wraps the real MapContainer in `React.lazy` + `Suspense` with a fixed-height placeholder. All five consumers (`Stats`, `Photo` footer, `Year`/`Month`/`Day` footers) swap their import from `MapContainer` to `MapContainer.lazy`. Rollup now emits a single shared `MapContainer-*.js` chunk pulled by every consumer.

## Bundle effect

| Stage | Main bundle | Stats | Photo | MapContainer |
| --- | --- | --- | --- | --- |
| Baseline (pre-0.7) | 859 kB raw / 276 kB gz | (in main) | (in main) | (in main) |
| After #228 | 642 kB / 204 kB gz | 210 kB / 72 kB gz | 7 kB / 3 kB gz | (still in main) |
| **After this PR** | **444 kB / 143 kB gz** | 210 kB / 72 kB gz | 7 kB / 3 kB gz | **198 kB / 60 kB gz (new shared chunk)** |

Main bundle is now under vite's 500 kB warning threshold (warning is gone). Calendar browsing pulls just the main bundle until a map renders, then the shared MapContainer chunk arrives lazily with the placeholder filling its slot.

## Pares deliberately not applied here

- **`i18n-iso-countries` eager loading of `en` + `fi` + `ja`** (12 kB gz). Clear win, but the reshape belongs with the broader i18n architecture pass in #220 — coordinating with locale detection / runtime switching makes more sense than touching it in isolation.
- **`chart.js` replacement** (89 kB gz on the Stats chunk). Only paid by visitors who open `/g/:id/stats`. A smaller chart lib (uPlot, Chartist, hand-rolled SVG) would save ~50 kB gz on that chunk but is a substantially bigger swap; documented and filed-when-someone-cares.

## Documentation deliverables

[`react-app/README.md`](react-app/README.md) gains two new sections:

- **Bundle shape** — per-chunk size table, top heaviest deps with rationale, `ANALYZE=1` build instructions for re-running the visualizer.
- **CSS approach** — documents the deliberate split between `App.css` (global tokens + body resets, ~30 lines) and Emotion (`@emotion/styled` + `@emotion/react`'s `css` + `<Global>`, ~38 files for everything component-specific). Migration to a different system (vanilla-extract, Tailwind, etc.) **not currently planned**; the Emotion runtime is ~14 kB gz and the consistency win across the existing files is real.

## Verified

- `npm run typecheck --workspace=react-app` — clean
- `npm run lint --workspace=react-app` — clean (one auto-fix on `vite.config.js` indent)
- `npm test --workspace=react-app` — 945/945
- `npm run build --workspace=react-app` — chunks as documented above, no 500 kB warning
- `ANALYZE=1 npm run build --workspace=react-app` — writes `build/bundle-stats.html` with the visualizer treemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)