### PR TITLE
server tests: await the missing four getGalleryPhoto calls (#309)

### DIFF
--- a/server/tests/api/gallery-photos.test.ts
+++ b/server/tests/api/gallery-photos.test.ts
@@ -149,7 +149,7 @@ describe("As admin", () => {
       expect(result.body.id).toBe("gallery12photo.jpg");
     });
     test("Get gallery2photo.jpg", async () => {
-      getGalleryPhoto(token, "gallery1", "gallery2photo.jpg", 404);
+      await getGalleryPhoto(token, "gallery1", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
       await getGalleryPhoto(token, "gallery1", "orphanphoto.jpg", 404);
@@ -246,7 +246,7 @@ describe("As admin", () => {
   });
   describe("Gallery :private", () => {
     test("Get gallery1photo.jpg", async () => {
-      getGalleryPhoto(token, ":private", "gallery2photo.jpg", 404);
+      await getGalleryPhoto(token, ":private", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
       const result = await getGalleryPhoto(
@@ -391,7 +391,7 @@ describe("As gallery1Admin", () => {
   });
   describe("Gallery :private", () => {
     test("Get gallery1photo.jpg", async () => {
-      getGalleryPhoto(token, ":private", "gallery2photo.jpg", 404);
+      await getGalleryPhoto(token, ":private", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
       const result = await getGalleryPhoto(
@@ -637,7 +637,7 @@ describe("As plainUser", () => {
   });
   describe("Gallery :private", () => {
     test("Get gallery1photo.jpg", async () => {
-      getGalleryPhoto(token, ":private", "gallery2photo.jpg", 404);
+      await getGalleryPhoto(token, ":private", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
       const result = await getGalleryPhoto(


### PR DESCRIPTION
## Summary

Closes #309. Four \`getGalleryPhoto\` calls in \`server/tests/api/gallery-photos.test.ts\` (lines 152, 249, 394, 640) were missing \`await\`. The tests returned immediately while the supertest request was still in flight; CI's tighter timing made the lingering request occasionally race with the next test's \`init()\` or the suite's \`afterAll\` server close, surfacing as the intermittent \`ECONNRESET\` we hit on PR #303 and PR #308.

The four tests all assert a 404 status code and don't use the response body, which is why the missed \`await\` slipped past every local run.

## Test plan

- [x] CI runs cleanly on the same suite that intermittently failed before.
- [x] Local \`server/\` test suite still passes (619 tests, did pass on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)