### PR TITLE
Prepare for v0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-23
+
 ### Server
 
 - Collapse "no view permission" and "gallery doesn't exist" into the same response on `GET /api/v1/galleries/:id` (`200 { id, hideMap: false }`) and `GET /api/v1/gallery-photos/:galleryId` (`200 []`). The single-photo endpoint similarly returns `404` for both cases (was `403` for no-access, `404` for no-such-photo). Without this, an unauthenticated walk of gallery IDs could enumerate which ones exist by reading the `403` / `404` distinction.
 - JWTs now expire after `SESSION_LENGTH_MS` (90 days, bumped from the 7-day constant that was defined but unused). `setExpirationTime` is wired into the sign step, and the verify path distinguishes `JWTExpired` (jose) from other verification failures so the wire response is the new typed `TokenExpiredError` instead of the generic `InvalidTokenError`. (closes #207)
-- `PUT /api/v1/users/self/password` lets an authenticated user change their own password without admin help. Body: `{ currentPassword, newPassword }`; verifies the current password via bcrypt, hashes the new one, rotates the user's `secret` (invalidating every other outstanding JWT for the user — same security model as `bin/user.ts passwd`), and returns a freshly-minted JWT so the caller's current session stays alive. Guests get 403; wrong current password gets 401. (part of #182)
+- `PUT /api/v1/users/self/password` lets an authenticated user change their own password without admin help. Body: `{ currentPassword, newPassword }`; verifies the current password via bcrypt, hashes the new one, rotates the user's `secret` (invalidating every other outstanding JWT for the user — same security model as `bin/user.ts passwd`), and returns a freshly-minted JWT so the caller's current session stays alive. Guests get 403; wrong current password gets 422 (body content, not a session problem — keeps the SPA's global 401 handler from kicking the user out of their valid session). New `ValidationError(422)` added to the typed error hierarchy. (part of #182)
 
 ### Frontend
 
@@ -15,6 +17,7 @@
 - Add a responsive toast-notification surface (`<Notifications />` mounted at the app root, backed by a `useNotificationsStore` Zustand store with per-type defaults, click-to-dismiss, and auto-dismiss timeouts). Login uses it to surface "invalid username or password" for 401s and the rate-limit message for 429s — previously failures were silently swallowed via a `TODO: notify user` comment. The toast strip spans edge-to-edge on phones and tucks into the top-right of wider viewports. (closes #248)
 - Move the login form out of the top menu and into a floating modal. A global onResponse handler in the openapi-fetch client catches any 401 with an Authorization header attached and opens the modal — same UX whether the bearer expired (now possible after the JWT expiration change), the operator rotated the user's secret, or the token was otherwise invalidated mid-session. A "session expired" toast accompanies the modal so the user understands why they're being asked to log in again. The URL is preserved across the re-login so they land back where they were; if the new session has narrower access, the empty-gallery view from the previous PRs takes over. (closes #207)
 - Replace the inline login/logout buttons in the top menu with a profile icon (`<UserMenu>`). Outlined `BsPerson` when not logged in (clicking opens the login modal); filled `BsPersonFill` when logged in (clicking opens a dropdown with the username, "Change password", and "Log out"). The "Change password" entry opens a new floating `<ChangePasswordModal>` mirroring the login modal's shape — three fields (current / new / confirm), inline error pill on failure, success toast on completion. The new JWT returned by the backend is swapped into local state so the user stays logged in across the rotation. (closes #182)
+- Global 401 handler closes the change-password modal before opening the login modal so a session expiry mid-change-password no longer stacks two backdrops. The hand-rolled JWT-payload decode in `Login.tsx` (`JSON.parse(TextDecoder.decode(jose.base64url.decode(...)))`) is replaced with a direct `jose.decodeJwt(rawToken)` call — same effect, matches the codebase's `jose` usage everywhere else, retires the `TODO: sign/verify` comment.
 
 ## [0.8.0] - 2026-05-22
 

--- a/README.md
+++ b/README.md
@@ -57,20 +57,20 @@ Directory layout:
 
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
-  0.7.0/                                #   each version unpacked into its own subdir
-  0.8.0/                                #   so different instances can run different versions
+  0.8.0/                                #   each version unpacked into its own subdir
+  0.9.0/                                #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/0.8.0      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/0.9.0      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  display/  thumbnail/
   travel/
     .env
-    code -> /opt/photo-diary/0.7.0      # different instance, possibly on a different version
+    code -> /opt/photo-diary/0.8.0      # different instance, possibly on a different version
     db.sqlite3
     photos/
       …
@@ -91,7 +91,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.8.0
+V=0.9.0
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -106,7 +106,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.8.0/bin/instance.ts dailybw
+/opt/photo-diary/0.9.0/bin/instance.ts dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The script can be invoked from any working directory; the instance dir is derived from the name (and the `--base <dir>` flag, default `/var/photo-diary`, if you want instances under a different parent). Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -134,7 +134,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.8.0/bin/instance.ts dailybw          # backs up the DB, flips the symlink
+/opt/photo-diary/0.9.0/bin/instance.ts dailybw          # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                    # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                         # migration runner applies any schema bumps

--- a/converter/package.json
+++ b/converter/package.json
@@ -34,5 +34,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4"
   },
-  "version": "0.8.0"
+  "version": "0.9.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -19,7 +19,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -12345,7 +12345,7 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -12671,7 +12671,7 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -64,5 +64,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.8.0"
+  "version": "0.9.0"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.8.0"
+    "version": "0.9.0"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -54,5 +54,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.8.0"
+  "version": "0.9.0"
 }


### PR DESCRIPTION
## Summary

Release-prep PR for v0.9.0. Same flow as 0.8.0.

- All four `package.json` files bumped 0.8.0 → 0.9.0 via `npm run version:sync`. `server/openapi.json` regenerated so the embedded `info.version` matches.
- `CHANGELOG.md`: `[Unreleased]` block becomes `[0.9.0] - 2026-05-23`. Two corrections to existing 0.9 entries — the password-change bullet now says wrong-current returns 422 (matches the `ValidationError` fix), and a new line for the polish PR (#257) covers the global-401 modal-stacking fix and the `jose.decodeJwt` cleanup.
- `README.md`: install-command examples shift versions forward one tag. The two intentional "older instance" references (showing multi-version coexistence) move from 0.7.0 → 0.8.0 in step.

## What's in 0.9.0

Per the consolidated CHANGELOG section:

**Server**
- Privacy collapse on `GET /api/v1/galleries/:id` and `GET /api/v1/gallery-photos/:galleryId` — no-access and no-such-id both return uniform empty payloads (#249).
- JWT expiration (90 days), `TokenExpiredError` distinguished from `InvalidTokenError` (#207).
- `PUT /api/v1/users/self/password` for self-service password change with `ValidationError(422)` on wrong-current (#182).

**Frontend**
- Empty-view render for galleries the requester can't see (loading-spinner regression fix) with placeholder option in the Title dropdown.
- Login/logout invalidate access-derived TanStack Query caches; ordering fixed; `localStorage.clear()` narrowed (#244).
- Responsive `<Notifications />` toast surface (#248).
- Login form moves out of the top menu into a floating `<LoginModal>`; global 401 handler opens it on mid-session expiry (#207).
- Profile-icon `<UserMenu>` replaces the inline login/logout UI; `<ChangePasswordModal>` for the self-service flow (#182).
- Polish: global 401 closes stacked modals; `jose.decodeJwt` replaces hand-rolled payload decode.

## Test plan

- [x] `npx tsc --noEmit` across all three workspaces — clean
- [x] `npm run lint` across all three workspaces — clean
- [x] `npm test --workspaces` — 619 server + 958 react-app + 60 converter pass
- [x] `git diff --exit-code react-app/src/lib/api-schema.ts` clean after `npm run api:codegen` (the `info.version` lives in `openapi.json` only, not the generated TS types)
- [x] All `package.json`s at 0.9.0; no stray `0.8.0` strings in `CHANGELOG.md` / `README.md` outside historical entries and the deliberate "older instance" example
- [ ] After merge: `git tag v0.9.0 && git push origin v0.9.0` + create GH release with the 0.9.0 CHANGELOG section as the body

🤖 Generated with [Claude Code](https://claude.com/claude-code)