### PR TITLE
build: bump Vite chunkSizeWarningLimit to silence the index-chunk note

### DIFF
--- a/react-app/vite.config.js
+++ b/react-app/vite.config.js
@@ -27,6 +27,13 @@ export default defineConfig({
   },
   build: {
     outDir: "build",
+    // Default warning trips at 500 kB; the index chunk now sits at ~505
+    // kB minified (158 kB gzip) because of unavoidable core deps
+    // (react-dom + react-router + i18next + tanstack-query). Bigger,
+    // optional deps (framer-motion, Leaflet, chart.js) are already in
+    // their own lazy chunks. Bump the threshold so the warning isn't
+    // noise on every build.
+    chunkSizeWarningLimit: 600,
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary

After #175 landed, the index chunk sits at **504.82 kB minified / 158.63 kB gzip** — just past Vite's default 500 kB warning threshold. Investigated the contents with `ANALYZE=1 npm run build`:

| Rendered | Package | In bundle |
|---|---|---|
| 448 kB | react-dom | unavoidable |
| 87 kB | react-router | unavoidable |
| 72 kB | i18next | unavoidable |
| 60 kB | @tanstack/query-core | unavoidable |
| 17.5 kB | i18n-iso-countries | flags |
| 14.7 kB | react-icons | tree-shaken |
| ≤ 12 kB each | various smaller deps | — |

framer-motion is correctly in the Photo chunk (137 kB minified, 44 kB gzip) and Leaflet is correctly in MapContainer (199 kB minified, 60 kB gzip) — neither is in the index. The 500-kB-plus index is just the core SPA dependencies; nothing in there is an obvious trim target without an architectural change (replacing i18next, swapping icon library, etc.).

Bump `build.chunkSizeWarningLimit` from the implicit 500 kB to 600 kB so every build stops printing the "Some chunks are larger than 500 kB after minification" warning. Bigger optional deps are already lazy-chunked, so this isn't hiding a real regression — it's silencing a threshold that no longer matches our actual baseline.

## Test plan

- [x] `npm run build` — produces the same chunk shapes (index 505 kB, Photo 137 kB, MapContainer 199 kB, Stats 224 kB) without the chunk-size warning.