### PR TITLE
server: convert controllers + middleware to native Fastify (slice 2/3 of #167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Replace string-constant error throws with a typed `AppError` class hierarchy (`AccessError`, `NotFoundError`, `LoginError`, `InvalidTokenError`, `NotImplementedError`, `UnavailableError`) in `server/lib/errors.ts`. Each subclass carries its HTTP status; the error-handler middleware reads `.status` and echoes `.message` as the JSON response. The legacy `CONST.ERROR_*` string constants and the dual-path switch in error-handler.ts are now retired (no remaining throw sites referenced them). Wire-shape unchanged for every existing endpoint. (closes #219)
 - Fastify migration slice 1/3: the server is now a Fastify instance, but every existing Express middleware and controller is mounted unchanged through `@fastify/express`. No behaviour change on the wire — the entire 606-test suite passes as-is. Slices 2 and 3 convert controllers + middleware to native Fastify and drop the adapter. (part of #167)
+- Fastify migration slice 2/3: all 6 controllers and 4 middleware files are now native Fastify routes/hooks, helmet/compression/static/body-parsing are `@fastify/*` plugins, and morgan is replaced by pino (with pino-pretty in dev). Per-instance log shape changes from morgan's text line to a structured single-line entry preserving `userId` / `ip` / `responseTime`. (part of #167)
 
 ### Frontend
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1418,6 +1418,22 @@
         }
       }
     },
