### PR TITLE
react-app: restore queryClient.invalidateQueries on UserMenu logout

### DIFF
--- a/react-app/src/components/UserMenu.tsx
+++ b/react-app/src/components/UserMenu.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
+import { useQueryClient } from "@tanstack/react-query";
 import { BsPersonFill, BsPerson } from "react-icons/bs";
 
 import token from "../lib/token";
@@ -86,6 +87,7 @@ const UserMenu = (): React.ReactElement => {
   const openLoginModal = useLoginModalStore((s) => s.open);
   const openChangePasswordModal = useChangePasswordModalStore((s) => s.open);
   const setUser = useUserStore((s) => s.setUser);
+  const queryClient = useQueryClient();
 
   const [isOpen, setIsOpen] = React.useState(false);
   const rootRef = React.useRef<HTMLDivElement>(null);
@@ -111,12 +113,19 @@ const UserMenu = (): React.ReactElement => {
   const handleLogout = () => {
     setIsOpen(false);
     // Order matters: clear the bearer before `setUser` so the React
-    // re-render's queries don't fire with the just-revoked token. Same
-    // sequence as `Logout.tsx`. localStorage is narrowed to the `user`
-    // key so the `lang` preference survives.
+    // re-render's queries don't fire with the just-revoked token.
+    // localStorage is narrowed to the `user` key so the `lang`
+    // preference survives.
     token.clearToken();
     window.localStorage.removeItem("user");
     setUser(undefined);
+    // Drop the access-derived caches under the previous user key so the
+    // re-render fetches the new (guest) view instead of leaving the
+    // previous identity's data on screen — galleries dropdown / map
+    // visibility / per-photo coords. This was on the deleted Logout.tsx
+    // and got lost when UserMenu inlined the logout handler in #182.
+    queryClient.invalidateQueries({ queryKey: ["galleries"] });
+    queryClient.invalidateQueries({ queryKey: ["gallery-photos"] });
   };
 
   if (!user) {


### PR DESCRIPTION
## Problem

After 0.9 shipped, logging out via the profile-icon `UserMenu` no longer refreshes access-derived state — the gallery list, map visibility, and per-photo coordinates keep showing the previous identity's view until a manual page reload or a navigation that changes `galleryId`.

## Root cause

#244 originally fixed this in `Logout.tsx` by calling
```ts
queryClient.invalidateQueries({ queryKey: ["galleries"] });
queryClient.invalidateQueries({ queryKey: ["gallery-photos"] });
```
after clearing token / localStorage / user.

#182 then deleted `Logout.tsx` and inlined the logout flow into `UserMenu.tsx`'s `handleLogout` (the new profile-icon dropdown's "Log out" item). The inlining lost the `invalidateQueries` calls.

`Login.tsx` still has them — that direction of the toggle works. Only logout regressed.

## Fix

Add `useQueryClient` import to `UserMenu.tsx`, restore the two `invalidateQueries` calls after the existing `token.clearToken()` / `localStorage.removeItem("user")` / `setUser(undefined)` sequence.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test --run` — 958/958 pass
- [x] Browser smoke: log in as a user with broader access for a gallery whose guest view has `hideMap=1`, navigate to that gallery, map should appear. Log out via the profile-icon dropdown: map should disappear (or the gallery should drop out of the list) without any manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)