### PR TITLE
server: per-route TypeBox schemas (PR B of #167)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ coverage/
 
 # Local dev instance bootstrapped by `server/bin/init-instance.ts dev --base .`
 dev/
+
+# Local sqlite databases that may sit next to the repo root or in server/
+*.sqlite3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Replace string-constant error throws with a typed `AppError` class hierarchy (`AccessError`, `NotFoundError`, `LoginError`, `InvalidTokenError`, `NotImplementedError`, `UnavailableError`) in `server/lib/errors.ts`. Each subclass carries its HTTP status; the error-handler middleware reads `.status` and echoes `.message` as the JSON response. The legacy `CONST.ERROR_*` string constants and the dual-path switch in error-handler.ts are now retired (no remaining throw sites referenced them). Wire-shape unchanged for every existing endpoint. (closes #219)
 - Migrate the server from Express to Fastify (host framework swap). Routes are native Fastify plugins; auth/error/404 are Fastify hooks; helmet, compression, and static-file serving move to `@fastify/*` plugins; morgan is replaced by pino with pino-pretty in dev. Wire shape is unchanged — same URLs, same response bodies, same status codes — but per-request log lines are now structured (still carrying `userId` / `ip` / `responseTime`). (part of #167)
+- Adopt TypeBox as the schema-and-types source for each route — every `:param` is now validated against a JSON Schema at the framework boundary, and route handlers infer their `request.params` / `request.body` types from the same definition. The login POST gains a body schema (`{ id?, password? }`); malformed structural bodies now reject with 400 before the handler runs (previously a non-object body fell through to 401 LoginError). (part of #167)
 
 ### Frontend
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1721,6 +1721,25 @@
         "glob": "^13.0.0"
       }
     },
+    "node_modules/@fastify/type-provider-typebox": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/type-provider-typebox/-/type-provider-typebox-6.1.0.tgz",
+      "integrity": "sha512-k29cOitDRcZhMXVjtRq0+caKxdWoArz7su+dQWGzGWnFG+fSKhevgiZ7nexHWuXOEEQzgJlh6cptIMu69beaTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typebox": "^1.0.13"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -3100,6 +3119,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -10143,6 +10168,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -12333,6 +12365,8 @@
         "@fastify/compress": "^8.3.1",
         "@fastify/helmet": "^13.0.2",
         "@fastify/static": "^9.1.3",
+        "@fastify/type-provider-typebox": "^6.1.0",
+        "@sinclair/typebox": "^0.34.49",
         "bcrypt": "^6.0.0",
         "better-sqlite3": "^12.10.0",
         "dotenv": "^17.4.2",

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 
-import Fastify, { type FastifyInstance } from "fastify";
+import Fastify from "fastify";
+import { type TypeBoxTypeProvider } from "@fastify/type-provider-typebox";
 import fastifyHelmet from "@fastify/helmet";
 import fastifyCompress from "@fastify/compress";
 import fastifyStatic from "@fastify/static";
@@ -18,7 +19,7 @@ import middleware from "./lib/middleware/index.js";
 import { NotFoundError } from "./lib/errors.js";
 import logger from "./lib/logger.js";
 
-export const app: FastifyInstance = Fastify({
+export const app = Fastify({
   trustProxy: 1,
   // Express's router treated trailing slashes as optional by default
   // (`strict: false`). The gallery-photos LIST route was registered as
@@ -48,7 +49,7 @@ export const app: FastifyInstance = Fastify({
   // onResponse hook below — disabling Fastify's built-in completion line
   // keeps logs from being noisy with two lines per request.
   disableRequestLogging: true,
-});
+}).withTypeProvider<TypeBoxTypeProvider>();
 
 const STATIC_DIR =
   process.env.STATIC_DIR ?? path.join(import.meta.dirname, "build");

--- a/server/controllers/galleries-v1.ts
+++ b/server/controllers/galleries-v1.ts
@@ -1,4 +1,5 @@
-import type { FastifyPluginAsync } from "fastify";
+import { Type } from "@sinclair/typebox";
+import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import authorizerFactory from "../lib/authorizer.js";
 import { shouldHideMap, maskCoordinates } from "../lib/privacy.js";
@@ -11,6 +12,8 @@ const init = async () => {
   await model.init();
 };
 
+const GalleryIdParam = Type.Object({ galleryId: Type.String() });
+
 const annotateWithHideMap = async (
   userId: string,
   galleries: Array<{ id: string }>
@@ -22,7 +25,7 @@ const annotateWithHideMap = async (
     }))
   );
 
-const plugin: FastifyPluginAsync = async (fastify) => {
+const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   /**
    * Get all galleries (admin sees all; guests/users see what they can view).
    */
@@ -61,8 +64,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   /**
    * Get a single gallery, including its photos.
    */
-  fastify.get<{ Params: { galleryId: string } }>(
+  fastify.get(
     "/:galleryId",
+    { schema: { params: GalleryIdParam } },
     async (request) => {
       await authorizer.authorizeGalleryView(
         request.user.id,
@@ -87,8 +91,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   /**
    * Update gallery properties.
    */
-  fastify.put<{ Params: { galleryId: string } }>(
+  fastify.put(
     "/:galleryId",
+    { schema: { params: GalleryIdParam } },
     async (request) => {
       await authorizer.authorizeGalleryAdmin(
         request.user.id,
@@ -103,8 +108,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   /**
    * Delete a gallery.
    */
-  fastify.delete<{ Params: { galleryId: string } }>(
+  fastify.delete(
     "/:galleryId",
+    { schema: { params: GalleryIdParam } },
     async (request, reply) => {
       await authorizer.authorizeGalleryAdmin(
         request.user.id,

--- a/server/controllers/gallery-photos-v1.ts
+++ b/server/controllers/gallery-photos-v1.ts
@@ -1,4 +1,5 @@
-import type { FastifyPluginAsync } from "fastify";
+import { Type } from "@sinclair/typebox";
+import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import authorizerFactory from "../lib/authorizer.js";
 import { shouldHideMap, maskCoordinates } from "../lib/privacy.js";
@@ -11,12 +12,19 @@ const init = async () => {
   await model.init();
 };
 
-const plugin: FastifyPluginAsync = async (fastify) => {
+const GalleryIdParam = Type.Object({ galleryId: Type.String() });
+const GalleryPhotoParams = Type.Object({
+  galleryId: Type.String(),
+  photoId: Type.String(),
+});
+
+const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   /**
    * Get all photos in the gallery.
    */
-  fastify.get<{ Params: { galleryId: string } }>(
+  fastify.get(
     "/:galleryId/",
+    { schema: { params: GalleryIdParam } },
     async (request) => {
       await authorizer.authorizeGalleryView(
         request.user.id,
@@ -33,8 +41,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   /**
    * Get the properties of a photo in gallery context.
    */
-  fastify.get<{ Params: { galleryId: string; photoId: string } }>(
+  fastify.get(
     "/:galleryId/:photoId",
+    { schema: { params: GalleryPhotoParams } },
     async (request) => {
       await authorizer.authorizeGalleryView(
         request.user.id,
@@ -54,8 +63,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   /**
    * Link a photo to a gallery.
    */
-  fastify.put<{ Params: { galleryId: string; photoId: string } }>(
+  fastify.put(
     "/:galleryId/:photoId",
+    { schema: { params: GalleryPhotoParams } },
     async (request, reply) => {
       await authorizer.authorizeGalleryAdmin(
         request.user.id,
@@ -72,8 +82,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   /**
    * Unlink a photo from a gallery.
    */
-  fastify.delete<{ Params: { galleryId: string; photoId: string } }>(
+  fastify.delete(
     "/:galleryId/:photoId",
+    { schema: { params: GalleryPhotoParams } },
     async (request, reply) => {
       await authorizer.authorizeGalleryAdmin(
         request.user.id,

--- a/server/controllers/meta-v1.ts
+++ b/server/controllers/meta-v1.ts
@@ -1,4 +1,5 @@
-import type { FastifyPluginAsync } from "fastify";
+import { Type } from "@sinclair/typebox";
+import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import authorizerFactory from "../lib/authorizer.js";
 import modelFactory from "../models/meta.js";
@@ -36,7 +37,9 @@ const envDefaults = (): Record<string, string> => {
   return out;
 };
 
-const plugin: FastifyPluginAsync = async (fastify) => {
+const KeyParam = Type.Object({ key: Type.String() });
+
+const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   /**
    * Get all meta.
    */
@@ -59,27 +62,36 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   /**
    * Get the matching meta.
    */
-  fastify.get<{ Params: { key: string } }>("/:key", async (request) => {
-    // Public, no authorization needed
-    const meta = await model.getMeta(`instance_${request.params.key}`);
-    return cleanMeta(meta);
-  });
+  fastify.get(
+    "/:key",
+    { schema: { params: KeyParam } },
+    async (request) => {
+      // Public, no authorization needed
+      const meta = await model.getMeta(`instance_${request.params.key}`);
+      return cleanMeta(meta);
+    }
+  );
 
   /**
    * Update the matching meta.
    */
-  fastify.put<{ Params: { key: string } }>("/:key", async (request) => {
-    await authorizer.authorizeAdmin(request.user.id);
-    const meta = {};
-    // TODO: validate and set content from request.body
-    return await model.updateMeta(meta);
-  });
+  fastify.put(
+    "/:key",
+    { schema: { params: KeyParam } },
+    async (request) => {
+      await authorizer.authorizeAdmin(request.user.id);
+      const meta = {};
+      // TODO: validate and set content from request.body
+      return await model.updateMeta(meta);
+    }
+  );
 
   /**
    * Delete the matching meta.
    */
-  fastify.delete<{ Params: { key: string } }>(
+  fastify.delete(
     "/:key",
+    { schema: { params: KeyParam } },
     async (request, reply) => {
       await authorizer.authorizeAdmin(request.user.id);
       await model.deleteMeta(request.params.key);

--- a/server/controllers/photos-v1.ts
+++ b/server/controllers/photos-v1.ts
@@ -1,4 +1,5 @@
-import type { FastifyPluginAsync } from "fastify";
+import { Type } from "@sinclair/typebox";
+import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import CONST from "../lib/constants.js";
 import authorizerFactory from "../lib/authorizer.js";
@@ -12,7 +13,9 @@ const init = async () => {
   await model.init();
 };
 
-const plugin: FastifyPluginAsync = async (fastify) => {
+const PhotoIdParam = Type.Object({ photoId: Type.String() });
+
+const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   /**
    * Get all photos.
    */
@@ -46,30 +49,39 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   /**
    * Get the matching photo.
    */
-  fastify.get<{ Params: { photoId: string } }>("/:photoId", async (request) => {
-    await authorizer.authorizeView(request.user.id);
-    const photo = await model.getPhoto(request.params.photoId);
-    if (await shouldHideMap(request.user.id, CONST.SPECIAL_GALLERY_ALL)) {
-      maskCoordinates([photo] as Parameters<typeof maskCoordinates>[0]);
+  fastify.get(
+    "/:photoId",
+    { schema: { params: PhotoIdParam } },
+    async (request) => {
+      await authorizer.authorizeView(request.user.id);
+      const photo = await model.getPhoto(request.params.photoId);
+      if (await shouldHideMap(request.user.id, CONST.SPECIAL_GALLERY_ALL)) {
+        maskCoordinates([photo] as Parameters<typeof maskCoordinates>[0]);
+      }
+      return photo;
     }
-    return photo;
-  });
+  );
 
   /**
    * Update the matching photo.
    */
-  fastify.put<{ Params: { photoId: string } }>("/:photoId", async (request) => {
-    await authorizer.authorizeAdmin(request.user.id);
-    const photo = {};
-    // TODO: validate and set content from request.body
-    return await model.updatePhoto(photo);
-  });
+  fastify.put(
+    "/:photoId",
+    { schema: { params: PhotoIdParam } },
+    async (request) => {
+      await authorizer.authorizeAdmin(request.user.id);
+      const photo = {};
+      // TODO: validate and set content from request.body
+      return await model.updatePhoto(photo);
+    }
+  );
 
   /**
    * Delete the matching photo.
    */
-  fastify.delete<{ Params: { photoId: string } }>(
+  fastify.delete(
     "/:photoId",
+    { schema: { params: PhotoIdParam } },
     async (request, reply) => {
       await authorizer.authorizeAdmin(request.user.id);
       await model.deletePhoto(request.params.photoId);

--- a/server/controllers/tokens-v1.ts
+++ b/server/controllers/tokens-v1.ts
@@ -1,4 +1,5 @@
-import type { FastifyPluginAsync } from "fastify";
+import { Type } from "@sinclair/typebox";
+import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import { LoginError } from "../lib/errors.js";
 import logger from "../lib/logger.js";
@@ -12,10 +13,18 @@ const init = async () => {
   await model.init();
 };
 
-interface LoginBody {
-  id?: string;
-  password?: string;
-}
+// Body schema for the login POST. Both fields are *optional* on the schema
+// so the handler controls the response: missing credentials hit the
+// `LoginError` path (401), matching pre-Fastify behaviour. Tightening the
+// schema to `required: ["id", "password"]` would short-circuit to a 400
+// validation error, which is a wire-shape regression for clients that rely
+// on the 401.
+const LoginBody = Type.Object({
+  id: Type.Optional(Type.String()),
+  password: Type.Optional(Type.String()),
+});
+
+const UserIdParam = Type.Object({ userId: Type.String() });
 
 // Per-IP throttle for the login POST. 10 *failed* attempts per 15-minute
 // window: a successful login doesn't tick the counter, so a typo'ing operator
@@ -55,7 +64,7 @@ const recordLoginFailure = (ip: string) => {
   entry.count += 1;
 };
 
-const plugin: FastifyPluginAsync = async (fastify) => {
+const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   /**
    * Verify and keep-alive token.
    */
@@ -66,38 +75,42 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   /**
    * Login, creating a new token.
    */
-  fastify.post<{ Body: LoginBody }>("/", async (request, reply) => {
-    if (isRateLimited(request.ip)) {
-      reply
-        .status(429)
-        .send({ error: "Too many failed login attempts. Try again later." });
-      return;
+  fastify.post(
+    "/",
+    { schema: { body: LoginBody } },
+    async (request, reply) => {
+      if (isRateLimited(request.ip)) {
+        reply
+          .status(429)
+          .send({ error: "Too many failed login attempts. Try again later." });
+        return;
+      }
+      logger.debug(`Login attempt for "${request.body?.id}"`);
+      const credentials = {
+        id: request.body?.id,
+        password: request.body?.password,
+      };
+      if (!credentials.id || !credentials.password) {
+        recordLoginFailure(request.ip);
+        throw new LoginError();
+      }
+      try {
+        await model.authenticateUser({
+          id: credentials.id,
+          password: credentials.password,
+        });
+      } catch (error) {
+        recordLoginFailure(request.ip);
+        throw error;
+      }
+      const token = await authorizer
+        .authorizeAdmin(credentials.id)
+        .then(() => model.createToken(credentials.id as string, true))
+        .catch(() => model.createToken(credentials.id as string, false));
+      logger.debug(`User "${credentials.id}" logged in successfully.`);
+      reply.status(200).send({ token });
     }
-    logger.debug(`Login attempt for "${request.body?.id}"`);
-    const credentials = {
-      id: request.body?.id,
-      password: request.body?.password,
-    };
-    if (!credentials.id || !credentials.password) {
-      recordLoginFailure(request.ip);
-      throw new LoginError();
-    }
-    try {
-      await model.authenticateUser({
-        id: credentials.id,
-        password: credentials.password,
-      });
-    } catch (error) {
-      recordLoginFailure(request.ip);
-      throw error;
-    }
-    const token = await authorizer
-      .authorizeAdmin(credentials.id)
-      .then(() => model.createToken(credentials.id as string, true))
-      .catch(() => model.createToken(credentials.id as string, false));
-    logger.debug(`User "${credentials.id}" logged in successfully.`);
-    reply.status(200).send({ token });
-  });
+  );
 
   /**
    * Logout, revoking the requesting user's tokens.
@@ -110,8 +123,9 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   /**
    * Logout (admin), revoking all tokens for another user.
    */
-  fastify.delete<{ Params: { userId: string } }>(
+  fastify.delete(
     "/:userId",
+    { schema: { params: UserIdParam } },
     async (request, reply) => {
       await authorizer.authorizeAdmin(request.user.id);
       await model.revokeToken(request.params.userId);

--- a/server/controllers/users-v1.ts
+++ b/server/controllers/users-v1.ts
@@ -1,4 +1,5 @@
-import type { FastifyPluginAsync } from "fastify";
+import { Type } from "@sinclair/typebox";
+import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import authorizerFactory from "../lib/authorizer.js";
 import modelFactory from "../models/user.js";
@@ -10,7 +11,9 @@ const init = async () => {
   await model.init();
 };
 
-const plugin: FastifyPluginAsync = async (fastify) => {
+const UserIdParam = Type.Object({ userId: Type.String() });
+
+const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   /**
    * Get all users.
    */
@@ -34,26 +37,35 @@ const plugin: FastifyPluginAsync = async (fastify) => {
   /**
    * Get the matching user.
    */
-  fastify.get<{ Params: { userId: string } }>("/:userId", async (request) => {
-    await authorizer.authorizeAdmin(request.user.id);
-    return await model.getUser(request.params.userId);
-  });
+  fastify.get(
+    "/:userId",
+    { schema: { params: UserIdParam } },
+    async (request) => {
+      await authorizer.authorizeAdmin(request.user.id);
+      return await model.getUser(request.params.userId);
+    }
+  );
 
   /**
    * Update the matching user.
    */
-  fastify.put<{ Params: { userId: string } }>("/:userId", async (request) => {
-    await authorizer.authorizeAdmin(request.user.id);
-    const user = {};
-    // TODO: validate and set content from request.body
-    return await model.updateUser(user);
-  });
+  fastify.put(
+    "/:userId",
+    { schema: { params: UserIdParam } },
+    async (request) => {
+      await authorizer.authorizeAdmin(request.user.id);
+      const user = {};
+      // TODO: validate and set content from request.body
+      return await model.updateUser(user);
+    }
+  );
 
   /**
    * Delete the matching user.
    */
-  fastify.delete<{ Params: { userId: string } }>(
+  fastify.delete(
     "/:userId",
+    { schema: { params: UserIdParam } },
     async (request, reply) => {
       await authorizer.authorizeAdmin(request.user.id);
       await model.deleteUser(request.params.userId);

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,8 @@
     "@fastify/compress": "^8.3.1",
     "@fastify/helmet": "^13.0.2",
     "@fastify/static": "^9.1.3",
+    "@fastify/type-provider-typebox": "^6.1.0",
+    "@sinclair/typebox": "^0.34.49",
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^12.10.0",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
## Summary

Adds JSON Schema (via TypeBox) for `params` and `body` on every controller route. Fastify validates the schema at the framework boundary; route handlers infer `request.params` / `request.body` types from the same definition, replacing the manual generic dance (`fastify.get<{ Params: { … } }>(…)`).

This is PR B of #167 — the schemas become the single source of truth that PR C exposes via `@fastify/swagger` + `swagger-ui`, and PR D consumes via `openapi-typescript` to generate the react-app's API client.

## Wire-shape changes (small but real)

- **`:param` paths**: Structurally-broken requests now reject with 400 at the framework boundary instead of reaching the handler. In practice every existing call already sends a string, so this is theoretical for live traffic.
- **`POST /api/v1/tokens` body**: declared as `{ id?: string, password?: string }` (both optional). A non-object body (e.g. a quoted string) now returns 400 instead of falling through to the handler's 401 `LoginError`. Object bodies with missing fields still hit the LoginError path (401), matching the pre-existing wire behaviour — this is intentional, tightening to `required` would break clients that depend on the 401.

## Deliberately not in this PR

- **Response schemas.** Fastify's response serialization with a declared schema strips unknown fields, and several routes return rich gallery/photo objects whose full shape isn't worth declaring before the OpenAPI work. Response schemas land alongside PR C, where they actually buy something.
- **Body schemas on the TODO endpoints** (POST/PUT for galleries / photos / users / meta). Those still accept `{}` and the handlers haven't been written. "No behaviour change" still holds for every endpoint that has live behaviour.

## Implementation

- [server/app.ts](server/app.ts) — `Fastify({…}).withTypeProvider<TypeBoxTypeProvider>()` switches the instance type so plugins typed as `FastifyPluginAsyncTypebox` get correct request-type inference from their schemas.
- Each controller declares its param/body schemas as `Type.Object({ … })` at module scope and passes them via `{ schema: { params, body } }` on the route registration.
- Token controller's body schema keeps both `id` and `password` optional so the handler still controls the 401-vs-400 split.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` — 606/606 pass
- [x] Live-boot smoke:
  - `GET /api/v1/meta` → 200
  - `GET /api/v1/users/foo` → 403 (route reachable, auth denies)
  - `GET /api/v1/gallery-photos/rikkun` → 403 (trailing-slash routing still works)
  - `POST /api/v1/tokens` with `"a-string"` body → 400 (new — TypeBox rejects)
  - `POST /api/v1/tokens` with `{"id":"nope"}` (missing password) → 401 (unchanged)

## Side-of-house

- `.gitignore` gains a `*.sqlite3` rule so local dev/test SQLite files stop slipping into commits (separate small commit on the branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)