+    "node_modules/@fastify/accept-negotiator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/accept-negotiator/-/accept-negotiator-2.0.1.tgz",
+      "integrity": "sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@fastify/ajv-compiler": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
@@ -1460,6 +1476,72 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/@fastify/compress": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@fastify/compress/-/compress-8.3.1.tgz",
+      "integrity": "sha512-BUpItLr6MUX9e9ukg5Y6xekyA/7pBFG8QWtFCrUDm9ctoBc3R2/nA16yOaOWtVoccpXGjdDEYA/MxAb5+8cxag==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "fastify-plugin": "^5.0.0",
+        "mime-db": "^1.52.0",
+        "minipass": "^7.0.4",
+        "peek-stream": "^1.1.3",
+        "pump": "^3.0.0",
+        "pumpify": "^2.0.1",
+        "readable-stream": "^4.5.2"
+      }
+    },
+    "node_modules/@fastify/compress/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@fastify/compress/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
@@ -1532,6 +1614,26 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@fastify/helmet": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.0.2.tgz",
+      "integrity": "sha512-tO1QMkOfNeCt9l4sG/FiWErH4QMm+RjHzbMTrgew1DYOQ2vb/6M1G2iNABBrD7Xq6dUk+HLzWW8u+rmmhQHifA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "helmet": "^8.0.0"
+      }
+    },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
@@ -1578,6 +1680,65 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@fastify/send": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/send/-/send-4.1.0.tgz",
+      "integrity": "sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/ms": "^2.0.2",
+        "escape-html": "~1.0.3",
+        "fast-decode-uri-component": "^1.0.1",
+        "http-errors": "^2.0.0",
+        "mime": "^3"
+      }
+    },
+    "node_modules/@fastify/send/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@fastify/static": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
+      "integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/send": "^4.0.0",
+        "content-disposition": "^1.0.1",
+        "fastify-plugin": "^5.0.0",
+        "fastq": "^1.17.1",
+        "glob": "^13.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2210,6 +2371,15 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
+    },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -3763,6 +3933,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -4158,7 +4340,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4301,7 +4482,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
       "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4367,6 +4547,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -4608,6 +4794,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -4734,6 +4926,12 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -4905,6 +5103,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -5150,6 +5357,54 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/duplexify/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexify/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/ee-first": {
@@ -5632,6 +5887,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/exifr": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/exifr/-/exifr-7.1.3.tgz",
@@ -5718,6 +5991,12 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
+      "integrity": "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==",
+      "license": "MIT"
+    },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -5803,7 +6082,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -6272,6 +6550,23 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -6427,6 +6722,12 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -7203,6 +7504,15 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7902,7 +8212,6 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -7921,6 +8230,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -8413,6 +8731,31 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
@@ -8447,6 +8790,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/peek-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
+      "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "duplexify": "^3.5.0",
+        "through2": "^2.0.3"
       }
     },
     "node_modules/photo-diary-app": {
@@ -8509,6 +8863,42 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-pretty/node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pino-std-serializers": {
@@ -8630,6 +9020,21 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -8686,6 +9091,29 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/pumpify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-2.0.1.tgz",
+      "integrity": "sha512-m7KOje7jZxrmutanlkS1daj1dS6z6BgslzOXmcSEpIlCxM3VJH7lG5QLeck/6hgF6F4crFf01UtQmNsJfweTAw==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexify": "^4.1.1",
+        "inherits": "^2.0.3",
+        "pump": "^3.0.0"
+      }
+    },
+    "node_modules/pumpify/node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
       }
     },
     "node_modules/punycode": {
@@ -9806,6 +10234,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -10118,6 +10552,52 @@
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
       "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
       "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -12153,6 +12633,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -12535,7 +13024,10 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@fastify/compress": "^8.3.1",
         "@fastify/express": "^4.0.5",
+        "@fastify/helmet": "^13.0.2",
+        "@fastify/static": "^9.1.3",
         "bcrypt": "^6.0.0",
         "better-sqlite3": "^12.10.0",
         "compression": "^1.8.1",
@@ -12547,6 +13039,7 @@
         "http-status-codes": "^2.3.0",
         "jose": "^6.2.3",
         "morgan": "^1.10.1",
+        "pino-pretty": "^13.1.3",
         "yargs": "^18.0.0"
       },
       "devDependencies": {

--- a/server/app.ts
+++ b/server/app.ts
@@ -25,6 +25,12 @@ import logger from "./lib/logger.js";
 // PR to keep the slice diffs honest.
 export const app: FastifyInstance = Fastify({
   trustProxy: 1,
+  // Express's router treated trailing slashes as optional by default
+  // (`strict: false`). The gallery-photos LIST route was registered as
+  // `/:galleryId/` but the SPA calls it without the trailing slash —
+  // Fastify is strict, so we match Express's lenient behaviour here so
+  // existing client URLs keep working.
+  ignoreTrailingSlash: true,
   logger:
     config.ENV === "test"
       ? false

--- a/server/app.ts
+++ b/server/app.ts
@@ -2,9 +2,9 @@ import path from "node:path";
 
 import Fastify, { type FastifyInstance } from "fastify";
 import fastifyExpress from "@fastify/express";
-import express from "express";
-import compression from "compression";
-import helmet from "helmet";
+import fastifyHelmet from "@fastify/helmet";
+import fastifyCompress from "@fastify/compress";
+import fastifyStatic from "@fastify/static";
 
 import config from "./lib/config/index.js";
 
@@ -16,30 +16,42 @@ import photosV1 from "./controllers/photos-v1.js";
 import galleryPhotosV1 from "./controllers/gallery-photos-v1.js";
 
 import middleware from "./lib/middleware/index.js";
+import { NotFoundError } from "./lib/errors.js";
 import logger from "./lib/logger.js";
 
-// First step of the Fastify migration (#167, slice 1): the public surface is
-// a Fastify instance, but every existing Express middleware / controller is
-// mounted through `@fastify/express`. This preserves the entire request
-// pipeline (routing, params, body parsing, error handling, supertest tests)
-// unchanged while the host framework moves. Subsequent slices convert
-// controllers + middleware to native Fastify and drop the adapter.
+// Slice 2 of the Fastify migration (#167): controllers + middleware are now
+// native Fastify routes/hooks. Slice 3 will drop the `@fastify/express`
+// registration below — it's no longer wired to anything but stays for one
+// PR to keep the slice diffs honest.
 export const app: FastifyInstance = Fastify({
-  // Disable Fastify's own logger — morgan still drives request logging via
-  // the Express adapter for now (switched to pino in slice 2).
-  logger: false,
-  // Match Express's behaviour: take exactly one hop of `X-Forwarded-For`
-  // unwrapping from nginx so req.ip / rate-limiter keying still works.
   trustProxy: 1,
+  logger:
+    config.ENV === "test"
+      ? false
+      : {
+        level: process.env.LOG_LEVEL ?? "info",
+        transport:
+            config.ENV === "dev"
+              ? {
+                target: "pino-pretty",
+                options: {
+                  translateTime: "SYS:yyyy-mm-dd HH:MM:ss.l",
+                  ignore: "pid,hostname",
+                  singleLine: true,
+                },
+              }
+              : undefined,
+      },
+  // We emit one structured per-response log line via the `requestLogger`
+  // onResponse hook below — disabling Fastify's built-in completion line
+  // keeps logs from being noisy with two lines per request.
+  disableRequestLogging: true,
 });
 
 const STATIC_DIR =
   process.env.STATIC_DIR ?? path.join(import.meta.dirname, "build");
 
-// Register the entire Express pipeline as Fastify plugins at module load —
-// Fastify requires all plugins to be registered before `app.ready()`, and the
-// test suite re-calls `init()` between tests, so registration cannot live
-// inside `init()` without double-registering.
+// Adapter from slice 1, retained for one PR. Slice 3 drops it.
 await app.register(fastifyExpress);
 
 // helmet sets a baseline of security headers (HSTS, nosniff, frame-ancestors
@@ -52,44 +64,56 @@ await app.register(fastifyExpress);
 // the no-referrer default strips the `Referer` header on every outbound
 // request, which breaks the leaflet map widget — OSM's volunteer-run tile
 // servers reject referrer-less requests as bot traffic (osm.wiki/Blocked).
-app.use(
-  helmet({
-    contentSecurityPolicy: false,
-    referrerPolicy: { policy: "strict-origin-when-cross-origin" },
-  })
-);
-app.use(compression());
-app.use(express.json());
+await app.register(fastifyHelmet, {
+  contentSecurityPolicy: false,
+  referrerPolicy: { policy: "strict-origin-when-cross-origin" },
+});
+await app.register(fastifyCompress);
+
 // Discourage indexing and AI scraping on every response. robots.txt is the
 // authoritative signal; this header covers non-HTML resources (photo files)
 // and reaches scrapers that honor X-Robots-Tag values like `noai`/`noimageai`.
-app.use((_req, res, next) => {
-  res.setHeader("X-Robots-Tag", "noindex, noai, noimageai");
-  next();
+app.addHook("onSend", async (_request, reply) => {
+  reply.header("X-Robots-Tag", "noindex, noai, noimageai");
 });
+
 // Multi-instance deploys may invoke the server from a different CWD (the
 // per-instance directory), so resolve the bundled frontend relative to this
 // source file by default. `STATIC_DIR` overrides if you need a different
 // build location.
-app.use(express.static(STATIC_DIR));
-app.use("/g", express.static(STATIC_DIR));
-app.use("/g/*splat", express.static(STATIC_DIR));
+await app.register(fastifyStatic, {
+  root: STATIC_DIR,
+  prefix: "/",
+});
 
-app.use(middleware.tokenFilter);
+app.addHook("onRequest", middleware.tokenFilter);
 /* istanbul ignore next */
 if (config.ENV !== "test") {
-  app.use(middleware.requestLogger);
+  app.addHook("onResponse", middleware.requestLogger);
 }
 
-app.use("/api/v1/meta", metaV1.router);
-app.use("/api/v1/tokens", tokensV1.router);
-app.use("/api/v1/users", usersV1.router);
-app.use("/api/v1/galleries", galleriesV1.router);
-app.use("/api/v1/photos", photosV1.router);
-app.use("/api/v1/gallery-photos", galleryPhotosV1.router);
+await app.register(metaV1.plugin, { prefix: "/api/v1/meta" });
+await app.register(tokensV1.plugin, { prefix: "/api/v1/tokens" });
+await app.register(usersV1.plugin, { prefix: "/api/v1/users" });
+await app.register(galleriesV1.plugin, { prefix: "/api/v1/galleries" });
+await app.register(photosV1.plugin, { prefix: "/api/v1/photos" });
+await app.register(galleryPhotosV1.plugin, {
+  prefix: "/api/v1/gallery-photos",
+});
 
-app.use(middleware.unknownEndpoint);
-app.use(middleware.errorHandler);
+// Fastify's not-found handler does double duty: SPA routes (`/g`, `/g/*`)
+// serve `index.html` so deep links into the calendar tree resolve via React
+// Router; everything else (including unknown `/api/*` paths) throws into the
+// shared `errorHandler` to get the JSON 404 the API has always produced.
+app.setNotFoundHandler(async (request, reply) => {
+  const pathOnly = request.url.split("?")[0];
+  if (pathOnly === "/g" || pathOnly.startsWith("/g/")) {
+    return reply.type("text/html").sendFile("index.html");
+  }
+  throw new NotFoundError();
+});
+
+app.setErrorHandler(middleware.errorHandler);
 
 export const init = async () => {
   logger.debug("Initialize app start");

--- a/server/controllers/galleries-v1.ts
+++ b/server/controllers/galleries-v1.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import type { FastifyPluginAsync } from "fastify";
 
 import authorizerFactory from "../lib/authorizer.js";
 import { shouldHideMap, maskCoordinates } from "../lib/privacy.js";
@@ -10,13 +10,7 @@ const model = modelFactory();
 const init = async () => {
   await model.init();
 };
-const router = express.Router();
 
-export default { init, router };
-
-/**
- * Get all galleries.
- */
 const annotateWithHideMap = async (
   userId: string,
   galleries: Array<{ id: string }>
@@ -28,84 +22,98 @@ const annotateWithHideMap = async (
     }))
   );
 
-router.get("/", async (request, response) => {
-  const galleries = (await model.getGalleries()) as Array<{ id: string }>;
+const plugin: FastifyPluginAsync = async (fastify) => {
+  /**
+   * Get all galleries (admin sees all; guests/users see what they can view).
+   */
+  fastify.get("/", async (request) => {
+    const galleries = (await model.getGalleries()) as Array<{ id: string }>;
+    try {
+      await authorizer.authorizeAdmin(request.user.id);
+      return await annotateWithHideMap(request.user.id, galleries);
+    } catch {
+      const galleryIds = galleries.map((gallery) => gallery.id);
+      const authorizedPromises = await Promise.allSettled(
+        galleryIds.map((galleryId) =>
+          authorizer.authorizeGalleryView(request.user.id, galleryId)
+        )
+      );
+      const authorizedGalleryIds = authorizedPromises
+        .filter((result) => result.status === "fulfilled")
+        .map((result) => result.value);
+      const authorizedGalleries = galleries.filter((gallery) =>
+        authorizedGalleryIds.includes(gallery.id)
+      );
+      return await annotateWithHideMap(request.user.id, authorizedGalleries);
+    }
+  });
 
-  try {
+  /**
+   * Create a new gallery.
+   */
+  fastify.post("/", async (request) => {
     await authorizer.authorizeAdmin(request.user.id);
-    response.json(await annotateWithHideMap(request.user.id, galleries));
-  } catch {
-    const galleryIds = galleries.map((gallery: { id: string }) => gallery.id);
+    const gallery = {};
+    // TODO: validate and set content from request.body
+    return await model.createGallery(gallery);
+  });
 
-    const authorizedPromises = await Promise.allSettled(
-      galleryIds.map((galleryId) =>
-        authorizer.authorizeGalleryView(request.user.id, galleryId)
-      )
-    );
-    const authorizedGalleryIds = authorizedPromises
-      .filter((result) => result.status === "fulfilled")
-      .map((result) => result.value);
+  /**
+   * Get a single gallery, including its photos.
+   */
+  fastify.get<{ Params: { galleryId: string } }>(
+    "/:galleryId",
+    async (request) => {
+      await authorizer.authorizeGalleryView(
+        request.user.id,
+        request.params.galleryId
+      );
+      const gallery = (await model.getGallery(
+        request.params.galleryId
+      )) as Record<string, unknown> & { photos?: unknown[] };
+      const hideMap = await shouldHideMap(
+        request.user.id,
+        request.params.galleryId
+      );
+      if (hideMap && gallery.photos) {
+        maskCoordinates(
+          gallery.photos as Parameters<typeof maskCoordinates>[0]
+        );
+      }
+      return { ...gallery, hideMap };
+    }
+  );
 
-    const authorizedGalleries = galleries.filter((gallery: { id: string }) =>
-      authorizedGalleryIds.includes(gallery.id)
-    );
-    response.json(
-      await annotateWithHideMap(request.user.id, authorizedGalleries)
-    );
-  }
-});
-/**
- * Create a new gallery.
- */
-router.post("/", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  const gallery = {};
-  // TODO: validate and set content from request.body
-  const craetedGallery = await model.createGallery(gallery);
-  response.json(craetedGallery);
-});
-/**
- * Get a single gallery, including its photos.
- */
-router.get("/:galleryId", async (request, response) => {
-  await authorizer.authorizeGalleryView(
-    request.user.id,
-    request.params.galleryId
+  /**
+   * Update gallery properties.
+   */
+  fastify.put<{ Params: { galleryId: string } }>(
+    "/:galleryId",
+    async (request) => {
+      await authorizer.authorizeGalleryAdmin(
+        request.user.id,
+        request.params.galleryId
+      );
+      const gallery = {};
+      // TODO: validate and set content from request.body
+      return await model.updateGallery(gallery);
+    }
   );
-  const gallery = (await model.getGallery(request.params.galleryId)) as Record<
-    string,
-    unknown
-  > & { photos?: unknown[] };
-  const hideMap = await shouldHideMap(
-    request.user.id,
-    request.params.galleryId
+
+  /**
+   * Delete a gallery.
+   */
+  fastify.delete<{ Params: { galleryId: string } }>(
+    "/:galleryId",
+    async (request, reply) => {
+      await authorizer.authorizeGalleryAdmin(
+        request.user.id,
+        request.params.galleryId
+      );
+      await model.deleteGallery(request.params.galleryId);
+      reply.status(204).send();
+    }
   );
-  if (hideMap && gallery.photos) {
-    maskCoordinates(gallery.photos as Parameters<typeof maskCoordinates>[0]);
-  }
-  response.json({ ...gallery, hideMap });
-});
-/**
- * Update gallery properties
- */
-router.put("/:galleryId", async (request, response) => {
-  await authorizer.authorizeGalleryAdmin(
-    request.user.id,
-    request.params.galleryId
-  );
-  const gallery = {};
-  // TODO: validate and set content from request.body
-  const updatedGallery = await model.updateGallery(gallery);
-  response.json(updatedGallery);
-});
-/**
- * Delete a gallery.
- */
-router.delete("/:galleryId", async (request, response) => {
-  await authorizer.authorizeGalleryAdmin(
-    request.user.id,
-    request.params.galleryId
-  );
-  await model.deleteGallery(request.params.galleryId);
-  response.status(204).end();
-});
+};
+
+export default { init, plugin };

--- a/server/controllers/gallery-photos-v1.ts
+++ b/server/controllers/gallery-photos-v1.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import type { FastifyPluginAsync } from "fastify";
 
 import authorizerFactory from "../lib/authorizer.js";
 import { shouldHideMap, maskCoordinates } from "../lib/privacy.js";
@@ -10,66 +10,82 @@ const model = modelFactory();
 const init = async () => {
   await model.init();
 };
-const router = express.Router();
 
-export default { init, router };
+const plugin: FastifyPluginAsync = async (fastify) => {
+  /**
+   * Get all photos in the gallery.
+   */
+  fastify.get<{ Params: { galleryId: string } }>(
+    "/:galleryId/",
+    async (request) => {
+      await authorizer.authorizeGalleryView(
+        request.user.id,
+        request.params.galleryId
+      );
+      const photos = await model.getGalleryPhotos(request.params.galleryId);
+      if (await shouldHideMap(request.user.id, request.params.galleryId)) {
+        maskCoordinates(photos as Parameters<typeof maskCoordinates>[0]);
+      }
+      return photos;
+    }
+  );
 
-/**
- * Get all photos in the gallery.
- */
-router.get("/:galleryId/", async (request, response) => {
-  await authorizer.authorizeGalleryView(
-    request.user.id,
-    request.params.galleryId
+  /**
+   * Get the properties of a photo in gallery context.
+   */
+  fastify.get<{ Params: { galleryId: string; photoId: string } }>(
+    "/:galleryId/:photoId",
+    async (request) => {
+      await authorizer.authorizeGalleryView(
+        request.user.id,
+        request.params.galleryId
+      );
+      const photo = await model.getGalleryPhoto(
+        request.params.galleryId,
+        request.params.photoId
+      );
+      if (await shouldHideMap(request.user.id, request.params.galleryId)) {
+        maskCoordinates([photo] as Parameters<typeof maskCoordinates>[0]);
+      }
+      return photo;
+    }
   );
-  const photos = await model.getGalleryPhotos(request.params.galleryId);
-  if (await shouldHideMap(request.user.id, request.params.galleryId)) {
-    maskCoordinates(photos as Parameters<typeof maskCoordinates>[0]);
-  }
-  response.json(photos);
-});
-/**
- * Get the properties of a photo in gallery context.
- */
-router.get("/:galleryId/:photoId", async (request, response) => {
-  await authorizer.authorizeGalleryView(
-    request.user.id,
-    request.params.galleryId
+
+  /**
+   * Link a photo to a gallery.
+   */
+  fastify.put<{ Params: { galleryId: string; photoId: string } }>(
+    "/:galleryId/:photoId",
+    async (request, reply) => {
+      await authorizer.authorizeGalleryAdmin(
+        request.user.id,
+        request.params.galleryId
+      );
+      await model.linkGalleryPhoto(
+        request.params.galleryId,
+        request.params.photoId
+      );
+      reply.status(204).send();
+    }
   );
-  const photo = await model.getGalleryPhoto(
-    request.params.galleryId,
-    request.params.photoId
+
+  /**
+   * Unlink a photo from a gallery.
+   */
+  fastify.delete<{ Params: { galleryId: string; photoId: string } }>(
+    "/:galleryId/:photoId",
+    async (request, reply) => {
+      await authorizer.authorizeGalleryAdmin(
+        request.user.id,
+        request.params.galleryId
+      );
+      await model.unlinkGalleryPhoto(
+        request.params.galleryId,
+        request.params.photoId
+      );
+      reply.status(204).send();
+    }
   );
-  if (await shouldHideMap(request.user.id, request.params.galleryId)) {
-    maskCoordinates([photo] as Parameters<typeof maskCoordinates>[0]);
-  }
-  response.json(photo);
-});
-/**
- * Link a photo to a gallery.
- */
-router.put("/:galleryId/:photoId", async (request, response) => {
-  await authorizer.authorizeGalleryAdmin(
-    request.user.id,
-    request.params.galleryId
-  );
-  await model.linkGalleryPhoto(
-    request.params.galleryId,
-    request.params.photoId
-  );
-  response.status(204).end();
-});
-/**
- * Unlink a photo from a gallery.
- */
-router.delete("/:galleryId/:photoId", async (request, response) => {
-  await authorizer.authorizeGalleryAdmin(
-    request.user.id,
-    request.params.galleryId
-  );
-  await model.unlinkGalleryPhoto(
-    request.params.galleryId,
-    request.params.photoId
-  );
-  response.status(204).end();
-});
+};
+
+export default { init, plugin };

--- a/server/controllers/meta-v1.ts
+++ b/server/controllers/meta-v1.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import type { FastifyPluginAsync } from "fastify";
 
 import authorizerFactory from "../lib/authorizer.js";
 import modelFactory from "../models/meta.js";
@@ -9,9 +9,6 @@ const model = modelFactory();
 const init = async () => {
   await model.init();
 };
-const router = express.Router();
-
-export default { init, router };
 
 const cleanMeta = (meta: Record<string, unknown>): Record<string, unknown> => {
   return Object.keys(meta)
@@ -39,47 +36,56 @@ const envDefaults = (): Record<string, string> => {
   return out;
 };
 
-/**
- * Get all meta.
- */
-router.get("/", async (request, response) => {
-  // Public, no authorization needed
-  const meta = await model.getMetas();
-  response.json({ ...cleanMeta(meta), ...envDefaults() });
-});
-/**
- * Create a meta.
- */
-router.post("/", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  const meta = {};
-  // TODO: validate and set content from request.body
-  const createdMeta = await model.createMeta(meta);
-  response.json(createdMeta);
-});
-/**
- * Get the matching meta.
- */
-router.get("/:key", async (request, response) => {
-  // Public, no authorization needed
-  const meta = await model.getMeta(`instance_${request.params.key}`);
-  response.json(cleanMeta(meta));
-});
-/**
- * Update the matching meta.
- */
-router.put("/:key", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  const meta = {};
-  // TODO: validate and set content from request.body
-  const updatedMeta = await model.updateMeta(meta);
-  response.json(updatedMeta);
-});
-/**
- * Delete the matching meta.
- */
-router.delete("/:key", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  await model.deleteMeta(request.params.key);
-  response.status(204).end();
-});
+const plugin: FastifyPluginAsync = async (fastify) => {
+  /**
+   * Get all meta.
+   */
+  fastify.get("/", async () => {
+    // Public, no authorization needed
+    const meta = await model.getMetas();
+    return { ...cleanMeta(meta), ...envDefaults() };
+  });
+
+  /**
+   * Create a meta.
+   */
+  fastify.post("/", async (request) => {
+    await authorizer.authorizeAdmin(request.user.id);
+    const meta = {};
+    // TODO: validate and set content from request.body
+    return await model.createMeta(meta);
+  });
+
+  /**
+   * Get the matching meta.
+   */
+  fastify.get<{ Params: { key: string } }>("/:key", async (request) => {
+    // Public, no authorization needed
+    const meta = await model.getMeta(`instance_${request.params.key}`);
+    return cleanMeta(meta);
+  });
+
+  /**
+   * Update the matching meta.
+   */
+  fastify.put<{ Params: { key: string } }>("/:key", async (request) => {
+    await authorizer.authorizeAdmin(request.user.id);
+    const meta = {};
+    // TODO: validate and set content from request.body
+    return await model.updateMeta(meta);
+  });
+
+  /**
+   * Delete the matching meta.
+   */
+  fastify.delete<{ Params: { key: string } }>(
+    "/:key",
+    async (request, reply) => {
+      await authorizer.authorizeAdmin(request.user.id);
+      await model.deleteMeta(request.params.key);
+      reply.status(204).send();
+    }
+  );
+};
+
+export default { init, plugin };

--- a/server/controllers/photos-v1.ts
+++ b/server/controllers/photos-v1.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import type { FastifyPluginAsync } from "fastify";
 
 import CONST from "../lib/constants.js";
 import authorizerFactory from "../lib/authorizer.js";
@@ -11,65 +11,71 @@ const model = modelFactory();
 const init = async () => {
   await model.init();
 };
-const router = express.Router();
 
-export default { init, router };
+const plugin: FastifyPluginAsync = async (fastify) => {
+  /**
+   * Get all photos.
+   */
+  fastify.get("/", async (request) => {
+    await authorizer.authorizeView(request.user.id);
+    const photos = await model.getPhotos();
+    // No per-gallery scope here — resolve the user's :all-level preference.
+    // `Object.values` covers both the array shape (real sqlite driver) and the
+    // {photoId: photo} dict shape the dummy driver returns; either way we get
+    // an iterable of photo objects that `maskCoordinates` can mutate in place.
+    if (await shouldHideMap(request.user.id, CONST.SPECIAL_GALLERY_ALL)) {
+      maskCoordinates(
+        Object.values(photos as Record<string, unknown>) as Parameters<
+          typeof maskCoordinates
+        >[0]
+      );
+    }
+    return photos;
+  });
 
-/**
- * Get all photos.
- */
-router.get("/", async (request, response) => {
-  await authorizer.authorizeView(request.user.id);
-  const photos = await model.getPhotos();
-  // No per-gallery scope here — resolve the user's :all-level preference.
-  // `Object.values` covers both the array shape (real sqlite driver) and the
-  // {photoId: photo} dict shape the dummy driver returns; either way we get
-  // an iterable of photo objects that `maskCoordinates` can mutate in place.
-  if (await shouldHideMap(request.user.id, CONST.SPECIAL_GALLERY_ALL)) {
-    maskCoordinates(
-      Object.values(photos as Record<string, unknown>) as Parameters<
-        typeof maskCoordinates
-      >[0]
-    );
-  }
-  response.json(photos);
-});
-/**
- * Create a photo.
- */
-router.post("/", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  const photo = {};
-  // TODO: validate and set content from request.body
-  const createdPhoto = await model.createPhoto(photo);
-  response.json(createdPhoto);
-});
-/**
- * Get the matching photo.
- */
-router.get("/:photoId", async (request, response) => {
-  await authorizer.authorizeView(request.user.id);
-  const photo = await model.getPhoto(request.params.photoId);
-  if (await shouldHideMap(request.user.id, CONST.SPECIAL_GALLERY_ALL)) {
-    maskCoordinates([photo] as Parameters<typeof maskCoordinates>[0]);
-  }
-  response.json(photo);
-});
-/**
- * Update the matching photo.
- */
-router.put("/:photoId", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  const photo = {};
-  // TODO: validate and set content from request.body
-  const updatedPhoto = await model.updatePhoto(photo);
-  response.json(updatedPhoto);
-});
-/**
- * Delete the matching photo.
- */
-router.delete("/:photoId", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  await model.deletePhoto(request.params.photoId);
-  response.status(204).end();
-});
+  /**
+   * Create a photo.
+   */
+  fastify.post("/", async (request) => {
+    await authorizer.authorizeAdmin(request.user.id);
+    const photo = {};
+    // TODO: validate and set content from request.body
+    return await model.createPhoto(photo);
+  });
+
+  /**
+   * Get the matching photo.
+   */
+  fastify.get<{ Params: { photoId: string } }>("/:photoId", async (request) => {
+    await authorizer.authorizeView(request.user.id);
+    const photo = await model.getPhoto(request.params.photoId);
+    if (await shouldHideMap(request.user.id, CONST.SPECIAL_GALLERY_ALL)) {
+      maskCoordinates([photo] as Parameters<typeof maskCoordinates>[0]);
+    }
+    return photo;
+  });
+
+  /**
+   * Update the matching photo.
+   */
+  fastify.put<{ Params: { photoId: string } }>("/:photoId", async (request) => {
+    await authorizer.authorizeAdmin(request.user.id);
+    const photo = {};
+    // TODO: validate and set content from request.body
+    return await model.updatePhoto(photo);
+  });
+
+  /**
+   * Delete the matching photo.
+   */
+  fastify.delete<{ Params: { photoId: string } }>(
+    "/:photoId",
+    async (request, reply) => {
+      await authorizer.authorizeAdmin(request.user.id);
+      await model.deletePhoto(request.params.photoId);
+      reply.status(204).send();
+    }
+  );
+};
+
+export default { init, plugin };

--- a/server/controllers/tokens-v1.ts
+++ b/server/controllers/tokens-v1.ts
@@ -1,5 +1,4 @@
-import express from "express";
-import rateLimit from "express-rate-limit";
+import type { FastifyPluginAsync } from "fastify";
 
 import { LoginError } from "../lib/errors.js";
 import logger from "../lib/logger.js";
@@ -12,70 +11,113 @@ const model = modelFactory();
 const init = async () => {
   await model.init();
 };
-const router = express.Router();
 
-// Per-IP throttle for the login POST. The GET keep-alive and DELETE logout
-// paths aren't rate-limited (they're routine app traffic). 10 *failed*
-// attempts per 15-minute window: `skipSuccessfulRequests: true` means a
-// successful login doesn't tick the counter, so a typo'ing operator who then
-// gets it right isn't penalised — only sustained guessing is. Per-IP only;
-// keys off `req.ip`, which requires nginx to forward `X-Forwarded-For` (the
-// README's nginx section shows the headers).
-const loginLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 10,
-  skipSuccessfulRequests: true,
-  message: { error: "Too many failed login attempts. Try again later." },
-  standardHeaders: true,
-  legacyHeaders: false,
-});
+interface LoginBody {
+  id?: string;
+  password?: string;
+}
 
-export default { init, router };
+// Per-IP throttle for the login POST. 10 *failed* attempts per 15-minute
+// window: a successful login doesn't tick the counter, so a typo'ing operator
+// who then gets it right isn't penalised — only sustained guessing is. The
+// GET keep-alive and DELETE logout paths aren't rate-limited (they're
+// routine app traffic).
+//
+// In-memory only; per-IP keying off `request.ip` (which respects
+// `trustProxy: 1`, so behind nginx with `X-Forwarded-For` forwarded, it's
+// the real client IP). On server restart the counter resets — fine for a
+// self-hosted single-instance deploy.
+//
+// `@fastify/rate-limit` was the natural plugin choice but doesn't support
+// the equivalent of express-rate-limit's `skipSuccessfulRequests`, which
+// was the whole point of #213. Twenty lines of plain Map state preserves
+// the 0.7.3 behavior without pulling in a custom store.
+const LOGIN_WINDOW_MS = 15 * 60 * 1000;
+const LOGIN_MAX_FAILURES = 10;
+const failedLogins = new Map<string, { count: number; firstAt: number }>();
 
-/**
- * Verify and keep-alive token.
- */
-router.get("/", (request, response) => {
-  response.status(200).end();
-});
-/**
- * Login, creating a new token.
- */
-router.post("/", loginLimiter, async (request, response, next) => {
-  logger.debug(`Login attempt for "${request.body?.id}"`);
-  const credentials = {
-    id: request.body.id,
-    password: request.body.password,
-  };
-  if (!credentials.id || !credentials.password) {
-    next(new LoginError());
+const isRateLimited = (ip: string): boolean => {
+  const now = Date.now();
+  const entry = failedLogins.get(ip);
+  if (!entry || now - entry.firstAt > LOGIN_WINDOW_MS) {
+    return false;
+  }
+  return entry.count >= LOGIN_MAX_FAILURES;
+};
+
+const recordLoginFailure = (ip: string) => {
+  const now = Date.now();
+  const entry = failedLogins.get(ip);
+  if (!entry || now - entry.firstAt > LOGIN_WINDOW_MS) {
+    failedLogins.set(ip, { count: 1, firstAt: now });
     return;
   }
-  await model.authenticateUser(credentials);
-  const token = await authorizer
-    .authorizeAdmin(credentials.id)
-    .then(async () => {
-      return await model.createToken(credentials.id, true);
-    })
-    .catch(async () => {
-      return await model.createToken(credentials.id, false);
-    });
-  logger.debug(`User "${credentials.id}" logged in successfully.`);
+  entry.count += 1;
+};
 
-  response.status(200).send({ token: token }).end();
-});
-/**
- * Logout, revoking all tokens.
- */
-router.delete("/", async (request, response) => {
-  await model.revokeToken(request.user.id);
-  response.status(204).end();
-});
-/**
- * Logout, revoking all tokens.
- */
-router.delete("/:userId", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  await model.revokeToken(request.params.userId);
-  response.status(204).end();
-});
+const plugin: FastifyPluginAsync = async (fastify) => {
+  /**
+   * Verify and keep-alive token.
+   */
+  fastify.get("/", async (_request, reply) => {
+    reply.status(200).send();
+  });
+
+  /**
+   * Login, creating a new token.
+   */
+  fastify.post<{ Body: LoginBody }>("/", async (request, reply) => {
+    if (isRateLimited(request.ip)) {
+      reply
+        .status(429)
+        .send({ error: "Too many failed login attempts. Try again later." });
+      return;
+    }
+    logger.debug(`Login attempt for "${request.body?.id}"`);
+    const credentials = {
+      id: request.body?.id,
+      password: request.body?.password,
+    };
+    if (!credentials.id || !credentials.password) {
+      recordLoginFailure(request.ip);
+      throw new LoginError();
+    }
+    try {
+      await model.authenticateUser({
+        id: credentials.id,
+        password: credentials.password,
+      });
+    } catch (error) {
+      recordLoginFailure(request.ip);
+      throw error;
+    }
+    const token = await authorizer
+      .authorizeAdmin(credentials.id)
+      .then(() => model.createToken(credentials.id as string, true))
+      .catch(() => model.createToken(credentials.id as string, false));
+    logger.debug(`User "${credentials.id}" logged in successfully.`);
+    reply.status(200).send({ token });
+  });
+
+  /**
+   * Logout, revoking the requesting user's tokens.
+   */
+  fastify.delete("/", async (request, reply) => {
+    await model.revokeToken(request.user.id);
+    reply.status(204).send();
+  });
+
+  /**
+   * Logout (admin), revoking all tokens for another user.
+   */
+  fastify.delete<{ Params: { userId: string } }>(
+    "/:userId",
+    async (request, reply) => {
+      await authorizer.authorizeAdmin(request.user.id);
+      await model.revokeToken(request.params.userId);
+      reply.status(204).send();
+    }
+  );
+};
+
+export default { init, plugin };

--- a/server/controllers/users-v1.ts
+++ b/server/controllers/users-v1.ts
@@ -1,4 +1,4 @@
-import express from "express";
+import type { FastifyPluginAsync } from "fastify";
 
 import authorizerFactory from "../lib/authorizer.js";
 import modelFactory from "../models/user.js";
@@ -9,56 +9,57 @@ const model = modelFactory();
 const init = async () => {
   await model.init();
 };
-const router = express.Router();
 
-export default { init, router };
+const plugin: FastifyPluginAsync = async (fastify) => {
+  /**
+   * Get all users.
+   */
+  fastify.get("/", async (request) => {
+    await authorizer.authorizeAdmin(request.user.id);
+    const cleanUser = (user: { id: string }) => ({ id: user.id });
+    const users = (await model.getUsers()) as Array<{ id: string }>;
+    return users.map(cleanUser);
+  });
 
-/**
- * Get all users.
- */
-router.get("/", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  const cleanUser = (user: { id: string }) => {
-    return {
-      id: user.id,
-    };
-  };
-  const users = (await model.getUsers()) as Array<{ id: string }>;
-  response.json(users.map(cleanUser));
-});
-/**
- * Create a user.
- */
-router.post("/", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  const user = {};
-  // TODO: validate and set content from request.body
-  const createdUser = await model.createUser(user);
-  response.json(createdUser);
-});
-/**
- * Get the matching user.
- */
-router.get("/:userId", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  const user = await model.getUser(request.params.userId);
-  response.json(user);
-});
-/**
- * Update the matching user.
- */
-router.put("/:userId", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  const user = {};
-  // TODO: validate and set content from request.body
-  const updateduser = await model.updateUser(user);
-  response.json(updateduser);
-});
-/**
- * Delete the matching user.
- */
-router.delete("/:userId", async (request, response) => {
-  await authorizer.authorizeAdmin(request.user.id);
-  await model.deleteUser(request.params.userId);
-  response.status(204).end();
-});
+  /**
+   * Create a user.
+   */
+  fastify.post("/", async (request) => {
+    await authorizer.authorizeAdmin(request.user.id);
+    const user = {};
+    // TODO: validate and set content from request.body
+    return await model.createUser(user);
+  });
+
+  /**
+   * Get the matching user.
+   */
+  fastify.get<{ Params: { userId: string } }>("/:userId", async (request) => {
+    await authorizer.authorizeAdmin(request.user.id);
+    return await model.getUser(request.params.userId);
+  });
+
+  /**
+   * Update the matching user.
+   */
+  fastify.put<{ Params: { userId: string } }>("/:userId", async (request) => {
+    await authorizer.authorizeAdmin(request.user.id);
+    const user = {};
+    // TODO: validate and set content from request.body
+    return await model.updateUser(user);
+  });
+
+  /**
+   * Delete the matching user.
+   */
+  fastify.delete<{ Params: { userId: string } }>(
+    "/:userId",
+    async (request, reply) => {
+      await authorizer.authorizeAdmin(request.user.id);
+      await model.deleteUser(request.params.userId);
+      reply.status(204).send();
+    }
+  );
+};
+
+export default { init, plugin };

