### PR TITLE
Converter: write minimal photo row at JPEG intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Server
+
+- New `photo.original_filename` column (schema migration `006`) records the basename the photo arrived with, backfilling existing rows to `id` so the values match pre-rename. Sets up the `(id, originalFilename, dateTimeOriginal)` lookup chain #272 needs once rename-on-import lands.
+
+### Converter
+
+- Converter now inserts a minimal photo row into the DB at JPEG intake — id, originalFilename, EXIF-derived `taken`/camera/lens/exposure, file dimensions — so `bin/photo.ts <enriched.json>` becomes pure update rather than create-or-update. Opinion fields (title, country, place, author, …) stay empty for the operator's enrichment JSON. Skip-if-exists so re-imports don't clobber prior enrichment. (closes #223)
+
 ### Tooling
 
 - `bin/instance.ts` upgrade-mode output reorganises around the recommended path: a "Next — cycle pm2 …" heading with the command block, a single-line "Note:" caveat (down from four), a horizontal rule, then a "Rollback — ONLY if the steps above didn't work" block. New `--quiet` / `-q` flag suppresses informational output (errors and warnings still surface) for scripted re-runs; missing-key warnings now route to stderr where they belong. (closes #284)

--- a/converter/extract-properties/index.ts
+++ b/converter/extract-properties/index.ts
@@ -5,8 +5,12 @@ import readExif from "./read-exif.js";
 import setDimensions from "./set-dimensions.js";
 import saveJson from "./save-json.js";
 
-export default async (fileName: string, rootDir: string): Promise<void> => {
+export default async (
+  fileName: string,
+  rootDir: string
+): Promise<Record<string, unknown>> => {
   const exif = await readExif(fileName, path.join(rootDir, DIR_INBOX));
   const properties = await setDimensions(fileName, rootDir, exif);
   await saveJson(fileName, rootDir, properties);
+  return properties;
 };

--- a/converter/package.json
+++ b/converter/package.json
@@ -10,7 +10,7 @@
     "dumpexif": "tsx bin/dump-exif.ts",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
-    "test": "tsx --test tests/**/*.test.ts"
+    "test": "DB_DRIVER=dummy SECRET=test NODE_ENV=test tsx --test tests/**/*.test.ts"
   },
   "author": "Ville Misaki",
   "license": "MIT",
@@ -23,6 +23,7 @@
     "exifr": "^7.1.3",
     "geo-coord": "^0.2.0",
     "image-size": "^2.0.2",
+    "photo-diary-server": "*",
     "sharp": "^0.34.5"
   },
   "devDependencies": {

--- a/converter/process-file.ts
+++ b/converter/process-file.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import db from "photo-diary-server/db/index.js";
+
 import { DIR_INBOX, DIR_ORIGINAL, TARGETS } from "./lib/constants.js";
 import * as logger from "./lib/logger.js";
 import extractProperties from "./extract-properties/index.js";
@@ -20,7 +22,24 @@ export default async (fileName: string, rootDir: string): Promise<void> => {
     TARGETS.map((target) => convertImage(fileName, rootDir, target))
   );
 
-  await extractProperties(fileName, rootDir);
+  const properties = await extractProperties(fileName, rootDir);
+
+  // Minimal DB row at intake — id, originalFilename, EXIF-derived
+  // factual fields. Opinion fields (title, country, place, …) stay
+  // empty; the operator's enrichment JSON via `bin/photo.ts` fills
+  // them in. Skip-if-exists so re-imports don't clobber prior
+  // enrichment.
+  const id = properties.id as string;
+  const existing = await db
+    .loadPhoto(id)
+    .then(() => true)
+    .catch(() => false);
+  if (existing) {
+    logger.debug(`[${fileName}] DB row already exists for ${id}; skipping insert`);
+  } else {
+    await db.createPhoto({ ...properties, originalFilename: fileName });
+    logger.debug(`[${fileName}] Created DB row for ${id}`);
+  }
 
   logger.debug(`[${fileName}] Moving file`);
   await fs.promises.rename(

--- a/converter/tests/pipeline.test.ts
+++ b/converter/tests/pipeline.test.ts
@@ -7,6 +7,10 @@ import { fileURLToPath } from "node:url";
 
 import processFile from "../process-file.js";
 import { imageSizeFromFile } from "image-size/fromFile";
+import db from "photo-diary-server/db/index.js";
+import dummyFactory from "photo-diary-server/db/dummy.js";
+
+const dummy = dummyFactory();
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const fixturesDir = path.join(here, "fixtures");
@@ -18,6 +22,7 @@ beforeEach(async () => {
   for (const sub of ["inbox", "original", "display", "thumbnail"]) {
     await fs.promises.mkdir(path.join(rootDir, sub));
   }
+  await dummy.init();
 });
 
 afterEach(async () => {
@@ -81,6 +86,13 @@ test("processes a JPEG with EXIF end-to-end", async () => {
   assert.ok(props.dimensions.original.width > 0);
   assert.ok(props.dimensions.display.width > 0);
   assert.ok(props.dimensions.thumbnail.width > 0);
+
+  // Minimal DB row created at intake with the factual EXIF fields +
+  // originalFilename. Opinion fields (title, country, place, …) stay
+  // empty for the operator's enrichment JSON to fill in later.
+  const row = (await db.loadPhoto("photo.jpg")) as Record<string, unknown>;
+  assert.equal(row.id, "photo.jpg");
+  assert.equal(row.originalFilename, "photo.jpg");
 });
 
 test("processes a JPEG without EXIF, producing 'Invalid date' placeholders", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "exifr": "^7.1.3",
         "geo-coord": "^0.2.0",
         "image-size": "^2.0.2",
+        "photo-diary-server": "*",
         "sharp": "^0.34.5"
       },
       "devDependencies": {

--- a/server/db/dummy.ts
+++ b/server/db/dummy.ts
@@ -270,8 +270,9 @@ const unlinkAllGalleries = async () => {
 const loadPhotos = async () => {
   return db.photos;
 };
-const createPhoto = async () => {
-  throw new NotImplementedError();
+const createPhoto = async (photo: { id?: string } & Record<string, unknown>) => {
+  if (!db.photos) db.photos = {};
+  if (photo.id) db.photos[photo.id] = photo;
 };
 const loadPhoto = async (photoId: string) => {
   if (!(photoId in db.photos)) {
@@ -279,8 +280,11 @@ const loadPhoto = async (photoId: string) => {
   }
   return db.photos[photoId];
 };
-const updatePhoto = async () => {
-  throw new NotImplementedError();
+const updatePhoto = async (photoId: string, patch: Record<string, unknown>) => {
+  if (!(photoId in db.photos)) {
+    throw new NotFoundError();
+  }
+  Object.assign(db.photos[photoId], patch);
 };
 
 const dbDump = JSON.stringify({

--- a/server/db/sqlite3/migrations/006_add_original_filename.sql
+++ b/server/db/sqlite3/migrations/006_add_original_filename.sql
@@ -1,0 +1,11 @@
+-- `original_filename` records the basename the photo arrived with (pre any
+-- rename-on-import the converter does). Today id == originalFilename for
+-- every row, so the backfill is trivial; #272's stable-ID rename makes them
+-- diverge going forward, at which point the operator's enrichment JSONs
+-- (and `bin/photo.ts search`) can still find rows via the human-recognised
+-- camera filename.
+
+ALTER TABLE photo ADD COLUMN original_filename TEXT;
+UPDATE photo SET original_filename = id;
+
+UPDATE meta SET value='6' WHERE key='schema_version';

--- a/server/db/sqlite3/schema.ts
+++ b/server/db/sqlite3/schema.ts
@@ -42,6 +42,7 @@ export interface GalleryPhotoRow {
 }
 export interface PhotoRow {
   id: string;
+  original_filename: string | null;
   title: string;
   description: string;
   author: string;
@@ -90,6 +91,7 @@ export interface GalleryPhoto {
 }
 export interface Photo {
   id: string;
+  originalFilename: string | undefined;
   index: number;
   title: string;
   description: string;
@@ -298,6 +300,7 @@ export default () => {
 
         return {
           id: toString(row.id),
+          originalFilename: row.original_filename ?? undefined,
           index,
           title: toString(row.title),
           description: toString(row.description),
@@ -358,6 +361,7 @@ export default () => {
         const map = photoMapToRow(photo);
         return [
           photo.id,
+          map.original_filename,
           map.title,
           map.description,
           map.author,
@@ -450,6 +454,7 @@ const galleryMapToRow = (
 };
 const photoMapToRow = (photo: PhotoInput): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
+  if ("originalFilename" in photo) result.original_filename = photo.originalFilename;
   if ("title" in photo) result.title = photo.title;
   if ("description" in photo) result.description = photo.description;
   if (photo.taken) {
@@ -575,6 +580,7 @@ const SCHEMA = {
     table: "photo",
     columns: [
       "id",
+      "original_filename",
       "title",
       "description",
       "author",

--- a/server/tests/db/sqlite3/migrate.test.ts
+++ b/server/tests/db/sqlite3/migrate.test.ts
@@ -33,7 +33,7 @@ describe("migrate", () => {
   test("fresh DB runs every migration and lands at the highest version", () => {
     const db = open();
     migrate(db);
-    expect(schemaVersion(db)).toBe(5);
+    expect(schemaVersion(db)).toBe(6);
     expect(tableNames(db)).toEqual(
       expect.arrayContaining([
         "gallery",
@@ -100,7 +100,7 @@ describe("migrate", () => {
 
     migrate(db);
 
-    expect(schemaVersion(db)).toBe(5);
+    expect(schemaVersion(db)).toBe(6);
     expect(gallerPhotoFkRefs(db).sort()).toEqual(["gallery", "photo"]);
     const rows = db.prepare("SELECT * FROM gallery_photo").all();
     expect(rows).toEqual([{ gallery_id: "g1", photo_id: "p1" }]);

--- a/server/tests/db/sqlite3/schema.test.ts
+++ b/server/tests/db/sqlite3/schema.test.ts
@@ -298,6 +298,7 @@ describe("Gallery Photo", () => {
 describe("Photo", () => {
   const cols = [
     "id",
+    "original_filename",
     "title",
     "description",
     "author",
@@ -330,7 +331,7 @@ describe("Photo", () => {
   ].join(",");
   test("Build create query", () =>
     expect(schema.photo.buildCreateQuery()).toBe(
-      `INSERT INTO photo (${cols}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
+      `INSERT INTO photo (${cols}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
     ));
   test("Build select by id query", () =>
     expect(schema.photo.buildSelectByIdQuery()).toBe(


### PR DESCRIPTION
## Summary

Today the photo DB row is born from `bin/photo.ts <enriched.json>` — the converter only generates files and moves the original. That made `bin/photo.ts` the de-facto row creator for renamed photos in the #272 design, but #272's enrichment JSONs come from operator-side scripts that don't know the renamed id. This PR has the converter write the row at intake so #272's `originalFilename` lookup chain has something to find.

This is the **minimum** of the original #223 — converter writes the row, nothing more. The fuller scope (converter consumes JSON dropped into `inbox/`, archive layout under `original/`) is filed as #333 in 0.12, paired with the admin UI work (#10) that retires `bin/photo.ts` as the routine enrichment path.

## Changes

- New migration `006_add_original_filename.sql` adds the `photo.original_filename` column and backfills existing rows to the current `id` (pre-#272, `id` IS the filename). Schema.ts learns the new column across `PhotoRow` / `Photo` / `SCHEMA.photo.columns` / `photoMapRow` / `photoMapToRow` / `mapInsert`.
- Converter gets a workspace dep on `photo-diary-server` so it can import the `db` facade. `process-file.ts` inserts the minimal row (factual EXIF fields + `originalFilename`) after `extractProperties` and before the file moves to `original/`. Skip-if-exists so re-imports don't clobber prior enrichment.
- `extractProperties` returns the properties object so `process-file` can hand it to `db.createPhoto` (was `Promise<void>`).
- Opinion fields (title, country, place, author, description) stay null in the minimal insert — those wait for `bin/photo.ts`.
- Dummy DB driver gets a real in-memory `createPhoto` / `updatePhoto` so converter tests can verify the insert without a sqlite file.

Closes #223.

## Test plan

- [x] `npm run typecheck --workspaces` — clean.
- [x] `npm test --workspaces` — 634 server + 963 react-app + 3 converter pass.
- [x] Manual: dropped a JPEG into the dev instance's `inbox/`, ran the converter; row appears in `dev/db.sqlite3` with `original_filename` populated, EXIF-derived `taken`/`camera`/`exposure` fields set, opinion fields null. Sidecar JSON still in `inbox/`, original moved to `original/`, dimensions populated.
- [x] Verified existing rows in the dev DB got `original_filename` backfilled to `id` (no NULLs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)