### PR TITLE
Title-bar keyboard shortcuts: m (map), g (Gallery), s (Stats)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Stats summary KPIs (photos / average / years / months / days) move to a card-based grid — bordered tiles with icon, uppercase label, and prominent numeric value.
 - Stats topic title bar (vertical `General` / `Time` / `Gear` / `Exposure` labels) now extends to the full topic height on Firefox via CSS Grid (was clipped under flex).
 - Ship seven new built-in themes (`dark`, `amoled`, `forest`, `silver`, `showcase`, `teal`, `paper`) and convert `bw` from a monochrome-filter theme into a true high-contrast light theme; picked via `DEFAULT_THEME` in `.env` or the per-gallery `theme` column.
+- Title bar gains keyboard shortcuts: `m` toggles the map modal, `g` jumps to Gallery, `s` jumps to Stats — the `g` path honours the remembered last-gallery URL. Shortcuts skip when an input / select / textarea is focused so the gallery dropdown's native letter-search keeps working. (closes #327)
 
 ## [0.9.1] - 2026-05-23
 

--- a/react-app/src/components/Gallery/Title.tsx
+++ b/react-app/src/components/Gallery/Title.tsx
@@ -7,6 +7,7 @@ import { BsFillHouseFill, BsChevronRight, BsMap } from "react-icons/bs";
 import Link from "./Link";
 import MapModal from "../MapModal";
 
+import useKeyPress from "../../lib/keypress";
 import { useLastGalleryPathStore } from "../../stores";
 import type { Gallery } from "../../models/GalleryModel";
 import type { Photo } from "../../models/PhotoModel";
@@ -264,20 +265,27 @@ const Title = ({
     return <GalleryCrumb>{gallery.title()}</GalleryCrumb>;
   };
 
+  const switchTo = (target: string) => {
+    if (target === context) return;
+    // Stats → Gallery: prefer the remembered last-gallery URL for this
+    // gallery so the user lands back on the year/month/day they left
+    // from. Falls through to `getRedirectPath` if nothing's been
+    // remembered yet (first visit, or store reset).
+    if (target === "gallery") {
+      const remembered = lookupGalleryPath(gallery.id());
+      navigate(remembered ?? getRedirectPath(gallery, target));
+      return;
+    }
+    navigate(getRedirectPath(gallery, target));
+  };
+
+  useKeyPress("m", () => {
+    if (mapPhotos.length > 0) setMapOpen((o) => !o);
+  });
+  useKeyPress("g", () => switchTo("gallery"));
+  useKeyPress("s", () => switchTo("stats"));
+
   const renderContext = () => {
-    const switchTo = (target: string) => {
-      if (target === context) return;
-      // Stats → Gallery: prefer the remembered last-gallery URL for this
-      // gallery so the user lands back on the year/month/day they left
-      // from. Falls through to `getRedirectPath` if nothing's been
-      // remembered yet (first visit, or store reset).
-      if (target === "gallery") {
-        const remembered = lookupGalleryPath(gallery.id());
-        navigate(remembered ?? getRedirectPath(gallery, target));
-        return;
-      }
-      navigate(getRedirectPath(gallery, target));
-    };
     return (
       <ContextGroup
         role="group"
@@ -285,6 +293,7 @@ const Title = ({
       >
         {["gallery", "stats"].map((c) => {
           const active = c === context;
+          const shortcut = c === "gallery" ? "g" : "s";
           return (
             <ContextButton
               key={c}
@@ -292,6 +301,7 @@ const Title = ({
               $active={active}
               aria-pressed={active}
               onClick={() => switchTo(c)}
+              title={`${t(`nav-${c}`)} (${shortcut})`}
             >
               {t(`nav-${c}`)}
             </ContextButton>
@@ -362,6 +372,7 @@ const Title = ({
           type="button"
           onClick={() => setMapOpen(true)}
           aria-label={String(t("stats-location-see-on-map"))}
+          title={`${t("stats-location-see-on-map")} (m)`}
         >
           <BsMap />
         </MapButton>

--- a/react-app/src/lib/keypress.ts
+++ b/react-app/src/lib/keypress.ts
@@ -1,11 +1,27 @@
 import React from "react";
 
+// Skip when focus is on a form element so single-letter shortcuts (m,
+// g, s, i, …) don't swallow the gallery <select>'s native search-by-
+// letter or hijack future text inputs.
+const isFormFocus = (): boolean => {
+  const el = document.activeElement as HTMLElement | null;
+  if (!el) return false;
+  const tag = el.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "SELECT" ||
+    tag === "TEXTAREA" ||
+    el.isContentEditable
+  );
+};
+
 export default (
   targetKey: string,
   handler: (event: KeyboardEvent) => void
 ): void => {
   const downHandler = (event: KeyboardEvent) => {
     if (event.key === targetKey) {
+      if (isFormFocus()) return;
       event.preventDefault();
       if (typeof handler === "function") {
         handler(event);


### PR DESCRIPTION
## Summary

- `m` toggles the Title-bar map modal (no-op when `mapPhotos` is empty or the gallery has `hideMap`).
- `g` jumps to Gallery, `s` jumps to Stats. The `g` path honours the remembered last-gallery URL added in #316 so the round-trip from Stats lands back on the same year/month/day/photo the user left from.
- `useKeyPress` gains a focus guard: shortcuts are skipped when an `input`, `select`, `textarea`, or `contentEditable` element is active. Without this, `g` would swallow the gallery dropdown's native search-by-letter when the dropdown is focused.
- Buttons grow `title=` attributes ("Map (m)", "Gallery (g)", "Statistics (s)") so the shortcut is discoverable on hover. `aria-label` stays unchanged for screen readers.

The Title bar is rendered on every view (Year / Month / Photo / Stats), so the shortcuts are global. Pressing `g` while already on Gallery (or `s` while on Stats) is a no-op — mirrors the disabled-pill UX of the segmented control.

Closes #327.

## Test plan

- [x] `npm run typecheck`
- [x] Manual: press `m` on Month — map opens; press `m` again — closes.
- [x] Manual: from Month press `s` — lands on `/stats`; press `g` — returns to the same `/year/month` (remembered URL).
- [x] Manual: existing Photo modal `i`-to-toggle-info shortcut still works (regression check on the keypress hook).
- [x] Manual: with multi-gallery instance, focus the gallery `<select>` and type the first letter of a gallery name — native dropdown search still works (verifies the focus guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)