--- a/server/lib/middleware/error-handler.ts
+++ b/server/lib/middleware/error-handler.ts
@@ -1,4 +1,4 @@
-import type { ErrorRequestHandler } from "express";
+import type { FastifyError, FastifyReply, FastifyRequest } from "fastify";
 import * as HttpStatus from "http-status-codes";
 
 import { AppError } from "../errors.js";
@@ -7,15 +7,19 @@ import logger from "../logger.js";
 // Every server-side throw flows through here. Typed `AppError` subclasses
 // carry their HTTP status; anything else is an unexpected exception and gets
 // a generic 500.
-const errorHandler: ErrorRequestHandler = (error, _request, response, _next) => {
+const errorHandler = (
+  error: FastifyError | Error,
+  _request: FastifyRequest,
+  reply: FastifyReply
+) => {
   logger.debug(error);
 
   if (error instanceof AppError) {
-    response.status(error.status).send({ error: error.message });
+    reply.status(error.status).send({ error: error.message });
     return;
   }
 
-  response.status(HttpStatus.INTERNAL_SERVER_ERROR).send({ error });
+  reply.status(HttpStatus.INTERNAL_SERVER_ERROR).send({ error });
 };
 
 export default errorHandler;

--- a/server/lib/middleware/fallback-route.ts
+++ b/server/lib/middleware/fallback-route.ts
@@ -1,9 +1,10 @@
-import type { RequestHandler } from "express";
-
 import { NotFoundError } from "../errors.js";
 
-const fallbackRoute: RequestHandler = (_request, _response, next) => {
-  next(new NotFoundError());
+// Registered via `setNotFoundHandler`. Fastify invokes this when no route
+// matches; throwing here routes the response through `errorHandler`, which
+// reads `NotFoundError.status` (404) and formats the body.
+const fallbackRoute = () => {
+  throw new NotFoundError();
 };
 
 export default fallbackRoute;

--- a/server/lib/middleware/index.ts
+++ b/server/lib/middleware/index.ts
@@ -1,6 +1,6 @@
 import requestLogger from "./request-logger.js";
-import unknownEndpoint from "./fallback-route.js";
+import fallbackRoute from "./fallback-route.js";
 import errorHandler from "./error-handler.js";
 import tokenFilter from "./token-filter.js";
 
-export default { requestLogger, unknownEndpoint, errorHandler, tokenFilter };
+export default { requestLogger, fallbackRoute, errorHandler, tokenFilter };

--- a/server/lib/middleware/request-logger.ts
+++ b/server/lib/middleware/request-logger.ts
@@ -1,28 +1,27 @@
 /* istanbul ignore file */
-import type { Request } from "express";
-import morgan from "morgan";
+import type { onResponseHookHandler } from "fastify";
 
-morgan.token<Request>("userId", (request) => request.user?.id ?? "");
-
-// `:localtime` matches the format used by lib/logger.ts ([YYYY-MM-DD
-// HH:MM:SS.mmm] in local time) so request lines interleave cleanly with the
-// rest of the log file. morgan's built-in `:date[iso]` would work but uses
-// UTC, which is annoying to correlate against the logger's local-time lines.
-morgan.token("localtime", () => {
-  const d = new Date();
-  const pad = (n: number, w = 2) => String(n).padStart(w, "0");
-  return (
-    `${pad(d.getFullYear(), 4)}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ` +
-    `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`
+// Fastify's built-in pino logger emits its own per-request lines, but the
+// shape doesn't include the resolved `userId` and isn't tunable enough to
+// match what operators are used to grepping for. We disable the built-in
+// completion log via `disableRequestLogging: true` in the Fastify constructor
+// and emit this single line per response instead — same fields the morgan
+// format used to surface, just structured.
+//
+// `request.ip` respects `trustProxy: 1`, so behind the nginx config in the
+// README it's the real client IP; otherwise it's the socket address.
+const requestLogger: onResponseHookHandler = async (request, reply) => {
+  request.log.info(
+    {
+      ip: request.ip,
+      method: request.method,
+      url: request.url,
+      status: reply.statusCode,
+      responseTime: Math.round(reply.elapsedTime),
+      userId: request.user?.id ?? "",
+    },
+    "request"
   );
-});
+};
 
-// `:remote-addr` resolves through `req.ip`, which respects `trust proxy`.
-// When nginx is in front and forwards `X-Forwarded-For`, this is the real
-// client IP; otherwise it falls back to the socket address (127.0.0.1 in
-// the typical reverse-proxy case). Also tells operators what address the
-// per-IP rate-limiter is keying off — if every line shows 127.0.0.1,
-// the nginx vhost is missing the `proxy_set_header X-Forwarded-For …` line.
-export default morgan(
-  "[:localtime] :remote-addr :method :url :status :res[content-length] - :response-time ms :userId"
-);
+export default requestLogger;

--- a/server/lib/middleware/token-filter.ts
+++ b/server/lib/middleware/token-filter.ts
@@ -1,4 +1,4 @@
-import type { Request, RequestHandler } from "express";
+import type { FastifyRequest, onRequestHookHandler } from "fastify";
 
 import CONST from "../constants.js";
 import { InvalidTokenError } from "../errors.js";
@@ -7,43 +7,32 @@ import logger from "../logger.js";
 
 const tokensModel = tokenFactory();
 
-const getToken = (request: Request): string | undefined => {
-  const token = request.get("Authorization");
-  if (token && token.toLowerCase().startsWith("bearer")) {
-    return token.substring(7);
+const getToken = (request: FastifyRequest): string | undefined => {
+  const header = request.headers.authorization;
+  if (header && header.toLowerCase().startsWith("bearer")) {
+    return header.substring(7);
   }
   return undefined;
 };
 
-const tokenFilter: RequestHandler = (request, _response, next) => {
+const tokenFilter: onRequestHookHandler = async (request) => {
   request.token = undefined;
-
-  const initGuest = () => {
-    logger.debug("Using anonymous guest");
-    request.user = {
-      id: CONST.GUEST_USER,
-    };
-  };
 
   const token = getToken(request);
   if (!token || (request.url === "/api/tokens" && request.method === "POST")) {
-    initGuest();
-    next();
+    logger.debug("Using anonymous guest");
+    request.user = { id: CONST.GUEST_USER };
     return;
   }
-  tokensModel
-    .verifyToken(token)
-    .then((user) => {
-      logger.debug("Verified token", user);
-      // verifyToken already asserts payload.id is a non-empty string.
-      request.user = user as unknown as Request["user"];
-      request.token = token;
-      next();
-    })
-    .catch((error) => {
-      logger.debug("Token verification failed", error);
-      next(new InvalidTokenError());
-    });
+  try {
+    const user = await tokensModel.verifyToken(token);
+    logger.debug("Verified token", user);
+    request.user = user as unknown as FastifyRequest["user"];
+    request.token = token;
+  } catch (error) {
+    logger.debug("Token verification failed", error);
+    throw new InvalidTokenError();
+  }
 };
 
 export default tokenFilter;

--- a/server/package.json
+++ b/server/package.json
@@ -18,7 +18,10 @@
     "node": ">=22"
   },
   "dependencies": {
+    "@fastify/compress": "^8.3.1",
     "@fastify/express": "^4.0.5",
+    "@fastify/helmet": "^13.0.2",
+    "@fastify/static": "^9.1.3",
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^12.10.0",
     "compression": "^1.8.1",
@@ -30,6 +33,7 @@
     "http-status-codes": "^2.3.0",
     "jose": "^6.2.3",
     "morgan": "^1.10.1",
+    "pino-pretty": "^13.1.3",
     "yargs": "^18.0.0"
   },
   "devDependencies": {

--- a/server/types/fastify.d.ts
+++ b/server/types/fastify.d.ts
@@ -3,8 +3,8 @@ export type AuthUser = {
   isAdmin?: boolean;
 } & Record<string, unknown>;
 
-declare module "express-serve-static-core" {
-  interface Request {
+declare module "fastify" {
+  interface FastifyRequest {
     user: AuthUser;
     token?: string;
   }


### PR DESCRIPTION
## Summary

Second step of the Express → Fastify migration. All 6 controllers and the 4 middleware files are now native Fastify (routes as plugins, hooks for auth/logging, `setErrorHandler` + `setNotFoundHandler` for the fallback paths). Helmet / compression / static / JSON body parsing move to the `@fastify/*` plugin set; morgan is replaced by pino via Fastify's built-in logger.

The `@fastify/express` registration line in `app.ts` is no longer wired to anything but stays for one more PR; slice 3 drops it along with the now-unused Express-era deps (`express`, `helmet`, `compression`, `morgan`, `express-rate-limit`, and their `@types/*`).

All 606 tests pass unchanged — the supertest helper from slice 1 keeps working because `app.server` is still a plain `http.Server` either way.

## Notable behavior preservation

- **Login rate-limit** (`tokens-v1`) is hand-rolled (~25 lines of `Map`-based per-IP failure counter) instead of pulling `@fastify/rate-limit`, because the plugin doesn't support `skipSuccessfulRequests` and the failure-only counting added in 0.7.3 (#213) is the entire point of throttling the login route. Same `trustProxy: 1` plumbing applies, so the existing nginx config keeps working.
- **SPA fallback** for `/g` and `/g/*` is now explicit in `setNotFoundHandler` (serves `index.html` via `reply.sendFile`) instead of Express's implicit `express.static` directory-redirect behaviour. End-user result is identical.
- **helmet config** (CSP off, referrer-policy override for OSM tiles) ships unchanged via `@fastify/helmet`.
- **`request.user` / `request.token`** augmentation moved from `Request` (Express) to `FastifyRequest` — identical shape.

## Operator-facing change: log format

`morgan`'s line format is gone. Fastify's pino logger is now the per-request logger. The custom `onResponse` hook in `lib/middleware/request-logger.ts` emits a single structured entry per request preserving the fields the morgan format surfaced (`ip`, `method`, `url`, `status`, `responseTime`, `userId`):

- **Dev** (`NODE_ENV=dev`): pino-pretty with `SYS:yyyy-mm-dd HH:MM:ss.l` timestamps and `singleLine: true` — visually similar to the old morgan line.
- **Prod**: raw JSON, structured per pino's defaults. Operators who grep / `awk` the access log will need to adjust their queries.

This is the operator-facing change called out in the ticket's "Risks" section ("morgan formatted access logs differ from pino's default JSON. If anyone parses logs, that changes").

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` — 606/606 pass (no test changes needed)
- [x] Live-boot smoke:
  - `GET /api/v1/meta` → 200 with the expected JSON
  - `GET /g/foo/bar` → 200 serving the SPA `index.html`
  - `GET /api/v1/nope` → 404 JSON
  - `POST /api/v1/tokens` with bad creds → 401 (LoginError)
- [ ] Manual rate-limit smoke: 11 consecutive failed logins from one IP should return 429 on the 11th.

## Slice 3 next

Drop `@fastify/express` and the unused Express-era deps (`express`, `helmet`, `compression`, `morgan`, `express-rate-limit`, plus their `@types/*`). Tiny diff — mostly `package.json` and one line in `app.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)