### PR TITLE
Stats modals: scroll lock + backdrop covers reserved gutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Gallery Title bar carries a clickable breadcrumb path (`🏠 › Gallery › 2024 › March › #1234`); the Navigation bar below reorganises into left/right control groups. (closes #275)
 - Stats inline map collapses into a Location card in the General topic that opens the full map in a modal on demand; the inline 800px-tall map is gone, Leaflet stays lazy-loaded until the modal is opened, and the page reserves the scrollbar gutter so the modal lock no longer reflows underlying content. (part of #278)
 - Stats `TableModal` and `SummaryModal` now lock body scroll while open so the underlying stats grid no longer drifts behind the modal — matches the Photo modal and the new MapModal from #278.
+- Modal backdrops (Photo / Stats Table / Stats Summary / Stats Map) extend across the reserved scrollbar gutter so the dark scrim covers the full viewport — `inset: 0` alone left a ~15px light strip on the right once `scrollbar-gutter: stable` reserved that area.
 - Stats category tables cap at 10 rows inline (top 10 by count) with the full distribution one click away in a floating modal — click the title or the trailing "+ N more…" row to open it.
 - Stats inline tables always sort by count desc so every category reads as a "top N"; the natural order is still available in the expanded modal.
 - Stats expanded-table modal gains a `Top` / `By value` sort toggle on every data category, defaulting to `Top` to match the inline view.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Gallery Title bar carries a clickable breadcrumb path (`🏠 › Gallery › 2024 › March › #1234`); the Navigation bar below reorganises into left/right control groups. (closes #275)
 - Stats inline map collapses into a Location card in the General topic that opens the full map in a modal on demand; the inline 800px-tall map is gone, Leaflet stays lazy-loaded until the modal is opened, and the page reserves the scrollbar gutter so the modal lock no longer reflows underlying content. (part of #278)
 - Stats `TableModal` and `SummaryModal` now lock body scroll while open so the underlying stats grid no longer drifts behind the modal — matches the Photo modal and the new MapModal from #278.
-- Modal backdrops (Photo / Stats Table / Stats Summary / Stats Map) extend across the reserved scrollbar gutter so the dark scrim covers the full viewport — `inset: 0` alone left a ~15px light strip on the right once `scrollbar-gutter: stable` reserved that area.
+- Unified the modal scroll-lock into a `useBodyScrollLock` hook (Photo / Stats Map / Stats Table / Stats Summary): locks `body.overflow` and pads `body.padding-right` by the measured scrollbar width so the layout doesn't reflow and the backdrop covers the full viewport including the scrollbar-gutter area.
 - Stats category tables cap at 10 rows inline (top 10 by count) with the full distribution one click away in a floating modal — click the title or the trailing "+ N more…" row to open it.
 - Stats inline tables always sort by count desc so every category reads as a "top N"; the natural order is still available in the expanded modal.
 - Stats expanded-table modal gains a `Top` / `By value` sort toggle on every data category, defaulting to `Top` to match the inline view.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Photo view gains controlled zoom — mouse-wheel and `+` / `=` / `-` / `0` keys to zoom (clamped 1×–8×), drag to pan when zoomed past fit; swipe-nav is suppressed while zoomed. (closes #277)
 - Gallery Title bar carries a clickable breadcrumb path (`🏠 › Gallery › 2024 › March › #1234`); the Navigation bar below reorganises into left/right control groups. (closes #275)
 - Stats inline map collapses into a Location card in the General topic that opens the full map in a modal on demand; the inline 800px-tall map is gone, Leaflet stays lazy-loaded until the modal is opened, and the page reserves the scrollbar gutter so the modal lock no longer reflows underlying content. (part of #278)
+- Stats `TableModal` and `SummaryModal` now lock body scroll while open so the underlying stats grid no longer drifts behind the modal — matches the Photo modal and the new MapModal from #278.
 - Stats category tables cap at 10 rows inline (top 10 by count) with the full distribution one click away in a floating modal — click the title or the trailing "+ N more…" row to open it.
 - Stats inline tables always sort by count desc so every category reads as a "top N"; the natural order is still available in the expanded modal.
 - Stats expanded-table modal gains a `Top` / `By value` sort toggle on every data category, defaulting to `Top` to match the inline view.

--- a/react-app/src/App.css
+++ b/react-app/src/App.css
@@ -1,8 +1,4 @@
 html {
-  /* Reserve the scrollbar gutter so locking body overflow (Photo + Stats
-     modals) doesn't reflow the underlying content ~15px wider. */
-  scrollbar-gutter: stable;
-
   --primary-color: #000;
   --primary-background: #ddd;
   --inactive-color: #999;

--- a/react-app/src/components/Gallery/Photo/index.tsx
+++ b/react-app/src/components/Gallery/Photo/index.tsx
@@ -45,6 +45,10 @@ interface Props {
 const Backdrop = styled.div`
   position: fixed;
   inset: 0;
+  /* 100vw / 100dvh so the scrim covers the reserved scrollbar gutter
+     (scrollbar-gutter: stable on html) — inset: 0 alone leaves a ~15px
+     uncovered strip on the right while body overflow is locked. */
+  width: 100vw;
   height: 100dvh;
   box-sizing: border-box;
   z-index: 1000;

--- a/react-app/src/components/Gallery/Photo/index.tsx
+++ b/react-app/src/components/Gallery/Photo/index.tsx
@@ -17,6 +17,7 @@ import Content from "./Content";
 import MetadataPanel from "./MetadataPanel";
 
 import useKeyPress from "../../../lib/keypress";
+import { useBodyScrollLock } from "../../../lib/useBodyScrollLock";
 
 import type { Gallery } from "../../../models/GalleryModel";
 import type { Photo as PhotoT } from "../../../models/PhotoModel";
@@ -45,10 +46,6 @@ interface Props {
 const Backdrop = styled.div`
   position: fixed;
   inset: 0;
-  /* 100vw / 100dvh so the scrim covers the reserved scrollbar gutter
-     (scrollbar-gutter: stable on html) — inset: 0 alone leaves a ~15px
-     uncovered strip on the right while body overflow is locked. */
-  width: 100vw;
   height: 100dvh;
   box-sizing: border-box;
   z-index: 1000;
@@ -182,13 +179,7 @@ const Photo = ({
   );
 
   // Freeze the Month underneath while the modal is open.
-  React.useEffect(() => {
-    const previous = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = previous;
-    };
-  }, []);
+  useBodyScrollLock();
 
   const { t } = useTranslation();
 

--- a/react-app/src/components/Gallery/Stats/MapModal.tsx
+++ b/react-app/src/components/Gallery/Stats/MapModal.tsx
@@ -9,6 +9,8 @@ import type { Photo } from "../../../models/PhotoModel";
 const Backdrop = styled.div`
   position: fixed;
   inset: 0;
+  width: 100vw;
+  height: 100dvh;
   background: rgba(0, 0, 0, 0.55);
   z-index: 2000;
   display: flex;

--- a/react-app/src/components/Gallery/Stats/MapModal.tsx
+++ b/react-app/src/components/Gallery/Stats/MapModal.tsx
@@ -4,13 +4,12 @@ import { useTranslation } from "react-i18next";
 
 import MapContainer from "../../MapContainer.lazy";
 
+import { useBodyScrollLock } from "../../../lib/useBodyScrollLock";
 import type { Photo } from "../../../models/PhotoModel";
 
 const Backdrop = styled.div`
   position: fixed;
   inset: 0;
-  width: 100vw;
-  height: 100dvh;
   background: rgba(0, 0, 0, 0.55);
   z-index: 2000;
   display: flex;
@@ -75,15 +74,7 @@ const MapModal = ({ title, photos, onClose }: Props): React.ReactElement => {
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  // Freeze the Stats scroll underneath while the modal is open — the map
-  // is large enough that the underlying page sliding behind it is jarring.
-  React.useEffect(() => {
-    const previous = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = previous;
-    };
-  }, []);
+  useBodyScrollLock();
 
   const onBackdropClick = (event: React.MouseEvent) => {
     if (event.target === event.currentTarget) onClose();

--- a/react-app/src/components/Gallery/Stats/SummaryModal.tsx
+++ b/react-app/src/components/Gallery/Stats/SummaryModal.tsx
@@ -161,6 +161,14 @@ const SummaryModal = ({
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
+  React.useEffect(() => {
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, []);
+
   const extras = category.summaryExtras;
   if (!extras) return null;
 

--- a/react-app/src/components/Gallery/Stats/SummaryModal.tsx
+++ b/react-app/src/components/Gallery/Stats/SummaryModal.tsx
@@ -17,6 +17,8 @@ interface CountryData {
 const Backdrop = styled.div`
   position: fixed;
   inset: 0;
+  width: 100vw;
+  height: 100dvh;
   background: rgba(0, 0, 0, 0.55);
   z-index: 2000;
   display: flex;

--- a/react-app/src/components/Gallery/Stats/SummaryModal.tsx
+++ b/react-app/src/components/Gallery/Stats/SummaryModal.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
 
 import format from "../../../lib/format";
+import { useBodyScrollLock } from "../../../lib/useBodyScrollLock";
 import type {
   PeakShape,
   StatsCategory,
@@ -17,8 +18,6 @@ interface CountryData {
 const Backdrop = styled.div`
   position: fixed;
   inset: 0;
-  width: 100vw;
-  height: 100dvh;
   background: rgba(0, 0, 0, 0.55);
   z-index: 2000;
   display: flex;
@@ -163,13 +162,7 @@ const SummaryModal = ({
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  React.useEffect(() => {
-    const previous = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = previous;
-    };
-  }, []);
+  useBodyScrollLock();
 
   const extras = category.summaryExtras;
   if (!extras) return null;

--- a/react-app/src/components/Gallery/Stats/TableModal.tsx
+++ b/react-app/src/components/Gallery/Stats/TableModal.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import Charts from "./Charts";
 import Table from "./Table";
 
+import { useBodyScrollLock } from "../../../lib/useBodyScrollLock";
 import type { Filters as FiltersT } from "../../../lib/filter";
 import type { StatsTopic, StatsCategory, SortMode } from "../../../lib/stats";
 
@@ -13,8 +14,6 @@ type ActiveTheme = { get: (name: string) => string };
 const Backdrop = styled.div`
   position: fixed;
   inset: 0;
-  width: 100vw;
-  height: 100dvh;
   background: rgba(0, 0, 0, 0.55);
   z-index: 2000;
   display: flex;
@@ -126,13 +125,7 @@ const TableModal = ({
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  React.useEffect(() => {
-    const previous = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = previous;
-    };
-  }, []);
+  useBodyScrollLock();
 
   const onBackdropClick = (event: React.MouseEvent) => {
     if (event.target === event.currentTarget) onClose();

--- a/react-app/src/components/Gallery/Stats/TableModal.tsx
+++ b/react-app/src/components/Gallery/Stats/TableModal.tsx
@@ -124,6 +124,14 @@ const TableModal = ({
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
 
+  React.useEffect(() => {
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, []);
+
   const onBackdropClick = (event: React.MouseEvent) => {
     if (event.target === event.currentTarget) onClose();
   };

--- a/react-app/src/components/Gallery/Stats/TableModal.tsx
+++ b/react-app/src/components/Gallery/Stats/TableModal.tsx
@@ -13,6 +13,8 @@ type ActiveTheme = { get: (name: string) => string };
 const Backdrop = styled.div`
   position: fixed;
   inset: 0;
+  width: 100vw;
+  height: 100dvh;
   background: rgba(0, 0, 0, 0.55);
   z-index: 2000;
   display: flex;

--- a/react-app/src/lib/useBodyScrollLock.ts
+++ b/react-app/src/lib/useBodyScrollLock.ts
@@ -1,0 +1,21 @@
+import React from "react";
+
+// Lock body scroll while the caller is mounted. Pads body's padding-right
+// by the measured scrollbar width so the layout doesn't reflow ~15px when
+// the scrollbar disappears under the lock.
+export const useBodyScrollLock = (): void => {
+  React.useEffect(() => {
+    const previousOverflow = document.body.style.overflow;
+    const previousPaddingRight = document.body.style.paddingRight;
+    const scrollbarWidth =
+      window.innerWidth - document.documentElement.clientWidth;
+    document.body.style.overflow = "hidden";
+    if (scrollbarWidth > 0) {
+      document.body.style.paddingRight = `${scrollbarWidth}px`;
+    }
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.body.style.paddingRight = previousPaddingRight;
+    };
+  }, []);
+};


### PR DESCRIPTION
Follow-up to #278.

## Summary

Two related fixes for the Stats modal experience after #278 landed, both routed through a new shared `useBodyScrollLock` hook.

**1. Scroll lock on `TableModal` and `SummaryModal`.** Both modals previously let the page underneath stay scrollable while open. That was tolerable before, more visible now that the new `MapModal` from #278 covers a larger portion of the viewport and trains the eye on "modal = focused view". Both now lock body scroll.

**2. Backdrops cover the full viewport.** The `scrollbar-gutter: stable` rule introduced in #278 left a side effect: the modal Backdrop (`position: fixed; inset: 0`) stopped at the body's narrower width and left a ~15px light strip on the right. Chromium resolves `100vw` to the scrollport (body's narrower width) when html reserves a gutter, so the `width: 100vw` workaround tried mid-PR didn't help either.

The standard fix: switch from `scrollbar-gutter: stable` to a JS-measured `padding-right` on body during the lock. The new `useBodyScrollLock` hook (`react-app/src/lib/useBodyScrollLock.ts`) sets `body.overflow = "hidden"` and `body.padding-right = <measured scrollbar width>`. Body now spans the full viewport during the lock; padding-right keeps the content edge in the same place, so no reflow. `position: fixed; inset: 0` on every Backdrop now covers the full viewport (1440px in my test), scrim included.

Photo modal, MapModal, TableModal, and SummaryModal all call the hook instead of duplicating the `body.style.overflow` toggle. `html { scrollbar-gutter: stable; }` is removed from `App.css`.

## Test plan

- [x] `npm run typecheck` (react-app) — clean.
- [x] `npm test` (react-app) — 963 passed.
- [x] Manual: at viewport 1440px, opened TableModal (Country), SummaryModal (Summary), MapModal (Location) in turn. All three lock body scroll; body padding-right toggles 0 → 15px → 0; body width 1425 → 1440 (with the padding) → 1425; Backdrop spans 0→1440; visual scrim covers all the way to the viewport edge.
- [x] Manual: opened the Photo modal — same hook now, same scrim behaviour.
- [x] Manual: Esc / backdrop click / ╳ all close cleanly; body styles restore.