### PR TITLE
server: uniform empty payload for no-access / no-such gallery (closes #249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Server
+
+- Collapse "no view permission" and "gallery doesn't exist" into the same response on `GET /api/v1/galleries/:id` (`200 { id, hideMap: false }`) and `GET /api/v1/gallery-photos/:galleryId` (`200 []`). The single-photo endpoint similarly returns `404` for both cases (was `403` for no-access, `404` for no-such-photo). Without this, an unauthenticated walk of gallery IDs could enumerate which ones exist by reading the `403` / `404` distinction.
+
 ## [0.8.0] - 2026-05-22
 
 ### Server

--- a/server/controllers/galleries-v1.ts
+++ b/server/controllers/galleries-v1.ts
@@ -2,6 +2,7 @@ import { Type } from "typebox";
 import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import authorizerFactory from "../lib/authorizer.js";
+import { AccessError, NotFoundError } from "../lib/errors.js";
 import { shouldHideMap, maskCoordinates } from "../lib/privacy.js";
 import modelFactory from "../models/gallery.js";
 
@@ -110,23 +111,36 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       },
     },
     async (request) => {
-      await authorizer.authorizeGalleryView(
-        request.user.id,
-        request.params.galleryId
-      );
-      const gallery = (await model.getGallery(
-        request.params.galleryId
-      )) as Record<string, unknown> & { id: string; photos?: unknown[] };
-      const hideMap = await shouldHideMap(
-        request.user.id,
-        request.params.galleryId
-      );
-      if (hideMap && gallery.photos) {
-        maskCoordinates(
-          gallery.photos as Parameters<typeof maskCoordinates>[0]
+      // Both "no view permission" and "gallery doesn't exist" collapse to
+      // the same empty payload — without this, an unauthenticated walk of
+      // gallery IDs could enumerate which ones exist by reading the
+      // 403-vs-404 difference. The gallery LIST endpoint already filters
+      // to authorised galleries; this closes the matching hole on direct
+      // GET by id.
+      try {
+        await authorizer.authorizeGalleryView(
+          request.user.id,
+          request.params.galleryId
         );
+        const gallery = (await model.getGallery(
+          request.params.galleryId
+        )) as Record<string, unknown> & { id: string; photos?: unknown[] };
+        const hideMap = await shouldHideMap(
+          request.user.id,
+          request.params.galleryId
+        );
+        if (hideMap && gallery.photos) {
+          maskCoordinates(
+            gallery.photos as Parameters<typeof maskCoordinates>[0]
+          );
+        }
+        return { ...gallery, hideMap };
+      } catch (error) {
+        if (error instanceof AccessError || error instanceof NotFoundError) {
+          return { id: request.params.galleryId, hideMap: false };
+        }
+        throw error;
       }
-      return { ...gallery, hideMap };
     }
   );
 

--- a/server/controllers/gallery-photos-v1.ts
+++ b/server/controllers/gallery-photos-v1.ts
@@ -2,6 +2,7 @@ import { Type } from "typebox";
 import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import authorizerFactory from "../lib/authorizer.js";
+import { AccessError, NotFoundError } from "../lib/errors.js";
 import { shouldHideMap, maskCoordinates } from "../lib/privacy.js";
 import modelFactory from "../models/gallery-photo.js";
 
@@ -39,15 +40,25 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       },
     },
     async (request) => {
-      await authorizer.authorizeGalleryView(
-        request.user.id,
-        request.params.galleryId
-      );
-      const photos = await model.getGalleryPhotos(request.params.galleryId);
-      if (await shouldHideMap(request.user.id, request.params.galleryId)) {
-        maskCoordinates(photos as Parameters<typeof maskCoordinates>[0]);
+      // Both "no view permission" and "gallery doesn't exist" collapse to
+      // an empty array — see the matching note in `galleries-v1.ts` for
+      // why the difference would otherwise leak.
+      try {
+        await authorizer.authorizeGalleryView(
+          request.user.id,
+          request.params.galleryId
+        );
+        const photos = await model.getGalleryPhotos(request.params.galleryId);
+        if (await shouldHideMap(request.user.id, request.params.galleryId)) {
+          maskCoordinates(photos as Parameters<typeof maskCoordinates>[0]);
+        }
+        return photos;
+      } catch (error) {
+        if (error instanceof AccessError || error instanceof NotFoundError) {
+          return [];
+        }
+        throw error;
       }
-      return photos;
     }
   );
 
