### PR TITLE
Ship more built-in themes + theme manifest + theme-aware chrome (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Frontend
 
 - Merge the standalone Day view into Month — navigating to `/g/<gallery>/<year>/<month>/<day>` now renders the whole Month with that day's `DayTitle` highlighted and scrolled into view, rather than a dedicated per-day page. Shared/bookmarked day URLs still work; the calendar hierarchy collapses from Year → Month → Day → Photo to Year → Month → Photo, matching how Photo's up-nav already skipped the Day view.
+- Ship six new built-in themes alongside the existing five: `dark` (true dark mode), `amoled` (pure-black background for OLED screens), `sepia` (warm cream + sepia-filtered photos for a vintage feel), `forest` (earthy green), `silver` (cool slate-gray), and `showcase` (museum-wall dark backdrop with muted chrome so the photos pop). Themes are picked via `DEFAULT_THEME` in `.env` or per-gallery `theme` column on the `gallery` row.
 
 ## [0.9.1] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Frontend
 
 - Merge the standalone Day view into Month — navigating to `/g/<gallery>/<year>/<month>/<day>` now renders the whole Month with that day's `DayTitle` highlighted and scrolled into view, rather than a dedicated per-day page. Shared/bookmarked day URLs still work; the calendar hierarchy collapses from Year → Month → Day → Photo to Year → Month → Photo, matching how Photo's up-nav already skipped the Day view.
-- Ship six new built-in themes alongside the existing five: `dark` (true dark mode), `amoled` (pure-black background for OLED screens), `sepia` (warm cream + sepia-filtered photos for a vintage feel), `forest` (earthy green), `silver` (cool slate-gray), and `showcase` (museum-wall dark backdrop with muted chrome so the photos pop). Themes are picked via `DEFAULT_THEME` in `.env` or per-gallery `theme` column on the `gallery` row.
+- Ship seven new built-in themes (`dark`, `amoled`, `forest`, `silver`, `showcase`, `teal`, `paper`) and repurpose `bw` from a monochrome-filter theme into a true high-contrast light theme. Highlights: `dark`/`amoled` fill the long-standing dark-mode gap, `showcase` is a museum-wall dark backdrop with muted chrome so the photos pop, `paper` is the warm-cream printed-album feel without the desaturation the previous `sepia` variant carried. Photo frame (matte + border) and the gallery/stats `<select>` text are now theme-aware. Themes are picked via `DEFAULT_THEME` in `.env` or per-gallery `theme` column on the `gallery` row.
 
 ## [0.9.1] - 2026-05-23
 

--- a/react-app/src/components/Gallery/Photo/Content.tsx
+++ b/react-app/src/components/Gallery/Photo/Content.tsx
@@ -19,9 +19,9 @@ const Root = styled.div`
 const Frame = styled("span", {
   shouldForwardProp: (prop) => prop !== "$width" && prop !== "$height",
 })<{ $width: number; $height: number }>`
-  border: solid var(--primary-color) 1px;
+  border: solid var(--photo-frame-border) 1px;
   padding: 10px;
-  background-color: var(--inactive-color);
+  background-color: var(--photo-frame-mat);
   flex-grow: 0;
   flex-shrink: 0;
   width: ${(props) => props.$width}px;

--- a/react-app/src/components/Gallery/Photo/Content.tsx
+++ b/react-app/src/components/Gallery/Photo/Content.tsx
@@ -19,9 +19,9 @@ const Root = styled.div`
 const Frame = styled("span", {
   shouldForwardProp: (prop) => prop !== "$width" && prop !== "$height",
 })<{ $width: number; $height: number }>`
-  border: solid #004 1px;
+  border: solid var(--primary-color) 1px;
   padding: 10px;
-  background-color: #bbb;
+  background-color: var(--inactive-color);
   flex-grow: 0;
   flex-shrink: 0;
   width: ${(props) => props.$width}px;

--- a/react-app/src/components/Gallery/Photo/Footer.tsx
+++ b/react-app/src/components/Gallery/Photo/Footer.tsx
@@ -33,7 +33,7 @@ const NextThumbnailContainer = styled(ThumbnailContainer)`
 const ThumbnailFrame = styled.div`
   margin: 0;
   padding: 2px;
-  border: solid #004 1px;
+  border: solid var(--primary-color) 1px;
 `;
 const Description = styled.span`
   flex-grow: 1;

--- a/react-app/src/components/Gallery/Photo/Footer.tsx
+++ b/react-app/src/components/Gallery/Photo/Footer.tsx
@@ -33,7 +33,7 @@ const NextThumbnailContainer = styled(ThumbnailContainer)`
 const ThumbnailFrame = styled.div`
   margin: 0;
   padding: 2px;
-  border: solid var(--primary-color) 1px;
+  border: solid var(--photo-frame-border) 1px;
 `;
 const Description = styled.span`
   flex-grow: 1;

--- a/react-app/src/components/Gallery/Thumbnail.tsx
+++ b/react-app/src/components/Gallery/Thumbnail.tsx
@@ -17,14 +17,14 @@ interface CountryData {
 const Root = styled.div`
   height: 212px;
   margin: 1px;
-  background-color: #bbb;
+  background-color: var(--inactive-color);
   text-align: left;
 `;
 const TN = styled.span`
   display: block;
   background-repeat: no-repeat;
   background-position: 5px 5px;
-  border: solid #004 1px;
+  border: solid var(--primary-color) 1px;
   margin: 0;
   padding: 0;
   text-align: left;

--- a/react-app/src/components/Gallery/Thumbnail.tsx
+++ b/react-app/src/components/Gallery/Thumbnail.tsx
@@ -17,14 +17,14 @@ interface CountryData {
 const Root = styled.div`
   height: 212px;
   margin: 1px;
-  background-color: var(--inactive-color);
+  background-color: var(--photo-frame-mat);
   text-align: left;
 `;
 const TN = styled.span`
   display: block;
   background-repeat: no-repeat;
   background-position: 5px 5px;
-  border: solid var(--primary-color) 1px;
+  border: solid var(--photo-frame-border) 1px;
   margin: 0;
   padding: 0;
   text-align: left;

--- a/react-app/src/components/Gallery/Title.tsx
+++ b/react-app/src/components/Gallery/Title.tsx
@@ -18,12 +18,21 @@ const Root = styled.div`
 const MainTitle = styled.h1`
   margin: 0;
 `;
+// Explicit `color` because `background: none` lets the page background
+// through, but the browser default text colour stays black — unreadable
+// on dark themes. `option` rules style the native dropdown popup, which
+// otherwise renders with platform defaults that ignore the theme.
 const TitleSelect = styled.select`
   font-size: 1em;
   background: none;
   border: none;
   font-weight: bold;
   text-align-last: right;
+  color: var(--primary-color);
+  & option {
+    background: var(--primary-background);
+    color: var(--primary-color);
+  }
 `;
 const GallerySelect = styled(TitleSelect)`
   text-align-last: right;

--- a/react-app/src/components/Gallery/Year/Month.tsx
+++ b/react-app/src/components/Gallery/Year/Month.tsx
@@ -28,7 +28,7 @@ const Root = styled.div`
   border-style: solid;
   border-width: 1px;
   border-radius: 10px;
-  background-color: var(--header-color);
+  background-color: var(--tile-background);
   overflow: hidden;
 `;
 const MonthTitle = styled.h3`

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -62,6 +62,8 @@ const globalStyles = (theme: ActiveTheme) => css`
     --header-color: ${theme.get("header-color")};
     --header-sub-color: ${theme.get("header-sub-color")};
     --header-background: ${theme.get("header-background")};
+    --photo-frame-mat: ${theme.get("photo-frame-mat")};
+    --photo-frame-border: ${theme.get("photo-frame-border")};
     filter: ${theme.get("filter")};
   }
 `;

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -62,6 +62,7 @@ const globalStyles = (theme: ActiveTheme) => css`
     --header-color: ${theme.get("header-color")};
     --header-sub-color: ${theme.get("header-sub-color")};
     --header-background: ${theme.get("header-background")};
+    --tile-background: ${theme.get("tile-background")};
     --photo-frame-mat: ${theme.get("photo-frame-mat")};
     --photo-frame-border: ${theme.get("photo-frame-border")};
     filter: ${theme.get("filter")};

--- a/react-app/src/lib/theme.ts
+++ b/react-app/src/lib/theme.ts
@@ -19,6 +19,7 @@ type ThemeName =
 //   header-color         text on header bands (top menu, day-title column)
 //   header-sub-color     secondary text on header bands
 //   header-background    background of header bands
+//   tile-background      background of the Year view's month tiles (distinct from page bg so tiles read as cards)
 //   photo-frame-mat      matte colour around the photo (intentionally neutral, not theme-tinted)
 //   photo-frame-border   thin border between matte and photo (neutral)
 //   filter               CSS filter applied to the photos themselves (grayscale, sepia, ...)
@@ -29,6 +30,7 @@ type ThemeKey =
   | "header-color"
   | "header-sub-color"
   | "header-background"
+  | "tile-background"
   | "photo-frame-mat"
   | "photo-frame-border"
   | "filter";
@@ -55,6 +57,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#ddf",
     "header-background": "#004",
+    "tile-background": "#fff",
     ...FRAME_LIGHT,
     filter: "none",
   },
