### PR TITLE
Prepare for v0.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-23
+
+### Fixed
+
+- Logging out via the profile-icon `UserMenu` no longer leaves the previous identity's access-derived state on screen (gallery list, map visibility, per-photo coordinates). The `queryClient.invalidateQueries` calls #244 added to the original `Logout.tsx` got lost when #182 deleted that file and inlined the logout flow into `UserMenu.handleLogout`; restored.
+
 ## [0.9.0] - 2026-05-23
 
 ### Server

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.8.0/                                #   each version unpacked into its own subdir
-  0.9.0/                                #   so different instances can run different versions
+  0.9.1/                                #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/0.9.0      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/0.9.1      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  display/  thumbnail/
@@ -91,7 +91,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.9.0
+V=0.9.1
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -106,7 +106,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.9.0/bin/instance.ts dailybw
+/opt/photo-diary/0.9.1/bin/instance.ts dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The script can be invoked from any working directory; the instance dir is derived from the name (and the `--base <dir>` flag, default `/var/photo-diary`, if you want instances under a different parent). Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -134,7 +134,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.9.0/bin/instance.ts dailybw          # backs up the DB, flips the symlink
+/opt/photo-diary/0.9.1/bin/instance.ts dailybw          # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                    # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                         # migration runner applies any schema bumps

--- a/converter/package.json
+++ b/converter/package.json
@@ -34,5 +34,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4"
   },
-  "version": "0.9.0"
+  "version": "0.9.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -19,7 +19,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -12345,7 +12345,7 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -12671,7 +12671,7 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -64,5 +64,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.9.0"
+  "version": "0.9.1"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.9.0"
+    "version": "0.9.1"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -54,5 +54,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.9.0"
+  "version": "0.9.1"
 }


### PR DESCRIPTION
## Summary

Patch release for the logout-stale-cache regression that shipped in 0.9.0. PR #259 just landed the one-component fix; this PR is the release-prep around it.

- All four `package.json`s bumped 0.9.0 → 0.9.1 via `npm run version:sync`. `server/openapi.json` regenerated for the embedded `info.version`.
- `CHANGELOG.md`: `[Unreleased]` block becomes `[0.9.1] - 2026-05-23` with a single `### Fixed` bullet pointing at the regression and explaining how it slipped through the 0.9 refactor.
- `README.md`: install-command examples shift 0.9.0 → 0.9.1.

## What's in 0.9.1

Just the one fix:

> Logging out via the profile-icon `UserMenu` no longer leaves the previous identity's access-derived state on screen (gallery list, map visibility, per-photo coordinates). The `queryClient.invalidateQueries` calls #244 added to the original `Logout.tsx` got lost when #182 deleted that file and inlined the logout flow into `UserMenu.handleLogout`; restored.

## Test plan

- [x] `npx tsc --noEmit` across all three workspaces — clean
- [x] `npm run lint` across all three workspaces — clean
- [x] `npm test --workspaces` — 619 server + 958 react-app + 60 converter pass
- [x] All `package.json`s at 0.9.1
- [ ] After merge: `git tag v0.9.1 && git push origin v0.9.1` + GH release with the 0.9.1 CHANGELOG section as the body

🤖 Generated with [Claude Code](https://claude.com/claude-code)