@@ -65,18 +76,30 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       },
     },
     async (request) => {
-      await authorizer.authorizeGalleryView(
-        request.user.id,
-        request.params.galleryId
-      );
-      const photo = await model.getGalleryPhoto(
-        request.params.galleryId,
-        request.params.photoId
-      );
-      if (await shouldHideMap(request.user.id, request.params.galleryId)) {
-        maskCoordinates([photo] as Parameters<typeof maskCoordinates>[0]);
+      // Single-photo lookup uses a uniform 404: gallery-level enumeration
+      // is the actual leak the empty-payload trick guards against, and
+      // photos aren't enumerable via the LIST surface anyway. So both
+      // "no access" and "no such photo" return 404 — converted from
+      // `AccessError` to `NotFoundError` here so the wire shape is one.
+      try {
+        await authorizer.authorizeGalleryView(
+          request.user.id,
+          request.params.galleryId
+        );
+        const photo = await model.getGalleryPhoto(
+          request.params.galleryId,
+          request.params.photoId
+        );
+        if (await shouldHideMap(request.user.id, request.params.galleryId)) {
+          maskCoordinates([photo] as Parameters<typeof maskCoordinates>[0]);
+        }
+        return photo;
+      } catch (error) {
+        if (error instanceof AccessError) {
+          throw new NotFoundError();
+        }
+        throw error;
       }
-      return photo;
     }
   );
 

--- a/server/tests/api/galleries.test.ts
+++ b/server/tests/api/galleries.test.ts
@@ -27,6 +27,21 @@ const getGallery = async (token: string | undefined, galleryId: string, status =
     .set("Authorization", `Bearer ${token}`)
     .expect(status);
 
+// Every "the requester can't see this gallery" case (no access AND no such
+// gallery, regardless of role) collapses to the same 200 with an empty
+// payload — the privacy rationale is that the difference between the two
+// otherwise lets an unauthenticated attacker enumerate gallery IDs. This
+// helper centralises the assertion so the tests stay readable.
+const expectGalleryUnavailable = async (
+  token: string | undefined,
+  galleryId: string
+) => {
+  const req = api.get(`/api/v1/galleries/${galleryId}`);
+  if (token) req.set("Authorization", `Bearer ${token}`);
+  const result = await req.expect(200);
+  expect(result.body).toStrictEqual({ id: galleryId, hideMap: false });
+};
+
 const expectGallery1 = (result: { body: Record<string, any> }) => {
   expect(result.body.id).toBe("gallery1");
   expect(result.body.title).toBe("gallery 1");
@@ -94,26 +109,26 @@ describe("As guest", () => {
     expect(result.body.length).toBe(1);
   });
   test("Get gallery1", async () => {
-    await api.get("/api/v1/galleries/gallery1").expect(403);
+    await expectGalleryUnavailable(undefined, "gallery1");
   });
   test("Get gallery2", async () => {
-    await api.get("/api/v1/galleries/gallery2").expect(403);
+    await expectGalleryUnavailable(undefined, "gallery2");
   });
   test("Get gallery3", async () => {
     const result = await api.get("/api/v1/galleries/gallery3").expect(200);
     expectGallery3(result);
   });
   test("Get :all", async () => {
-    await api.get("/api/v1/galleries/:all").expect(403);
+    await expectGalleryUnavailable(undefined, ":all");
   });
   test("Get :public", async () => {
-    await api.get("/api/v1/galleries/:public").expect(403);
+    await expectGalleryUnavailable(undefined, ":public");
   });
   test("Get :private", async () => {
-    await api.get("/api/v1/galleries/:private").expect(403);
+    await expectGalleryUnavailable(undefined, ":private");
   });
   test("Get invalid", async () => {
-    await api.get("/api/v1/galleries/invalid").expect(403);
+    await expectGalleryUnavailable(undefined, "invalid");
   });
 });
 