@@ -65,6 +68,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#f0e3e3",
     "header-background": "#4a1424",
+    "tile-background": "#fff",
     ...FRAME_LIGHT,
     filter: "none",
   },
@@ -75,6 +79,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#ddd",
     "header-background": "#444",
+    "tile-background": "#fff",
     ...FRAME_LIGHT,
     filter: "grayscale(100%)",
   },
@@ -88,6 +93,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#ddd",
     "header-background": "#000",
+    "tile-background": "#fff",
     ...FRAME_LIGHT,
     filter: "none",
   },
@@ -100,6 +106,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#ff6",
     "header-sub-color": "#ddd",
     "header-background": "#f00",
+    "tile-background": "#ff6",
     ...FRAME_LIGHT,
     filter: "none",
   },
@@ -110,6 +117,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#aaa",
     "header-background": "#2a2a2a",
+    "tile-background": "#2a2a2a",
     ...FRAME_DARK,
     filter: "none",
   },
@@ -120,6 +128,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#aaa",
     "header-background": "#000",
+    "tile-background": "#1a1a1a",
     ...FRAME_DARK,
     filter: "none",
   },
@@ -130,6 +139,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#e8f0e6",
     "header-background": "#1e3a2a",
+    "tile-background": "#fff",
     ...FRAME_LIGHT,
     filter: "none",
   },
