### PR TITLE
react-app: invalidate access-derived caches + fix logout ordering (closes #244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Frontend
 
 - Navigating to a gallery the requester can't see (private gallery, non-existent ID, or a revoked session) no longer hangs on a persistent "Loading" spinner — the SPA renders the empty-gallery view directly without firing the photos API call. The Title bar's gallery dropdown gains an italicised placeholder option for the unavailable id (matching the URL) so the selection is honest, and renders even when only one real gallery is accessible so the user has a way to switch into it.
+- Login / logout now invalidate the access-derived TanStack Query caches (`["galleries"]`, `["gallery-photos"]`) so the gallery list, map visibility, and any other per-user data refreshes immediately — previously the SPA would keep showing the prior identity's view until a manual reload. Logout's bearer-token cleanup also runs before the React re-render now (not after), so the queries fired by the user change don't send the just-revoked token. Drive-by: `localStorage.clear()` in the auth paths is narrowed to just the `user` key so the `lang` preference (and any other unrelated storage) survives auth state changes. (closes #244)
 
 ## [0.8.0] - 2026-05-22
 

--- a/react-app/src/components/Login.tsx
+++ b/react-app/src/components/Login.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styled from "@emotion/styled";
 import * as jose from "jose";
 import { useTranslation } from "react-i18next";
+import { useQueryClient } from "@tanstack/react-query";
 
 import TopMenuButton from "./TopMenuButton";
 
@@ -30,6 +31,7 @@ const Login = (): React.ReactElement => {
 
   const { t } = useTranslation();
   const setUser = useUserStore((s) => s.setUser);
+  const queryClient = useQueryClient();
 
   const login = async (userId: string, password: string) => {
     try {
@@ -44,9 +46,18 @@ const Login = (): React.ReactElement => {
       token.setToken(rawToken);
       window.localStorage.setItem("user", user.toJson());
       setUser(user);
+      // Drop any access-derived data we cached under the previous (guest or
+      // other-user) key. Without this, toggling auth state inside the
+      // `staleTime` window leaves the SPA showing the previous identity's
+      // view of `/galleries` and `/gallery-photos`.
+      queryClient.invalidateQueries({ queryKey: ["galleries"] });
+      queryClient.invalidateQueries({ queryKey: ["gallery-photos"] });
     } catch (_error) {
       token.clearToken();
-      window.localStorage.clear();
+      // Only the `user` key is auth state — the `lang` preference and
+      // anything else live alongside but aren't tied to login, so the
+      // previous `localStorage.clear()` here was a privacy/UX overreach.
+      window.localStorage.removeItem("user");
       setUser(undefined);
       // TODO: notify user
     }

--- a/react-app/src/components/Logout.tsx
+++ b/react-app/src/components/Logout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
+import { useQueryClient } from "@tanstack/react-query";
 
 import TopMenuButton from "./TopMenuButton";
 
@@ -12,12 +13,25 @@ const Form = styled.form``;
 const Logout = (): React.ReactElement => {
   const { t } = useTranslation();
   const setUser = useUserStore((s) => s.setUser);
+  const queryClient = useQueryClient();
 
   const handleLogout = (event: React.FormEvent) => {
     event.preventDefault();
-    window.localStorage.clear();
-    setUser(undefined);
+    // Ordering matters: clear the bearer token *before* `setUser`, otherwise
+    // the React re-render fires the new (guest-keyed) queries while the old
+    // token is still attached, and the server replies as if the user were
+    // still authenticated. The cached response then sticks under the new
+    // key until something invalidates it.
     token.clearToken();
+    // Only the `user` key is auth state — preserve `lang` and any other
+    // unrelated prefs that happen to share `localStorage`.
+    window.localStorage.removeItem("user");
+    setUser(undefined);
+    // Invalidate the access-derived caches so the immediate re-render
+    // fetches the new (guest) view instead of reusing the
+    // previous-user data cached under the old query key.
+    queryClient.invalidateQueries({ queryKey: ["galleries"] });
+    queryClient.invalidateQueries({ queryKey: ["gallery-photos"] });
   };
 
   return (


### PR DESCRIPTION
## Summary

Three related auth-state bugs that combined to make the SPA stick on the previous identity's view until a manual page refresh:

| # | Bug | Fix |
| - | --- | --- |
| 1 | **Logout ordering** — `setUser(undefined)` ran *before* `token.clearToken()`. The React re-render fired the new (guest-keyed) queries with the just-revoked token still attached; the server replied as if the user were still authenticated, and TanStack Query cached *that* response under the guest key. | Reorder: token cleared first, then `setUser`. |
| 2 | **No explicit cache invalidation** on login/logout. Even with the right token order, the global `staleTime: 5 * 60 * 1000` lets data cached under a previously-seen key (logout → log back in as the same user within 5 min) stick instead of refetching. | Login and Logout call `queryClient.invalidateQueries({ queryKey: ["galleries"] })` and `(["gallery-photos"])` after the auth transition. |
| 3 | **`localStorage.clear()`** in the login error path and the logout path nuked *all* localStorage on auth change — including the unrelated `lang` preference. | Narrowed to `localStorage.removeItem("user")`. |

Login's token order was already correct (`token.setToken` before `setUser`), so only the invalidation is needed on that side. Bug 1 is the logout-only fix.

## Why this PR matters beyond closing #244

The `invalidateQueries` plumbing landed here is the same machinery #207 (session-expired modal + recovery flow) needs for its post-re-login refresh. The bigger session-UX work can build on top instead of inventing a parallel path.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test --run` — 950/950 pass
- [x] Manual smoke against a running backend: log in as a user with broader access for a gallery whose guest view has `hideMap=1`; navigate to the gallery; map should appear. Log out: map should disappear (gallery either drops out of the list, or stays with `hideMap=true` if guest sees it). Log back in: map should reappear. Both transitions should resolve without a page reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)