@@ -131,10 +146,10 @@ describe("As blocked user", () => {
     expect(result.body.length).toBe(0);
   });
   test("Get gallery1", async () => {
-    await getGallery(token, "gallery1", 403);
+    await expectGalleryUnavailable(token, "gallery1");
   });
   test("Get gallery2", async () => {
-    await getGallery(token, "gallery2", 403);
+    await expectGalleryUnavailable(token, "gallery2");
   });
   test("Get gallery3 (anonymous, not as blockedUser)", async () => {
     // Anonymous request — :guest has gallery3=VIEW, so this still works.
@@ -142,16 +157,16 @@ describe("As blocked user", () => {
     expectGallery3(result);
   });
   test("Get :all", async () => {
-    await getGallery(token, ":all", 403);
+    await expectGalleryUnavailable(token, ":all");
   });
   test("Get :public", async () => {
-    await getGallery(token, ":public", 403);
+    await expectGalleryUnavailable(token, ":public");
   });
   test("Get :private", async () => {
-    await getGallery(token, ":private", 403);
+    await expectGalleryUnavailable(token, ":private");
   });
   test("Get invalid", async () => {
-    await getGallery(token, "invalid", 403);
+    await expectGalleryUnavailable(token, "invalid");
   });
 });
 
@@ -166,26 +181,26 @@ describe("As simple user", () => {
     expect(result.body.length).toBe(1);
   });
   test("Get gallery1", async () => {
-    await getGallery(token, "gallery1", 403);
+    await expectGalleryUnavailable(token, "gallery1");
   });
   test("Get gallery2", async () => {
-    await getGallery(token, "gallery2", 403);
+    await expectGalleryUnavailable(token, "gallery2");
   });
   test("Get gallery3", async () => {
     const result = await getGallery(token, "gallery3", 200);
     expectGallery3(result);
   });
   test("Get :all", async () => {
-    await getGallery(token, ":all", 403);
+    await expectGalleryUnavailable(token, ":all");
   });
   test("Get :public", async () => {
-    await getGallery(token, ":public", 403);
+    await expectGalleryUnavailable(token, ":public");
   });
   test("Get :private", async () => {
-    await getGallery(token, ":private", 403);
+    await expectGalleryUnavailable(token, ":private");
   });
   test("Get invalid", async () => {
-    await getGallery(token, "invalid", 403);
+    await expectGalleryUnavailable(token, "invalid");
   });
 });
 
@@ -212,17 +227,17 @@ describe("As publicUser", () => {
     expectGallery3(result);
   });
   test("Get :all", async () => {
-    await getGallery(token, ":all", 403);
+    await expectGalleryUnavailable(token, ":all");
   });
   test("Get :public", async () => {
     const result = await getGallery(token, ":public");
     expectGalleryPublic(result);
   });
   test("Get :private", async () => {
-    await getGallery(token, ":private", 403);
+    await expectGalleryUnavailable(token, ":private");
   });
   test("Get invalid", async () => {
-    await getGallery(token, "invalid", 404);
+    await expectGalleryUnavailable(token, "invalid");
   });
 });
 
@@ -261,7 +276,7 @@ describe("As admin", () => {
     expectGalleryPrivate(result);
   });
   test("Get invalid", async () => {
-    await getGallery(token, "invalid", 404);
+    await expectGalleryUnavailable(token, "invalid");
   });
 });
 
@@ -300,7 +315,7 @@ describe("As gallery1Admin", () => {
     expectGalleryPrivate(result);
   });
   test("Get invalid", async () => {
-    await getGallery(token, "invalid", 404);
+    await expectGalleryUnavailable(token, "invalid");
   });
 });
 
@@ -315,7 +330,7 @@ describe("As gallery2Admin", () => {
     expect(result.body.length).toBe(2);
   });
   test("Get gallery1", async () => {
-    await getGallery(token, "gallery1", 403);
+    await expectGalleryUnavailable(token, "gallery1");
   });
   test("Get gallery2", async () => {
     const result = await getGallery(token, "gallery2");
@@ -326,16 +341,16 @@ describe("As gallery2Admin", () => {
     expectGallery3(result);
   });
   test("Get :all", async () => {
-    await getGallery(token, ":all", 403);
+    await expectGalleryUnavailable(token, ":all");
   });
   test("Get :public", async () => {
-    await getGallery(token, ":public", 403);
+    await expectGalleryUnavailable(token, ":public");
   });
   test("Get :private", async () => {
-    await getGallery(token, ":private", 403);
+    await expectGalleryUnavailable(token, ":private");
   });
   test("Get invalid", async () => {
-    await getGallery(token, "invalid", 403);
+    await expectGalleryUnavailable(token, "invalid");
   });
 });
 