@@ -141,6 +151,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#2a3540",
     "header-sub-color": "#6a7580",
     "header-background": "#d4dadf",
+    "tile-background": "#fff",
     ...FRAME_LIGHT,
     filter: "none",
   },
@@ -153,6 +164,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#888",
     "header-sub-color": "#666",
     "header-background": "#0a0a0a",
+    "tile-background": "#1f1f1f",
     ...FRAME_DARK,
     filter: "none",
   },
@@ -163,6 +175,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#e0eef0",
     "header-background": "#114040",
+    "tile-background": "#fff",
     ...FRAME_LIGHT,
     filter: "none",
   },
@@ -175,6 +188,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#3a2e20",
     "header-sub-color": "#8a7a60",
     "header-background": "#ece1ce",
+    "tile-background": "#fefaf0",
     ...FRAME_LIGHT,
     filter: "none",
   },

--- a/react-app/src/lib/theme.ts
+++ b/react-app/src/lib/theme.ts
@@ -6,15 +6,16 @@ type ThemeName =
   | "alert"
   | "dark"
   | "amoled"
-  | "sepia"
   | "forest"
   | "silver"
-  | "showcase";
+  | "showcase"
+  | "teal"
+  | "paper";
 
 // Theme variable roles:
-//   primary-color       main text / dark accents on light backgrounds
+//   primary-color       main text / dark accents on light backgrounds; also the photo-frame border colour
 //   primary-background  page background
