### PR TITLE
Prepare for v0.8.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - run: npm test --workspace=converter
 
   react-app:
-    name: React app (lint + build + test)
+    name: React app (lint + typecheck + build + test)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,6 +62,10 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: npm ci
       - run: npm run lint --workspace=react-app
+      # `vite build` uses esbuild which strips types without checking them,
+      # so a missing dedicated `tsc --noEmit` step lets type errors slip
+      # past CI. Run it explicitly.
+      - run: npm run typecheck --workspace=react-app
       - run: npm run build --workspace=react-app
       - run: npm test --workspace=react-app
       # The typed API client is generated from server/openapi.json. Fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-22
+
 ### Server
 
 - Replace string-constant error throws with a typed `AppError` class hierarchy (`AccessError`, `NotFoundError`, `LoginError`, `InvalidTokenError`, `NotImplementedError`, `UnavailableError`) in `server/lib/errors.ts`. Each subclass carries its HTTP status; the error-handler middleware reads `.status` and echoes `.message` as the JSON response. The legacy `CONST.ERROR_*` string constants and the dual-path switch in error-handler.ts are now retired (no remaining throw sites referenced them). Wire-shape unchanged for every existing endpoint. (closes #219)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.7.4
+V=0.8.0
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -106,7 +106,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.7.4/bin/instance.ts dailybw
+/opt/photo-diary/0.8.0/bin/instance.ts dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The script can be invoked from any working directory; the instance dir is derived from the name (and the `--base <dir>` flag, default `/var/photo-diary`, if you want instances under a different parent). Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).

--- a/converter/package.json
+++ b/converter/package.json
@@ -34,5 +34,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4"
   },
-  "version": "0.7.4"
+  "version": "0.8.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "0.7.4",
+      "version": "0.8.0",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -19,7 +19,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "0.7.4",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -12345,7 +12345,7 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "0.7.4",
+      "version": "0.8.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -12671,7 +12671,7 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "0.7.4",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -64,5 +64,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.7.4"
+  "version": "0.8.0"
 }

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -160,7 +160,7 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
   // values depend on `lang` and `t`, so the memo recomputes on language
   // changes as well as data changes.
   const uniqueValues = React.useMemo<UniqueValues | undefined>(() => {
-    if (!photos) return undefined;
+    if (!photos || !countryData) return undefined;
     // The reduce builds up a `{ topic: { category: Set<unknown> } }` shape,
     // then the forEach normalizes each Set into the consumer-facing
     // `UniqueValueEntry[]`. The accumulator is typed as the loose
@@ -226,7 +226,7 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
     return <div className="error">Loading failed</div>;
   }
 
-  if (!meta || !galleries) {
+  if (!meta || !galleries || !countryData) {
     return <div>{t("loading")}</div>;
   }
   if (!galleryId) {

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.7.4"
+    "version": "0.8.0"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -54,5 +54,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.7.4"
+  "version": "0.8.0"
 }


### PR DESCRIPTION
## Summary

Release-prep PR for v0.8.0.

- All four `package.json` files bumped 0.7.4 → 0.8.0 (root + workspaces via `npm run version:sync`).
- `CHANGELOG.md`: the `[Unreleased]` block becomes `[0.8.0] - 2026-05-22`; `[Unreleased]` placeholder stays for the next cycle.
- `README.md`: the two install-command examples updated from `v0.7.4` to `v0.8.0`.

## What's in 0.8.0

Per the CHANGELOG, the three main milestone tickets all landed:

- **#220** — i18n architecture pass (plural keys → CLDR suffixes, `fallbackLng: "en"`, lazy-loaded country dictionaries).
- **#167** — Express → Fastify migration (PRs A/B/C/D: host-framework swap, route schemas, OpenAPI exposure, typed client) plus the #238 follow-up (typebox 0.34 → 1.x).
- **#181** — TanStack Query + Zustand for state management.

Plus the 0.8 follow-ups (response schemas, route security, rate-limit tests) and a restored `errorHandler` registration bug that had been masking AppError response shapes since slice 2 of the Fastify migration.

## Two drive-by fixes

While running the pre-release checks I caught:

- **React-app typecheck failure on main.** The Zustand store's `useLangStore` returns `countryData: typeof countryData | undefined`, but `Gallery/index.tsx` passes it to downstream consumers (Stats / Filters / `format.categoryValue`) that expect non-undefined. App.tsx gates the entire `<Routes>` block on `countryDataReady`, so this is fine at runtime, but TypeScript can't see across components. Narrowed at two points: the `uniqueValues` memo bails early on `undefined`, and the loading branch adds `!countryData` to the existing `!meta || !galleries` check.
- **React-app CI now runs `npm run typecheck`.** The above had been on `main` since the Zustand PR landed; CI didn't catch it because `vite build` uses esbuild, which strips types without checking them. Adding an explicit `tsc --noEmit` step alongside lint + build + test closes the gap so this can't recur.

## Test plan

- [x] `npm run typecheck` across all three workspaces — clean
- [x] `npm run lint` across all three workspaces — clean
- [x] `npm test --workspaces` — 609 server + 950 react-app + 60 converter tests pass
- [x] All `package.json` files at 0.8.0
- [x] No remaining `0.7.x` strings in `README.md` or `CHANGELOG.md` outside the historical changelog entries
- [ ] After merge: `git tag v0.8.0 && git push origin v0.8.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)