@@ -374,7 +389,7 @@ describe("As plainUser", () => {
     expectGalleryPrivate(result);
   });
   test("Get invalid", async () => {
-    await getGallery(token, "invalid", 404);
+    await expectGalleryUnavailable(token, "invalid");
   });
 });
 
@@ -397,19 +412,19 @@ describe("As gallery1User", () => {
     expectGallery3(result);
   });
   test("Get gallery2", async () => {
-    await getGallery(token, "gallery2", 403);
+    await expectGalleryUnavailable(token, "gallery2");
   });
   test("Get :all", async () => {
-    await getGallery(token, ":all", 403);
+    await expectGalleryUnavailable(token, ":all");
   });
   test("Get :public", async () => {
-    await getGallery(token, ":public", 403);
+    await expectGalleryUnavailable(token, ":public");
   });
   test("Get :private", async () => {
-    await getGallery(token, ":private", 403);
+    await expectGalleryUnavailable(token, ":private");
   });
   test("Get invalid", async () => {
-    await getGallery(token, "invalid", 403);
+    await expectGalleryUnavailable(token, "invalid");
   });
 });
 
@@ -432,23 +447,23 @@ describe("As gallery12User", () => {
     expectGallery2(result);
   });
   test("Get gallery3", async () => {
-    await getGallery(token, "gallery3", 403);
+    await expectGalleryUnavailable(token, "gallery3");
   });
   test("Get :all", async () => {
-    await getGallery(token, ":all", 403);
+    await expectGalleryUnavailable(token, ":all");
   });
   test("Get :public", async () => {
-    await getGallery(token, ":public", 403);
+    await expectGalleryUnavailable(token, ":public");
   });
   test("Get :private", async () => {
-    await getGallery(token, ":private", 403);
+    await expectGalleryUnavailable(token, ":private");
   });
   test("Get invalid", async () => {
-    await getGallery(token, "invalid", 403);
+    await expectGalleryUnavailable(token, "invalid");
   });
 });
 
-describe("hide_map cascade applied to GET /galleries/:id (regression #201)", () => {
+describe("hide_map cascade applied to GET /galleries/:id", () => {
   let token: string | undefined = undefined;
   let spy: ReturnType<typeof vi.spyOn>;
   beforeAll(async () => {

--- a/server/tests/api/gallery-photos.test.ts
+++ b/server/tests/api/gallery-photos.test.ts
@@ -24,101 +24,101 @@ describe("As guest", () => {
     test("Get gallery1photo.jpg", async () => {
       await api
         .get("/api/v1/gallery-photos/gallery1/gallery1photo.jpg")
-        .expect(403);
+        .expect(404);
     });
     test("Get gallery12photo.jpg", async () => {
       await api
         .get("/api/v1/gallery-photos/gallery1/gallery12photo.jpg")
-        .expect(403);
+        .expect(404);
     });
     test("Get gallery2photo.jpg", async () => {
       await api
         .get("/api/v1/gallery-photos/gallery1/gallery2photo.jpg")
-        .expect(403);
+        .expect(404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/gallery1/orphanphoto.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/gallery1/orphanphoto.jpg").expect(404);
     });
     test("Get invalid.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/gallery1/orphanphoto.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/gallery1/orphanphoto.jpg").expect(404);
     });
   });
   describe("Gallery 2", () => {
     test("Get gallery1photo.jpg", async () => {
       await api
         .get("/api/v1/gallery-photos/gallery2/gallery1photo.jpg")
-        .expect(403);
+        .expect(404);
     });
     test("Get gallery12photo.jpg", async () => {
       await api
         .get("/api/v1/gallery-photos/gallery2/gallery12photo.jpg")
-        .expect(403);
+        .expect(404);
     });
     test("Get gallery2photo.jpg", async () => {
       await api
         .get("/api/v1/gallery-photos/gallery2/gallery2photo.jpg")
-        .expect(403);
+        .expect(404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/gallery2/orphanphoto.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/gallery2/orphanphoto.jpg").expect(404);
     });
   });
   describe("Gallery :all", () => {
     test("Get gallery1photo.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/:all/gallery1photo.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/:all/gallery1photo.jpg").expect(404);
     });
     test("Get gallery12photo.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/:all/gallery12photo.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/:all/gallery12photo.jpg").expect(404);
     });
     test("Get gallery2photo.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/:all/gallery2photo.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/:all/gallery2photo.jpg").expect(404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/:all/orphanphoto.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/:all/orphanphoto.jpg").expect(404);
     });
     test("Get invalid.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/:all/orphanphoto.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/:all/orphanphoto.jpg").expect(404);
     });
   });
   describe("Gallery :public", () => {
     test("Get gallery1photo.jpg", async () => {
       await api
         .get("/api/v1/gallery-photos/:public/gallery1photo.jpg")
-        .expect(403);
+        .expect(404);
     });
     test("Get gallery12photo.jpg", async () => {
       await api
         .get("/api/v1/gallery-photos/:public/gallery12photo.jpg")
-        .expect(403);
+        .expect(404);
     });
     test("Get gallery2photo.jpg", async () => {
       await api
         .get("/api/v1/gallery-photos/:public/gallery2photo.jpg")
-        .expect(403);
+        .expect(404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/:public/orphanphoto.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/:public/orphanphoto.jpg").expect(404);
     });
     test("Get invalid.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/:public/orphanphoto.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/:public/orphanphoto.jpg").expect(404);
     });
   });
   describe("Gallery :private", () => {
     test("Get gallery1photo.jpg", async () => {
       await api
         .get("/api/v1/gallery-photos/:private/gallery1photo.jpg")
-        .expect(403);
+        .expect(404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/:private/orphanphoto.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/:private/orphanphoto.jpg").expect(404);
     });
     test("Get invalid.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/:private/orphanphoto.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/:private/orphanphoto.jpg").expect(404);
     });
   });
   describe("Invalid gallery", () => {
     test("Get orphanphoto.jpg", async () => {
-      await api.get("/api/v1/gallery-photos/gallery2/orphanphoto.jpg").expect(403);
+      await api.get("/api/v1/gallery-photos/gallery2/orphanphoto.jpg").expect(404);
     });
   });
 });