-//   inactive-color      muted text and borders (disabled, weekday labels, etc)
+//   inactive-color      muted text and borders (disabled, weekday labels); also the photo-frame mat colour
 //   header-color        text on header bands (top menu, day-title column)
 //   header-sub-color    secondary text on header bands (weekday short labels under day numbers)
 //   header-background   background of header bands
@@ -40,12 +41,12 @@ const THEMES: Record<ThemeName, Theme> = {
     filter: "none",
   },
   red: {
-    "primary-color": "#400",
-    "primary-background": "#fdd",
-    "inactive-color": "#b99",
+    "primary-color": "#4a1424",
+    "primary-background": "#f0e3e3",
+    "inactive-color": "#b59a9a",
     "header-color": "#fff",
-    "header-sub-color": "#fdd",
-    "header-background": "#400",
+    "header-sub-color": "#f0e3e3",
+    "header-background": "#4a1424",
     filter: "none",
   },
   grayscale: {
@@ -57,15 +58,18 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-background": "#444",
     filter: "grayscale(100%)",
   },
+  // High-contrast light: pure black on white, no photo filter.
   bw: {
     "primary-color": "#000",
-    "primary-background": "#ddd",
-    "inactive-color": "#999",
+    "primary-background": "#fff",
+    "inactive-color": "#666",
     "header-color": "#fff",
     "header-sub-color": "#ddd",
     "header-background": "#000",
-    filter: "grayscale(100%)",
+    filter: "none",
   },
+  // Loud red-on-yellow surface used as a visibility flag for the `:private`
+  // gallery — see memory `alert-theme-purpose`. Not a generic style.
   alert: {
     "primary-color": "#f00",
     "primary-background": "#ff6",
@@ -93,15 +97,6 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-background": "#000",
     filter: "none",
   },
-  sepia: {
-    "primary-color": "#4a3a2a",
-    "primary-background": "#f5e6d3",
-    "inactive-color": "#b09a85",
-    "header-color": "#f5e6d3",
-    "header-sub-color": "#d4c4ad",
-    "header-background": "#4a3a2a",
-    filter: "sepia(80%)",
-  },
   forest: {
     "primary-color": "#1e3a2a",
     "primary-background": "#e8f0e6",
@@ -111,13 +106,15 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-background": "#1e3a2a",
     filter: "none",
   },
+  // Light overall: dark-text-on-light header for a lighter feel than the
+  // dark-header-with-white-text pattern other themes use.
   silver: {
-    "primary-color": "#2a3540",
+    "primary-color": "#3a4250",
     "primary-background": "#e8ebef",
     "inactive-color": "#8a95a0",
-    "header-color": "#fff",
-    "header-sub-color": "#e8ebef",
-    "header-background": "#2a3540",
+    "header-color": "#2a3540",
+    "header-sub-color": "#6a7580",
+    "header-background": "#d4dadf",
     filter: "none",
   },
   // Photo-focused: dark backdrop so photos read like prints on a museum
@@ -131,6 +128,26 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-background": "#0a0a0a",
     filter: "none",
   },
