### PR TITLE
react-app: close stacked modals on session expiry + drop hand-rolled JWT decode

### DIFF
--- a/react-app/src/components/Login.tsx
+++ b/react-app/src/components/Login.tsx
@@ -74,10 +74,16 @@ const Login = ({ onSuccess, autoFocus = true }: Props): React.ReactElement => {
     try {
       const data = await tokenService.login(userId, password);
       const rawToken = data.token;
-      // TODO: sign/verify
-      const userData = JSON.parse(
-        new TextDecoder().decode(jose.base64url.decode(rawToken.split(".")[1]))
-      );
+      // We trust the just-issued token (the server signed it; we got it
+      // back from the response body). `decodeJwt` parses the claims
+      // without verifying the signature — verification happens server-
+      // side on every subsequent request via `verifyToken`. Using jose's
+      // decoder instead of the hand-rolled base64-then-JSON dance keeps
+      // the JWT handling consistent with the rest of the codebase.
+      const userData = jose.decodeJwt(rawToken) as unknown as {
+        id: string;
+        isAdmin?: boolean;
+      };
       const user = UserModel(userData, rawToken);
 
       token.setToken(rawToken);

--- a/react-app/src/lib/api.ts
+++ b/react-app/src/lib/api.ts
@@ -3,7 +3,11 @@ import createClient from "openapi-fetch";
 import type { paths } from "./api-schema";
 import token from "./token";
 import i18n from "./i18n";
-import { useUserStore, useLoginModalStore } from "../stores";
+import {
+  useUserStore,
+  useLoginModalStore,
+  useChangePasswordModalStore,
+} from "../stores";
 
 // Single typed client for the entire server API. The `paths` type is
 // generated from the committed `server/openapi.json` (CI verifies the
@@ -50,6 +54,10 @@ client.use({
     token.clearToken();
     window.localStorage.removeItem("user");
     useUserStore.getState().setUser(undefined);
+    // Close any other modal that might be open (e.g. change-password mid-
+    // submit) so the login modal doesn't stack on top of it — two
+    // backdrops at once reads as broken.
+    useChangePasswordModalStore.getState().close();
     useLoginModalStore.getState().open(i18n.t("session-expired"));
   },
 });


### PR DESCRIPTION
## Summary

Two small auth-UX polish items before 0.9 cuts.

### 1. Close other modals on global 401

`lib/api.ts`'s `onResponse` 401 handler now closes the change-password modal before opening the login modal. Previously, if a user's session expired mid-change-password, both modal backdrops stacked — visually broken. With this fix, the change-password modal closes silently and the login modal shows with the standard "session expired" message; the user can re-log in and reattempt the change-password flow from a clean state.

### 2. Drop the hand-rolled JWT decode

`Login.tsx` replaces

```ts
const userData = JSON.parse(
  new TextDecoder().decode(jose.base64url.decode(rawToken.split(".")[1]))
);
```

with

```ts
const userData = jose.decodeJwt(rawToken) as unknown as { id: string; isAdmin?: boolean };
```

Functionally identical (both read the unsigned payload — the server just minted the token and we trust the response; verification happens server-side on every subsequent request). The codebase uses `jose` everywhere else; the direct decoder is cleaner and retires the `TODO: sign/verify` comment that's been sitting in that file.

### Filed separately for 0.10

[#256](https://github.com/vlumi/photo-diary/issues/256) — server-side logout / token revocation. `revokeToken` is currently `NotImplementedError`, so clicking "Log out" only clears local state; the bearer is valid until natural expiry (90 days). Three implementation paths sketched in the ticket; design question doesn't fit a quick polish PR.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test --run` — 958/958 pass
- [ ] Manual smoke: open change-password, leave the modal open, forcibly expire the session (devtools → delete the JWT from localStorage and let an API call fire), confirm change-password modal closes and login modal opens with the session-expired banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)