@@ -421,19 +421,19 @@ describe("As gallery2Admin", () => {
 
   describe("Gallery 1", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, "gallery1", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, "gallery1", "gallery1photo.jpg", 404);
     });
     test("Get gallery12photo.jpg", async () => {
-      await getGalleryPhoto(token, "gallery1", "gallery12photo.jpg", 403);
+      await getGalleryPhoto(token, "gallery1", "gallery12photo.jpg", 404);
     });
     test("Get gallery2photo.jpg", async () => {
-      await getGalleryPhoto(token, "gallery1", "gallery2photo.jpg", 403);
+      await getGalleryPhoto(token, "gallery1", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, "gallery1", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, "gallery1", "orphanphoto.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
-      await getGalleryPhoto(token, "gallery1", "invalid.jpg", 403);
+      await getGalleryPhoto(token, "gallery1", "invalid.jpg", 404);
     });
   });
   describe("Gallery 2", () => {
@@ -464,52 +464,52 @@ describe("As gallery2Admin", () => {
   });
   describe("Gallery :all", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, ":all", "gallery1photo.jpg", 404);
     });
     test("Get gallery12photo.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "gallery12photo.jpg", 403);
+      await getGalleryPhoto(token, ":all", "gallery12photo.jpg", 404);
     });
     test("Get gallery2photo.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "gallery2photo.jpg", 403);
+      await getGalleryPhoto(token, ":all", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, ":all", "orphanphoto.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "invalid.jpg", 403);
+      await getGalleryPhoto(token, ":all", "invalid.jpg", 404);
     });
   });
   describe("Gallery :public", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, ":public", "gallery1photo.jpg", 404);
     });
     test("Get gallery12photo.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "gallery12photo.jpg", 403);
+      await getGalleryPhoto(token, ":public", "gallery12photo.jpg", 404);
     });
     test("Get gallery2photo.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "gallery2photo.jpg", 403);
+      await getGalleryPhoto(token, ":public", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, ":public", "orphanphoto.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "invalid.jpg", 403);
+      await getGalleryPhoto(token, ":public", "invalid.jpg", 404);
     });
   });
   describe("Gallery :private", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, ":private", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, ":private", "gallery1photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":private", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, ":private", "orphanphoto.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
-      await getGalleryPhoto(token, ":private", "invalid.jpg", 403);
+      await getGalleryPhoto(token, ":private", "invalid.jpg", 404);
     });
   });
   describe("Invalid gallery", () => {
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, "invalid", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, "invalid", "orphanphoto.jpg", 404);
     });
   });
 });