+  teal: {
+    "primary-color": "#114040",
+    "primary-background": "#e0eef0",
+    "inactive-color": "#80a0a0",
+    "header-color": "#fff",
+    "header-sub-color": "#e0eef0",
+    "header-background": "#114040",
+    filter: "none",
+  },
+  // Warm cream / printed-album feel without the photo-desaturation that
+  // sepia carried — the photos themselves stay unmodified.
+  paper: {
+    "primary-color": "#3a2e20",
+    "primary-background": "#f8f1e4",
+    "inactive-color": "#b8a890",
+    "header-color": "#f8f1e4",
+    "header-sub-color": "#d8c9b0",
+    "header-background": "#4a3a28",
+    filter: "none",
+  },
 };
 
 interface ThemeManifestEntry {
@@ -142,14 +159,15 @@ const MANIFEST: ThemeManifestEntry[] = [
   { id: "blue", displayName: "Blue" },
   { id: "red", displayName: "Red" },
   { id: "grayscale", displayName: "Grayscale" },
-  { id: "bw", displayName: "Black & White" },
+  { id: "bw", displayName: "High Contrast" },
   { id: "alert", displayName: "Alert" },
   { id: "dark", displayName: "Dark" },
   { id: "amoled", displayName: "AMOLED" },
-  { id: "sepia", displayName: "Sepia" },
   { id: "forest", displayName: "Forest" },
   { id: "silver", displayName: "Silver" },
   { id: "showcase", displayName: "Showcase" },
+  { id: "teal", displayName: "Teal" },
+  { id: "paper", displayName: "Paper" },
 ];
 
 const isThemeName = (name: string): name is ThemeName => name in THEMES;

--- a/react-app/src/lib/theme.ts
+++ b/react-app/src/lib/theme.ts
@@ -1,4 +1,24 @@
-type ThemeName = "blue" | "red" | "grayscale" | "bw" | "alert";
+type ThemeName =
+  | "blue"
+  | "red"
+  | "grayscale"
+  | "bw"
+  | "alert"
+  | "dark"
+  | "amoled"
+  | "sepia"
+  | "forest"
+  | "silver"
+  | "showcase";
+
+// Theme variable roles:
+//   primary-color       main text / dark accents on light backgrounds
+//   primary-background  page background
+//   inactive-color      muted text and borders (disabled, weekday labels, etc)
+//   header-color        text on header bands (top menu, day-title column)
+//   header-sub-color    secondary text on header bands (weekday short labels under day numbers)
+//   header-background   background of header bands
+//   filter              CSS filter applied to the photos themselves (grayscale, sepia, ...)
 type ThemeKey =
   | "primary-color"
   | "primary-background"
@@ -55,7 +75,82 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-background": "#f00",
     filter: "none",
   },
+  dark: {
+    "primary-color": "#e0e0e0",
+    "primary-background": "#1a1a1a",
+    "inactive-color": "#666",
+    "header-color": "#fff",
+    "header-sub-color": "#aaa",
+    "header-background": "#2a2a2a",
+    filter: "none",
+  },
+  amoled: {
+    "primary-color": "#fff",
+    "primary-background": "#000",
+    "inactive-color": "#555",
+    "header-color": "#fff",
+    "header-sub-color": "#aaa",
+    "header-background": "#000",
+    filter: "none",
+  },
+  sepia: {
+    "primary-color": "#4a3a2a",
+    "primary-background": "#f5e6d3",
+    "inactive-color": "#b09a85",
+    "header-color": "#f5e6d3",
+    "header-sub-color": "#d4c4ad",
+    "header-background": "#4a3a2a",
+    filter: "sepia(80%)",
+  },
+  forest: {
+    "primary-color": "#1e3a2a",
+    "primary-background": "#e8f0e6",
+    "inactive-color": "#8aa098",
+    "header-color": "#fff",
+    "header-sub-color": "#e8f0e6",
+    "header-background": "#1e3a2a",
+    filter: "none",
+  },
+  silver: {
+    "primary-color": "#2a3540",
+    "primary-background": "#e8ebef",
+    "inactive-color": "#8a95a0",
+    "header-color": "#fff",
+    "header-sub-color": "#e8ebef",
+    "header-background": "#2a3540",
+    filter: "none",
+  },
+  // Photo-focused: dark backdrop so photos read like prints on a museum
+  // wall, muted UI chrome so it doesn't compete.
+  showcase: {
+    "primary-color": "#ccc",
+    "primary-background": "#141414",
+    "inactive-color": "#555",
+    "header-color": "#888",
+    "header-sub-color": "#666",
+    "header-background": "#0a0a0a",
+    filter: "none",
+  },
 };
