### PR TITLE
Photo modal: stop Month scrolling under the modal during photo nav (#307)

### DIFF
--- a/react-app/src/components/Gallery/Month/Content.tsx
+++ b/react-app/src/components/Gallery/Month/Content.tsx
@@ -51,6 +51,7 @@ interface Props {
   day?: number;
   lang: string;
   countryData: CountryData;
+  modalActive?: boolean;
 }
 
 const Content = ({
@@ -61,19 +62,27 @@ const Content = ({
   day,
   lang,
   countryData,
+  modalActive,
 }: Props): React.ReactElement => {
   const { t } = useTranslation();
 
   // RAF defers past ScrollToPosition's setTimeout(0) — without that delay
-  // the parent's scroll restore fires last and undoes this jump.
+  // the parent's scroll restore fires last and undoes this jump. While
+  // the Photo modal is mounted on top, fire only once (the initial mount
+  // — so closing a direct-link photo URL lands on the right day) and
+  // skip subsequent day-prop changes triggered by in-modal photo
+  // navigation, which otherwise visibly scroll Month under the modal.
+  const hasScrolledRef = React.useRef(false);
   React.useEffect(() => {
     if (!day) return;
+    if (modalActive && hasScrolledRef.current) return;
+    hasScrolledRef.current = true;
     const handle = requestAnimationFrame(() => {
       const el = document.getElementById(`month-day-${day}`);
       el?.scrollIntoView({ behavior: "smooth", block: "start" });
     });
     return () => cancelAnimationFrame(handle);
-  }, [day, year, month]);
+  }, [day, year, month, modalActive]);
 
   if (!gallery.includesMonth(year, month)) {
     return (

--- a/react-app/src/components/Gallery/Month/index.tsx
+++ b/react-app/src/components/Gallery/Month/index.tsx
@@ -25,6 +25,10 @@ interface Props {
   day?: number;
   lang: string;
   countryData: CountryData;
+  // True when the Photo modal is mounted on top — suppresses the
+  // scroll-to-day on subsequent day changes so the Month doesn't
+  // visibly scroll under the modal during in-modal navigation.
+  modalActive?: boolean;
 }
 
 const Month = ({
@@ -35,6 +39,7 @@ const Month = ({
   day,
   lang,
   countryData,
+  modalActive,
 }: Props): React.ReactElement => {
   const [redirect, setRedirect] = React.useState<string | undefined>(undefined);
 
@@ -113,6 +118,7 @@ const Month = ({
           day={day}
           lang={lang}
           countryData={countryData}
+          modalActive={modalActive}
         >
           {children}
         </Content>

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -449,6 +449,7 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
           day={day || undefined}
           lang={lang}
           countryData={countryData}
+          modalActive
         >
           <Title
             galleries={galleries}


### PR DESCRIPTION
## Summary

Closes #307. The body-scroll lock from #308 froze the document's scroll position, but Month's own \`scrollIntoView\` (in \`Month/Content.tsx\`) still fired on every \`day\`-prop change. Each in-modal prev/next changed the day segment in the URL, Month received the new day, and the smooth-scroll animated the page under the scrim.

Gate the scroll-to-day useEffect with a new \`modalActive\` prop threaded \`Gallery/index.tsx\` → \`Month\` → \`Content\`:

- A \`hasScrolledRef\` lets the effect fire once on initial mount (so a direct-link photo URL still scrolls the underlying Month to the right day, which the user lands on when closing the modal).
- Subsequent \`day\`-prop changes while \`modalActive\` is true are skipped — Month stays put under the modal.
- When the modal is closed (Photo URL → Month URL), \`modalActive\` becomes false; if \`day\` changes from inside Month later (e.g. user clicks a day from Year view), the scroll fires as before.

## Test plan

- [x] Open a photo from Month (any day). Scroll through several photos with prev/next or swipe — Month underneath does not visibly scroll.
- [x] Photos across day boundaries also don't trigger the scroll.
- [ ] Direct-link photo URL (e.g. paste \`/g/...year/month/day/photo-id\` into a fresh tab): Month underneath the modal scrolls to the right day on initial mount; closing the modal lands on the highlighted day.
- [ ] Close modal then re-open with a different photo (different day): Month re-mounts and scrolls to the new day on the fresh modal open. Subsequent navigation still doesn't move Month.
- [x] Normal Month navigation outside the modal (clicking a day in the Year view) still smooth-scrolls to that day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)