### PR TITLE
docs(README): link two live example galleries near the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Photo Diary** is a calendar-based photo gallery platform for self-hosting. The photos are arranged by the date they were shot, in calendar-based views, aimed at diaries and other, date-based photography projects.
 
+Live examples: [dailybw.misaki.fi](https://dailybw.misaki.fi) and [papusama.misaki.fi](https://papusama.misaki.fi).
+
 Key features include:
 
 - Calendar-based views (year, month, day, photo)


### PR DESCRIPTION
## Summary

- Add a one-line "Live examples" pointer to [dailybw.misaki.fi](https://dailybw.misaki.fi) and [papusama.misaki.fi](https://papusama.misaki.fi) right under the project description, so anyone landing on the repo can see what a running Photo Diary actually looks like before reading any setup docs.

## Test plan

- [x] Markdown renders the two links inline; both URLs resolve to live instances.