+
+interface ThemeManifestEntry {
+  id: ThemeName;
+  displayName: string;
+}
+
+const MANIFEST: ThemeManifestEntry[] = [
+  { id: "blue", displayName: "Blue" },
+  { id: "red", displayName: "Red" },
+  { id: "grayscale", displayName: "Grayscale" },
+  { id: "bw", displayName: "Black & White" },
+  { id: "alert", displayName: "Alert" },
+  { id: "dark", displayName: "Dark" },
+  { id: "amoled", displayName: "AMOLED" },
+  { id: "sepia", displayName: "Sepia" },
+  { id: "forest", displayName: "Forest" },
+  { id: "silver", displayName: "Silver" },
+  { id: "showcase", displayName: "Showcase" },
+];
 
 const isThemeName = (name: string): name is ThemeName => name in THEMES;
 const isThemeKey = (key: string): key is ThemeKey =>
@@ -74,4 +169,5 @@ const setTheme = (theme: string) => {
 
 export default {
   setTheme,
+  manifest: MANIFEST,
 };

--- a/react-app/src/lib/theme.ts
+++ b/react-app/src/lib/theme.ts
@@ -2,7 +2,7 @@ type ThemeName =
   | "blue"
   | "red"
   | "grayscale"
-  | "bw"
+  | "contrast"
   | "alert"
   | "dark"
   | "amoled"
@@ -13,13 +13,15 @@ type ThemeName =
   | "paper";
 
 // Theme variable roles:
-//   primary-color       main text / dark accents on light backgrounds; also the photo-frame border colour
-//   primary-background  page background
-//   inactive-color      muted text and borders (disabled, weekday labels); also the photo-frame mat colour
-//   header-color        text on header bands (top menu, day-title column)
-//   header-sub-color    secondary text on header bands (weekday short labels under day numbers)
-//   header-background   background of header bands
-//   filter              CSS filter applied to the photos themselves (grayscale, sepia, ...)
+//   primary-color        main text / dark accents
+//   primary-background   page background
+//   inactive-color       muted text and borders (disabled, weekday labels)
+//   header-color         text on header bands (top menu, day-title column)
+//   header-sub-color     secondary text on header bands
+//   header-background    background of header bands
+//   photo-frame-mat      matte colour around the photo (intentionally neutral, not theme-tinted)
+//   photo-frame-border   thin border between matte and photo (neutral)
+//   filter               CSS filter applied to the photos themselves (grayscale, sepia, ...)
 type ThemeKey =
   | "primary-color"
   | "primary-background"
@@ -27,8 +29,23 @@ type ThemeKey =
   | "header-color"
   | "header-sub-color"
   | "header-background"
+  | "photo-frame-mat"
+  | "photo-frame-border"
   | "filter";
 type Theme = Record<ThemeKey, string>;
+
+// Photo-frame variables are deliberately kept neutral (not tinted) so the
+// matte reads as a separator between the photo and the surrounding theme,
+// not as more theme chrome. Light themes share one neutral pair, dark
+// themes another.
+const FRAME_LIGHT = {
+  "photo-frame-mat": "#b0b0b0",
+  "photo-frame-border": "#444",
+} as const;
+const FRAME_DARK = {
+  "photo-frame-mat": "#555",
+  "photo-frame-border": "#aaa",
+} as const;
 
 const THEMES: Record<ThemeName, Theme> = {
   blue: {
@@ -38,6 +55,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#ddf",
     "header-background": "#004",
+    ...FRAME_LIGHT,
     filter: "none",
   },
   red: {
@@ -47,6 +65,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#f0e3e3",
     "header-background": "#4a1424",
+    ...FRAME_LIGHT,
     filter: "none",
   },
   grayscale: {
@@ -56,20 +75,24 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#ddd",
     "header-background": "#444",
+    ...FRAME_LIGHT,
     filter: "grayscale(100%)",
   },
-  // High-contrast light: pure black on white, no photo filter.
-  bw: {
+  // High-contrast light: pure black on white, no photo filter. Renamed
+  // from `bw` since the monochrome-photo filter is gone — too close to
+  // grayscale otherwise.
+  contrast: {
     "primary-color": "#000",
     "primary-background": "#fff",
     "inactive-color": "#666",
     "header-color": "#fff",
     "header-sub-color": "#ddd",
     "header-background": "#000",
+    ...FRAME_LIGHT,
     filter: "none",
   },
-  // Loud red-on-yellow surface used as a visibility flag for the `:private`
-  // gallery — see memory `alert-theme-purpose`. Not a generic style.
+  // Loud red-on-yellow surface used as a visibility flag for the
+  // `:private` gallery. Not a generic style — see project memory.
   alert: {
     "primary-color": "#f00",
     "primary-background": "#ff6",
@@ -77,6 +100,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#ff6",
     "header-sub-color": "#ddd",
     "header-background": "#f00",
+    ...FRAME_LIGHT,
     filter: "none",
   },
   dark: {
@@ -86,6 +110,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#aaa",
     "header-background": "#2a2a2a",
+    ...FRAME_DARK,
     filter: "none",
   },
   amoled: {
@@ -95,6 +120,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#aaa",
     "header-background": "#000",
+    ...FRAME_DARK,
     filter: "none",
   },
   forest: {
@@ -104,10 +130,10 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#e8f0e6",
     "header-background": "#1e3a2a",
+    ...FRAME_LIGHT,
     filter: "none",
   },
-  // Light overall: dark-text-on-light header for a lighter feel than the
-  // dark-header-with-white-text pattern other themes use.
+  // Light overall: dark-text-on-light header, no dark header band.
   silver: {
     "primary-color": "#3a4250",
     "primary-background": "#e8ebef",
@@ -115,6 +141,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#2a3540",
     "header-sub-color": "#6a7580",
     "header-background": "#d4dadf",
+    ...FRAME_LIGHT,
     filter: "none",
   },
   // Photo-focused: dark backdrop so photos read like prints on a museum
@@ -126,6 +153,7 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#888",
     "header-sub-color": "#666",
     "header-background": "#0a0a0a",
+    ...FRAME_DARK,
     filter: "none",
   },
   teal: {
@@ -135,17 +163,19 @@ const THEMES: Record<ThemeName, Theme> = {
     "header-color": "#fff",
     "header-sub-color": "#e0eef0",
     "header-background": "#114040",
+    ...FRAME_LIGHT,
     filter: "none",
   },
-  // Warm cream / printed-album feel without the photo-desaturation that
-  // sepia carried — the photos themselves stay unmodified.
+  // Creamy printed-album feel without the photo desaturation that sepia
+  // carried — page + header are both light cream, dark text reads on top.
   paper: {
     "primary-color": "#3a2e20",
-    "primary-background": "#f8f1e4",
+    "primary-background": "#faf4e8",
     "inactive-color": "#b8a890",
-    "header-color": "#f8f1e4",
-    "header-sub-color": "#d8c9b0",
-    "header-background": "#4a3a28",
+    "header-color": "#3a2e20",
+    "header-sub-color": "#8a7a60",
+    "header-background": "#ece1ce",
+    ...FRAME_LIGHT,
     filter: "none",
   },
 };
@@ -159,7 +189,7 @@ const MANIFEST: ThemeManifestEntry[] = [
   { id: "blue", displayName: "Blue" },
   { id: "red", displayName: "Red" },
   { id: "grayscale", displayName: "Grayscale" },
-  { id: "bw", displayName: "High Contrast" },
+  { id: "contrast", displayName: "High Contrast" },
   { id: "alert", displayName: "Alert" },
   { id: "dark", displayName: "Dark" },
   { id: "amoled", displayName: "AMOLED" },


### PR DESCRIPTION
## Summary

- **Seven new themes** alongside the existing five:
  - `dark` — true dark mode (was the long-standing gap)
  - `amoled` — pure-black backdrop for OLED screens
  - `forest` — earthy green color accent
  - `silver` — light slate-gray, dark-text-on-light header
  - `showcase` — museum-wall dark backdrop with muted chrome so the photos pop
  - `teal` — cool teal color accent
  - `paper` — creamy printed-album feel without photo desaturation
- **`bw` → `contrast`** (renamed). Repurposed from a `grayscale(100%)`-filter theme into a true high-contrast light theme. Display name "High Contrast".
- **`red` polished** — background toned away from pink (`#fdd` → `#f0e3e3`), header shifted from brown-red (`#400`) to burgundy/wine (`#4a1424`).
- **`MANIFEST` array** exports `{ id, displayName }` per theme so the upcoming admin theme selector (#287) can enumerate from a single source of truth.
- **Token-roles comment** at the top of `theme.ts` documents what each variable controls visually so a new theme author can pick colors without grepping every component.

## Theme-aware chrome (fixes exposed by the new dark themes)

The previous themes were all light, which masked several places where dark-theme support was missing:

- **Gallery + stats `<select>` elements in `Title.tsx`** — added explicit `color: var(--primary-color)` plus `& option { background; color }` so the native dropdown popup is theme-aware. Without these, dark themes rendered black-on-near-black selects (invisible).
- **Photo frame** (matte + border in `Thumbnail.tsx`, `Photo/Content.tsx`, `Photo/Footer.tsx`) — replaced hard-coded `#bbb` matte / `#004` border with two new theme variables `--photo-frame-mat` and `--photo-frame-border`. Light themes share `FRAME_LIGHT` (mat `#b0b0b0`, border `#444`); dark themes share `FRAME_DARK` (mat `#555`, border `#aaa`). Deliberately kept neutral across themes — the frame's job is to separate the photo from the surrounding theme, not to read as more theme chrome.
- **Year view month tile** in `Year/Month.tsx` was painting itself with `var(--header-color)`, which is the *text* colour. This worked accidentally for every theme whose header-color was white (most of them) but broke as soon as a theme inverted the header (paper's dark brown header-color made tiles render dark brown). Introduced `--tile-background` as a dedicated variable so each theme picks its tile colour explicitly.

## Token roles (audit)

Documented in `theme.ts` for future theme authors:

| Variable | What it controls |
|---|---|
| `--primary-color` | Main text and dark accents |
| `--primary-background` | Page background |
| `--inactive-color` | Muted text and borders (disabled, weekday labels) |
| `--header-color` | Text on header bands (top menu, day-title column) |
| `--header-sub-color` | Secondary text on header bands |
| `--header-background` | Background of header bands |
| `--tile-background` | Background of the Year view's month tiles |
| `--photo-frame-mat` | Matte colour around the photo (intentionally neutral) |
| `--photo-frame-border` | Thin border between matte and photo (neutral) |
| `filter` | CSS filter applied to the photos themselves |

## Test plan

- [x] `npm run typecheck --workspace=react-app` — clean.
- [x] `npm run test --workspace=react-app` — 958 tests pass.
- [x] `npm run build --workspace=react-app` — clean Vite build.
- [x] **Visual verification across all 12 themes** — paged through each one in dev (`dailybw` instance) by flipping `DEFAULT_THEME` in `dev/.env` and reloading. All shipping themes look coherent; the Year view month tile fix verified on paper and silver (the two affected by the previous `header-color`-as-background usage); photo frame verified neutral across teal/silver/dark themes (no theme tint).

## Note on the previously-considered `sepia` theme

Initially shipped as part of the first iteration; pulled during review after the operator's feedback that the warm tone read too yellow and the use case was too niche. The "warm vintage album" intent it served is now covered by `paper`, which keeps the cream feel without the `sepia(80%)` photo filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)