### PR TITLE
bin/meta.ts: operator script for the meta table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `bin/instance.ts` upgrade-mode output reorganises around the recommended path: a "Next — cycle pm2 …" heading with the command block, a single-line "Note:" caveat (down from four), a horizontal rule, then a "Rollback — ONLY if the steps above didn't work" block. New `--quiet` / `-q` flag suppresses informational output (errors and warnings still surface) for scripted re-runs; missing-key warnings now route to stderr where they belong. (closes #284)
 - New `bin/meta.ts` operator script (`list` / `get` / `set [--force]`) paralleling `bin/{user,gallery,photo,access}.ts` so the `meta` table can be read and written without `curl` against `/api/v1/meta` or raw SQL; unknown keys rejected by default, `schema_version` hard-blocked, per-instance `bin/meta.ts` symlink wired up via `bin/instance.ts`. (closes #269)
 - Drive-by fix in the sqlite3 driver's `metaMapToRow`, which produced empty SET clauses on `db.updateMeta` until the new `bin/meta.ts` exercised that path.
+- Pin yargs to `.locale("en")` across all operator scripts (`bin/instance.ts` + `server/bin/{meta,user,gallery,photo,access}.ts`) so a non-English shell locale (`LANG=ja_JP.UTF-8` etc.) no longer half-translates `--help` against fully-English status / error text.
 
 ## [0.10.0] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Tooling
 
 - `bin/instance.ts` upgrade-mode output reorganises around the recommended path: a "Next — cycle pm2 …" heading with the command block, a single-line "Note:" caveat (down from four), a horizontal rule, then a "Rollback — ONLY if the steps above didn't work" block. New `--quiet` / `-q` flag suppresses informational output (errors and warnings still surface) for scripted re-runs; missing-key warnings now route to stderr where they belong. (closes #284)
+- New `bin/meta.ts` operator script (`list` / `get` / `set [--force]`) paralleling `bin/{user,gallery,photo,access}.ts` so the `meta` table can be read and written without `curl` against `/api/v1/meta` or raw SQL; unknown keys rejected by default, `schema_version` hard-blocked, per-instance `bin/meta.ts` symlink wired up via `bin/instance.ts`. (closes #269)
+- Drive-by fix in the sqlite3 driver's `metaMapToRow`, which produced empty SET clauses on `db.updateMeta` until the new `bin/meta.ts` exercised that path.
 
 ## [0.10.0] - 2026-05-26
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,13 @@ Quickstart for a single personal instance. For the full production layout (multi
    ./bin/access.ts level <user> :all admin
    ```
 
-5. **Set the instance `cdn`** — the public URL that serves `display/` and `thumbnail/` (typically the same nginx host). Via the `/api/v1/meta` API or `UPDATE meta SET value='https://photos.example.com/' WHERE key='instance_cdn'`. This overrides the frontend's `/` default at runtime; the bundle itself ships no per-instance config.
+5. **Set the instance `cdn`** — the public URL that serves `display/` and `thumbnail/` (typically the same nginx host):
+
+   ```sh
+   ./bin/meta.ts set instance_cdn https://photos.example.com/
+   ```
+
+   This overrides the frontend's `/` default at runtime; the bundle itself ships no per-instance config. The same value can also be set via the `/api/v1/meta` API or `UPDATE meta SET value='…' WHERE key='instance_cdn'` directly if the operator script isn't reachable.
 
 ### Dev Mode
 
@@ -186,7 +192,7 @@ The DB backup is named `db.sqlite3.pre-<new-version>` — a plain file copy that
 
 #### nginx
 
-One server block per instance, proxying to its `PORT` (set in the instance's `.env`). nginx also serves `display/` and `thumbnail/` directly from disk — the server never streams photos, only their metadata. The `cdn` meta row (set via the [API](server/README.md) or `UPDATE meta SET value='https://photos.example.com/' WHERE key='instance_cdn'`) tells the frontend which URL to load images from; typically the same host the API is on.
+One server block per instance, proxying to its `PORT` (set in the instance's `.env`). nginx also serves `display/` and `thumbnail/` directly from disk — the server never streams photos, only their metadata. The `cdn` meta row (set via `./bin/meta.ts set instance_cdn …` — or the [API](server/README.md) / raw SQL as fallback) tells the frontend which URL to load images from; typically the same host the API is on.
 
 A realistic per-instance vhost with TLS, certbot-managed certs, proxy headers, and aggressive caching on the photo locations:
 

--- a/bin/instance.ts
+++ b/bin/instance.ts
@@ -164,6 +164,7 @@ const looksLikeInstanceDir = (dir: string): boolean => {
 
 const argv = yargs(hideBin(process.argv))
   .scriptName("instance.ts")
+  .locale("en")
   .command(
     "$0 [name]",
     "Bootstrap, doctor, or upgrade a Photo Diary instance directory",

--- a/bin/instance.ts
+++ b/bin/instance.ts
@@ -256,7 +256,7 @@ if (inferredFromCwd) {
 // bootstrap and upgrade, and `./code/bin/instance.ts` for the rare doctor
 // re-run; a per-instance shortcut would be ambiguous about which code
 // version it points at.
-const OPERATOR_SCRIPTS = ["photo", "gallery", "user", "access"];
+const OPERATOR_SCRIPTS = ["photo", "gallery", "user", "access", "meta"];
 
 // ---- run -----------------------------------------------------------------
 

--- a/server/bin/access.ts
+++ b/server/bin/access.ts
@@ -77,6 +77,7 @@ const confirm = async (prompt: string): Promise<boolean> => {
 
 await yargs(hideBin(process.argv))
   .scriptName("access.ts")
+  .locale("en")
   .strict()
   .demandCommand(1, "Specify a subcommand: list, grant, revoke, or hide-map")
   .command(

--- a/server/bin/gallery.ts
+++ b/server/bin/gallery.ts
@@ -16,6 +16,7 @@ import db from "../db/index.js";
 
 const argv = yargs(hideBin(process.argv))
   .scriptName("gallery.ts")
+  .locale("en")
   .usage("Usage: $0 <id> [options]")
   .strict()
   .command("$0 <id>", "Create or update a gallery", (y) =>

--- a/server/bin/meta.ts
+++ b/server/bin/meta.ts
@@ -48,6 +48,7 @@ const formatTable = (rows: string[][]): string => {
 
 await yargs(hideBin(process.argv))
   .scriptName("meta.ts")
+  .locale("en")
   .strict()
   .demandCommand(1, "Specify a subcommand: list, get, or set")
   .command(

--- a/server/bin/meta.ts
+++ b/server/bin/meta.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env -S npx tsx
+/* eslint-disable no-console -- interactive CLI tool; console output is the UI */
+
+/**
+ * Read and write rows in the `meta` table without resorting to curl
+ * against `/api/v1/meta` or raw `UPDATE meta SET …` SQL.
+ *
+ * Subcommands:
+ *
+ *   meta.ts list
+ *   meta.ts get <key>                 (exit 1 if missing)
+ *   meta.ts set <key> <value> [--force]
+ *
+ * Unknown keys are rejected by default. `--force` adds a brand-new key;
+ * the schema-seeded set is `instance_name`, `instance_description`,
+ * `instance_cdn`, `instance_image`. `schema_version` is the migration
+ * runner's cursor and is hard-blocked here even with --force; reach
+ * for raw SQL if you really need to touch it.
+ */
+
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import db from "../db/index.js";
+
+const KNOWN_KEYS = new Set([
+  "instance_name",
+  "instance_description",
+  "instance_cdn",
+  "instance_image",
+]);
+const PROTECTED_KEYS = new Set(["schema_version"]);
+
+const formatTable = (rows: string[][]): string => {
+  if (rows.length <= 1) return rows[0]?.join("  ") ?? "";
+  const widths = rows[0].map((_, col) =>
+    Math.max(...rows.map((r) => r[col].length))
+  );
+  return rows
+    .map((row, i) => {
+      const padded = row.map((cell, c) => cell.padEnd(widths[c])).join("  ");
+      return i === 0
+        ? `${padded}\n${widths.map((w) => "-".repeat(w)).join("  ")}`
+        : padded;
+    })
+    .join("\n");
+};
+
+await yargs(hideBin(process.argv))
+  .scriptName("meta.ts")
+  .strict()
+  .demandCommand(1, "Specify a subcommand: list, get, or set")
+  .command(
+    "list",
+    "Print every row in meta as a table",
+    (y) => y,
+    async () => {
+      const metas = await db.loadMetas();
+      const entries = Object.entries(metas);
+      if (entries.length === 0) {
+        console.log("(no rows)");
+        return;
+      }
+      const rows: string[][] = [["key", "value"]];
+      for (const [key, value] of entries) rows.push([key, value]);
+      console.log(formatTable(rows));
+    }
+  )
+  .command(
+    "get <key>",
+    "Print one value (exit 1 if the key is missing)",
+    (y) =>
+      y.positional("key", {
+        describe: "Meta key",
+        type: "string",
+        demandOption: true,
+      }),
+    async (argv) => {
+      const meta = await db
+        .loadMeta(argv.key)
+        .then((m) => m as Record<string, string>)
+        .catch(() => null);
+      if (!meta) {
+        console.error(`Key "${argv.key}" not found.`);
+        process.exit(1);
+      }
+      console.log(meta[argv.key] ?? "");
+    }
+  )
+  .command(
+    "set <key> <value>",
+    "Upsert a meta row (rejects unknown keys without --force)",
+    (y) =>
+      y
+        .positional("key", {
+          describe: "Meta key",
+          type: "string",
+          demandOption: true,
+        })
+        .positional("value", {
+          describe: "Value to write (use empty string to clear)",
+          type: "string",
+          demandOption: true,
+        })
+        .option("force", {
+          describe:
+            "Allow setting an unknown key (not in the schema-seeded set)",
+          type: "boolean",
+          default: false,
+        }),
+    async (argv) => {
+      const key = argv.key;
+      if (PROTECTED_KEYS.has(key)) {
+        console.error(
+          `"${key}" is managed by the migration runner; refusing to touch it. Use raw SQL if you really must.`
+        );
+        process.exit(1);
+      }
+      const isKnown = KNOWN_KEYS.has(key);
+      if (!isKnown && !argv.force) {
+        console.error(`Unknown key "${key}". Known keys:`);
+        for (const k of KNOWN_KEYS) console.error(`  ${k}`);
+        console.error("Re-run with --force to add a brand-new key.");
+        process.exit(1);
+      }
+      const existing = await db
+        .loadMeta(key)
+        .then((m) => m as Record<string, string>)
+        .catch(() => null);
+      if (existing) {
+        await db.updateMeta(key, { value: argv.value });
+        console.log(`✓ Updated ${key}.`);
+      } else {
+        await db.createMeta({ key, value: argv.value });
+        console.log(`✓ Created ${key}.`);
+      }
+    }
+  )
+  .parseAsync();

--- a/server/bin/photo.ts
+++ b/server/bin/photo.ts
@@ -10,6 +10,7 @@ import logger from "../lib/logger.js";
 import db from "../db/index.js";
 
 const argv = yargs(hideBin(process.argv))
+  .locale("en")
   .usage("Usage: $0 [options] [JSON-files]")
   .nargs("gallery", 1)
   .describe("gallery", "Set to gallery, repeat for multiple")

--- a/server/bin/user.ts
+++ b/server/bin/user.ts
@@ -123,6 +123,7 @@ const formatTable = (rows: string[][]): string => {
 
 await yargs(hideBin(process.argv))
   .scriptName("user.ts")
+  .locale("en")
   .strict()
   .demandCommand(1, "Specify a subcommand: list, passwd, or delete")
   .command(

--- a/server/db/sqlite3/schema.ts
+++ b/server/db/sqlite3/schema.ts
@@ -409,9 +409,8 @@ const metaMapToRow = (
   meta: Partial<MetaRow>
 ): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
-  if ("key" in meta && meta.key !== undefined && "value" in meta) {
-    result[meta.key] = meta.value;
-  }
+  if ("key" in meta) result.key = meta.key;
+  if ("value" in meta) result.value = meta.value;
   return result;
 };
 const userMapToRow = (user: Partial<User>): Record<string, unknown> => {


### PR DESCRIPTION
## Summary

New `bin/meta.ts` operator script paralleling `bin/{user,gallery,photo,access}.ts` so the `meta` table can be read and written without resorting to `curl` against `/api/v1/meta` or raw `UPDATE meta SET …` SQL. The README's Basic Setup quickstart had to recommend one of those two paths for setting `instance_cdn` — both error-prone, both unfriendly when the operator is already on the host.

```
meta.ts list
meta.ts get <key>                  (exit 1 if missing)
meta.ts set <key> <value> [--force]
```

Unknown keys are rejected by default; `--force` adds a brand-new key (matches the ticket's intent — `access.ts`'s yargs `choices` is closed-enum validation with no escape hatch, so the analogy in the ticket text doesn't quite hold, but `--force` is the right shape for this use). `schema_version` is hard-blocked even with `--force` because it's the migration-runner cursor; operators reach for raw SQL if they really need to touch it.

`bin/instance.ts` adds `"meta"` to its `OPERATOR_SCRIPTS` array so the per-instance `bin/meta.ts` symlink shows up on next doctor/upgrade.

## Drive-by fixes

**`metaMapToRow` bug**: the sqlite3 driver's `metaMapToRow` produced `{ [meta.key]: meta.value }` — column name from input data, not the schema — so `db.updateMeta` resolved to an empty `SET` clause and SQLite errored with `near "WHERE": syntax error`. The bug was unreachable until now because all model-layer `createMeta` / `updateMeta` wrappers throw `NotImplementedError`; nothing in the controller paths exercised the driver method. `bin/meta.ts` is the first real caller, and the fix is a one-liner.

**yargs `.locale("en")` across all six operator scripts**: yargs auto-detects locale from `LANG` / `LC_*` env vars and translates its built-in section labels (`Commands:`, `Options:`, `Show help`, etc.). macOS Terminal sets `LANG` from System Settings → Region (independent of UI language), so an en-UI macOS with Region=Japan ends up with `LANG=ja_JP.UTF-8` and yargs prints half-Japanese / half-English help — labels translate but every subcommand description, `✓`/`✗` status, and error message is hand-written English. That mix is worse than fully English. The SPA keeps en/fi/ja for end users; the operator scripts are read by people already reading commits, runbooks, and stack traces in English, so pin `.locale("en")` across `bin/instance.ts` + `server/bin/{meta,user,gallery,photo,access}.ts`.

## README

Step 5 ("Set the instance `cdn`") and the nginx-section `cdn` reference now lead with `./bin/meta.ts set instance_cdn <url>`; the API / SQL paths stay as a one-line fallback.

Closes #269.

## Test plan

- [x] Server `npm run typecheck` — clean.
- [x] Server `npm test` — 634 pass (no regressions from the `metaMapToRow` fix).
- [x] Manual on the local dev instance: `list`, `get` (hit + miss), `set known`, `set unknown` (rejected), `set unknown --force` (created), `set schema_version` (blocked, with and without `--force`), `set existing ""` (clears).
- [x] Manual: `LANG=ja_JP.UTF-8 ./bin/<each>.ts --help` across all six scripts — every one prints English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)