@@ -696,66 +696,66 @@ describe("As gallery1User", () => {
   });
   describe("Gallery 2", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, "gallery2", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, "gallery2", "gallery1photo.jpg", 404);
     });
     test("Get gallery12photo.jpg", async () => {
-      await getGalleryPhoto(token, "gallery2", "gallery12photo.jpg", 403);
+      await getGalleryPhoto(token, "gallery2", "gallery12photo.jpg", 404);
     });
     test("Get gallery2photo.jpg", async () => {
-      await getGalleryPhoto(token, "gallery2", "gallery2photo.jpg", 403);
+      await getGalleryPhoto(token, "gallery2", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, "gallery2", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, "gallery2", "orphanphoto.jpg", 404);
     });
   });
   describe("Gallery :all", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, ":all", "gallery1photo.jpg", 404);
     });
     test("Get gallery12photo.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "gallery12photo.jpg", 403);
+      await getGalleryPhoto(token, ":all", "gallery12photo.jpg", 404);
     });
     test("Get gallery2photo.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "gallery2photo.jpg", 403);
+      await getGalleryPhoto(token, ":all", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, ":all", "orphanphoto.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "invalid.jpg", 403);
+      await getGalleryPhoto(token, ":all", "invalid.jpg", 404);
     });
   });
   describe("Gallery :public", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, ":public", "gallery1photo.jpg", 404);
     });
     test("Get gallery12photo.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "gallery12photo.jpg", 403);
+      await getGalleryPhoto(token, ":public", "gallery12photo.jpg", 404);
     });
     test("Get gallery2photo.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "gallery2photo.jpg", 403);
+      await getGalleryPhoto(token, ":public", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, ":public", "orphanphoto.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "invalid.jpg", 403);
+      await getGalleryPhoto(token, ":public", "invalid.jpg", 404);
     });
   });
   describe("Gallery :private", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, ":private", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, ":private", "gallery1photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":private", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, ":private", "orphanphoto.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
-      await getGalleryPhoto(token, ":private", "invalid.jpg", 403);
+      await getGalleryPhoto(token, ":private", "invalid.jpg", 404);
     });
   });
   describe("Invalid gallery", () => {
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, "invalid", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, "invalid", "orphanphoto.jpg", 404);
     });
   });
 });
@@ -823,52 +823,52 @@ describe("As gallery12User", () => {
   });
   describe("Gallery :all", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, ":all", "gallery1photo.jpg", 404);
     });
     test("Get gallery12photo.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "gallery12photo.jpg", 403);
+      await getGalleryPhoto(token, ":all", "gallery12photo.jpg", 404);
     });
     test("Get gallery2photo.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "gallery2photo.jpg", 403);
+      await getGalleryPhoto(token, ":all", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, ":all", "orphanphoto.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "invalid.jpg", 403);
+      await getGalleryPhoto(token, ":all", "invalid.jpg", 404);
     });
   });
   describe("Gallery :public", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, ":public", "gallery1photo.jpg", 404);
     });
     test("Get gallery12photo.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "gallery12photo.jpg", 403);
+      await getGalleryPhoto(token, ":public", "gallery12photo.jpg", 404);
     });
     test("Get gallery2photo.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "gallery2photo.jpg", 403);
+      await getGalleryPhoto(token, ":public", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, ":public", "orphanphoto.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "invalid.jpg", 403);
+      await getGalleryPhoto(token, ":public", "invalid.jpg", 404);
     });
   });
   describe("Gallery :private", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, ":private", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, ":private", "gallery1photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":private", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, ":private", "orphanphoto.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
-      await getGalleryPhoto(token, ":private", "invalid.jpg", 403);
+      await getGalleryPhoto(token, ":private", "invalid.jpg", 404);
     });
   });
   describe("Invalid gallery", () => {
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, "invalid", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, "invalid", "orphanphoto.jpg", 404);
     });
   });
 });
@@ -936,19 +936,19 @@ describe("As publicUser", () => {
   });
   describe("Gallery :all", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, ":all", "gallery1photo.jpg", 404);
     });
     test("Get gallery12photo.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "gallery12photo.jpg", 403);
+      await getGalleryPhoto(token, ":all", "gallery12photo.jpg", 404);
     });
     test("Get gallery2photo.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "gallery2photo.jpg", 403);
+      await getGalleryPhoto(token, ":all", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, ":all", "orphanphoto.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
-      await getGalleryPhoto(token, ":all", "invalid.jpg", 403);
+      await getGalleryPhoto(token, ":all", "invalid.jpg", 404);
     });
   });
   describe("Gallery :public", () => {
@@ -988,13 +988,13 @@ describe("As publicUser", () => {
   });
   describe("Gallery :private", () => {
     test("Get gallery1photo.jpg", async () => {
-      await getGalleryPhoto(token, ":private", "gallery1photo.jpg", 403);
+      await getGalleryPhoto(token, ":private", "gallery1photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":private", "orphanphoto.jpg", 403);
+      await getGalleryPhoto(token, ":private", "orphanphoto.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
-      await getGalleryPhoto(token, ":private", "invalid.jpg", 403);
+      await getGalleryPhoto(token, ":private", "invalid.jpg", 404);
     });
   });
   describe("Invalid gallery", () => {


### PR DESCRIPTION
## Summary

`GET /api/v1/galleries/:id` and `GET /api/v1/gallery-photos/:galleryId` now return the same response whether the gallery doesn't exist *or* exists but the requester can't see it:

| Route | Before | After |
| --- | --- | --- |
| `GET /api/v1/galleries/:id` | `403` (no access) or `404` (no such id) | `200 { "id": "<the-id>", "hideMap": false }` for both |
| `GET /api/v1/gallery-photos/:galleryId` | `403` / `404` | `200 []` for both |
| `GET /api/v1/gallery-photos/:galleryId/:photoId` | `403` (no access) / `404` (no such photo) | `404` for both — see "Single-photo case" below |

Without this, an unauthenticated walker could enumerate gallery IDs by reading the `403`-vs-`404` distinction. The LIST endpoint (`GET /api/v1/galleries`) already filters down to authorised galleries, so this just closes the matching hole on direct GET-by-id.

## Single-photo case

The single-photo endpoint stays at `404`. Two reasons:
- Photos aren't enumerable via any LIST surface, so the leak we care about is at the gallery level.
- Returning a synthetic empty photo object would be awkward — there's no natural "empty photo" shape, unlike galleries where `{ id, hideMap }` is already part of the contract.

So the only change there is converting `AccessError` → `NotFoundError` inside the handler so the wire status is uniform.

## Implementation

Both route handlers wrap the `authorize` + `load` calls in a `try/catch`. On `AccessError` or `NotFoundError`, return the empty payload (or rethrow `NotFoundError` for the single-photo case). Any other thrown error bubbles up to the central error handler unchanged.

## Test changes

The role-by-gallery matrix in `server/tests/api/galleries.test.ts` (~40 cases) is rewritten through a new `expectGalleryUnavailable(token, galleryId)` helper that asserts the empty body shape. The single-photo test suite (`server/tests/api/gallery-photos.test.ts`, ~130 cases) replaces every `403` expectation with `404`. **The underlying access-cascade coverage is preserved** — the tests now read "the requester sees an empty payload" rather than "the requester gets a 403". No test is dropped.

Drive-by: the `(regression #201)` ticket reference in a describe label is removed (per the source-comment policy).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test --workspace=server` — 609/609 pass
- [x] Live-boot smoke:
  - `GET /api/v1/galleries/gallery1` as guest → `{"id":"gallery1","hideMap":false}` 200
  - `GET /api/v1/galleries/never-existed` as guest → `{"id":"never-existed","hideMap":false}` 200
  - `GET /api/v1/galleries/gallery3` as guest (real access) → full payload 200
  - `GET /api/v1/gallery-photos/gallery1` as guest → `[]` 200
  - `GET /api/v1/gallery-photos/gallery1/<id>` as guest → `{"error":"Not found"}` 404
  - `GET /api/v1/gallery-photos/no-such-gallery/<id>` → same 404

## Frontend impact

None. The SPA already renders an empty gallery for the empty payload shape (same code path as a real-but-empty gallery via `Empty.tsx`). The `GET /api/v1/galleries` LIST still filters by visibility, so users don't see "ghost" galleries in their list; this just changes what happens on direct-URL access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)