### PR TITLE
bin/photo.ts: add audit subcommand for data-completeness checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Tooling
+
+- `bin/photo.ts audit` subcommand: surfaces rows with missing data (`--missing taken|coords|place|country|author|title|description`), orphan gallery links (`--orphans`), or shared `originalFilename` (`--duplicates`); no flag runs every check. `--format ids` emits one id per line for piping into batch fixers (`xargs -I{} ./bin/photo.ts {} --place "..."` etc.). New `db.loadOrphanPhotoIds()` driver method (sqlite3 + dummy + facade) powers the orphan check. First slice of #337 — the audit subcommand on `bin/{gallery,user,access,meta}.ts` follows in subsequent PRs.
+
 ### Server
 
 - New `photo.original_filename` column (schema migration `006`) records the basename the photo arrived with, backfilling existing rows to `id` so the values match pre-rename. Sets up the `(id, originalFilename, dateTimeOriginal)` lookup chain #272 needs once rename-on-import lands.

--- a/server/bin/photo.ts
+++ b/server/bin/photo.ts
@@ -208,6 +208,115 @@ const processJpeg = async (filePath: string, argv: any) => {
   await processPhoto({ id: fileName }, argv);
 };
 
+// ---- audit ---------------------------------------------------------------
+
+// Empty-data sentinel: NULL → "" through mapRow; "Invalid date" is the
+// explicit placeholder readExif emits for EXIF-less imports.
+const isMissing = (v: unknown): boolean =>
+  v === null || v === undefined || v === "" || v === "unknown" || v === "Invalid date";
+
+type MissingField =
+  | "taken"
+  | "coords"
+  | "place"
+  | "country"
+  | "author"
+  | "title"
+  | "description";
+
+const MISSING_PROBES: Record<MissingField, (p: any) => boolean> = {
+  taken: (p) => isMissing(p.taken?.instant?.timestamp),
+  coords: (p) =>
+    isMissing(p.taken?.location?.coordinates?.latitude) ||
+    isMissing(p.taken?.location?.coordinates?.longitude),
+  place: (p) => isMissing(p.taken?.location?.place),
+  country: (p) => isMissing(p.taken?.location?.country),
+  author: (p) => isMissing(p.taken?.author),
+  title: (p) => isMissing(p.title),
+  description: (p) => isMissing(p.description),
+};
+
+interface AuditCheck {
+  key: string;
+  title: string;
+  rows: () => Array<{ id: string; row: any; why?: string }>;
+}
+
+const buildChecks = (
+  photos: any[],
+  orphanIds: Set<string>
+): AuditCheck[] => {
+  const checks: AuditCheck[] = [];
+
+  for (const field of Object.keys(MISSING_PROBES) as MissingField[]) {
+    const probe = MISSING_PROBES[field];
+    checks.push({
+      key: `missing-${field}`,
+      title: `Photos with missing ${field}`,
+      rows: () =>
+        photos.filter(probe).map((p) => ({ id: p.id, row: p })),
+    });
+  }
+
+  checks.push({
+    key: "orphans",
+    title: "Photos with no gallery_photo link",
+    rows: () =>
+      photos
+        .filter((p) => orphanIds.has(p.id))
+        .map((p) => ({ id: p.id, row: p })),
+  });
+
+  checks.push({
+    key: "duplicates",
+    title: "Photos sharing an originalFilename",
+    rows: () => {
+      const byName = new Map<string, any[]>();
+      for (const p of photos) {
+        const name = (p.originalFilename ?? "") as string;
+        if (!name) continue;
+        if (!byName.has(name)) byName.set(name, []);
+        byName.get(name)!.push(p);
+      }
+      const out: Array<{ id: string; row: any; why?: string }> = [];
+      for (const [name, group] of byName) {
+        if (group.length <= 1) continue;
+        for (const p of group) out.push({ id: p.id, row: p, why: name });
+      }
+      return out;
+    },
+  });
+
+  return checks;
+};
+
+const printCheck = (
+  check: AuditCheck,
+  results: Array<{ id: string; row: any; why?: string }>,
+  format: "table" | "ids"
+): void => {
+  if (format === "ids") {
+    for (const r of results) console.log(r.id);
+    return;
+  }
+  console.log(`\n${check.title}: ${results.length}`);
+  if (results.length === 0) return;
+  const showWhy = results.some((r) => r.why !== undefined);
+  const header = showWhy
+    ? ["id", "originalFilename", "taken", "duplicate of"]
+    : ["id", "originalFilename", "taken"];
+  const table: string[][] = [header];
+  for (const r of results) {
+    const base = [
+      r.id ?? "",
+      r.row.originalFilename ?? "",
+      r.row.taken?.instant?.timestamp ?? "",
+    ];
+    table.push(showWhy ? [...base, r.why ?? ""] : base);
+  }
+  console.log(formatTable(table));
+};
+
 await yargs(hideBin(process.argv))
   .scriptName("photo.ts")
   .locale("en")
@@ -265,6 +374,78 @@ await yargs(hideBin(process.argv))
           default:
             logger.error(`Unrecognised extension: ${fp}`);
         }
+      }
+    }
+  )
+  .command(
+    "audit",
+    "Find photos with missing properties, orphan gallery links, or duplicate originalFilenames",
+    (y) =>
+      y
+        .option("missing", {
+          describe:
+            "Restrict to a single missing-field check (default: run every check)",
+          choices: [
+            "taken",
+            "coords",
+            "place",
+            "country",
+            "author",
+            "title",
+            "description",
+          ] as const,
+        })
+        .option("orphans", {
+          type: "boolean",
+          default: false,
+          describe: "Restrict to the orphan-gallery-link check",
+        })
+        .option("duplicates", {
+          type: "boolean",
+          default: false,
+          describe: "Restrict to the duplicate-originalFilename check",
+        })
+        .option("format", {
+          choices: ["table", "ids"] as const,
+          default: "table" as const,
+          describe:
+            "table (default, with id/originalFilename/taken) or ids (one per line, pipe-friendly)",
+        }),
+    async (argv) => {
+      const photos = (await db.loadPhotos()) as any[];
+      const orphanIds = new Set<string>(
+        (await db.loadOrphanPhotoIds()) as string[]
+      );
+
+      const all = buildChecks(photos, orphanIds);
+      const anyFilter =
+        argv.missing !== undefined || argv.orphans || argv.duplicates;
+
+      let selected: AuditCheck[];
+      if (!anyFilter) {
+        selected = all;
+      } else {
+        selected = [];
+        if (argv.missing) {
+          const key = `missing-${argv.missing}`;
+          const match = all.find((c) => c.key === key);
+          if (match) selected.push(match);
+        }
+        if (argv.orphans) {
+          const match = all.find((c) => c.key === "orphans");
+          if (match) selected.push(match);
+        }
+        if (argv.duplicates) {
+          const match = all.find((c) => c.key === "duplicates");
+          if (match) selected.push(match);
+        }
+      }
+
+      if (argv.format === "table") {
+        console.log(`Audited ${photos.length} photo(s).`);
+      }
+      for (const check of selected) {
+        printCheck(check, check.rows(), argv.format);
       }
     }
   )

--- a/server/db/dummy.ts
+++ b/server/db/dummy.ts
@@ -56,6 +56,7 @@ export default () => {
     createPhoto,
     loadPhoto,
     loadPhotosByOriginalFilename,
+    loadOrphanPhotoIds,
     updatePhoto,
     renamePhoto,
     deletePhoto: notImplemented,
@@ -286,6 +287,15 @@ const loadPhotosByOriginalFilename = async (originalFilename: string) => {
   return Object.values(db.photos).filter(
     (p: any) => p.originalFilename === originalFilename
   );
+};
+const loadOrphanPhotoIds = async (): Promise<string[]> => {
+  const linked = new Set<string>();
+  for (const ids of Object.values(db.galleryPhotos) as string[][]) {
+    for (const id of ids) linked.add(id);
+  }
+  return Object.keys(db.photos)
+    .filter((id) => !linked.has(id))
+    .sort();
 };
 // Deep-merge mirrors the sqlite3 driver's per-column update semantics:
 // only keys present in `patch` are touched, nested objects merge instead

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -170,6 +170,9 @@ export default {
   loadPhotosByOriginalFilename: async (originalFilename: string) => {
     return await db.loadPhotosByOriginalFilename(originalFilename);
   },
+  loadOrphanPhotoIds: async (): Promise<string[]> => {
+    return await db.loadOrphanPhotoIds();
+  },
   updatePhoto: async (photoId: string, photo: PhotoInput) => {
     await db.updatePhoto(photoId, photo);
   },

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -65,6 +65,7 @@ export default () => {
     createPhoto,
     loadPhoto,
     loadPhotosByOriginalFilename,
+    loadOrphanPhotoIds,
     updatePhoto,
     renamePhoto,
     deletePhoto,
@@ -426,6 +427,18 @@ const loadPhotosByOriginalFilename = async (originalFilename: string) => {
     .prepare(SCHEMA.photo.buildSelectQuery(["original_filename = ?"]))
     .all(originalFilename) as PhotoRow[];
   return rows.map((row, index) => SCHEMA.photo.mapRow(row, index));
+};
+// Photo rows with no gallery_photo link — useful for `bin/photo.ts audit`.
+// The SPA doesn't surface orphan photos anywhere; they're a data-drift
+// signal the operator might want to clean up (or deliberately keep as
+// unfiled, the model allows it).
+const loadOrphanPhotoIds = async (): Promise<string[]> => {
+  const rows = db
+    .prepare(
+      "SELECT id FROM photo WHERE id NOT IN (SELECT photo_id FROM gallery_photo) ORDER BY id ASC"
+    )
+    .all() as Array<{ id: string }>;
+  return rows.map((r) => r.id);
 };
 const updatePhoto = async (photoId: string, photo: PhotoInput) => {
   const { query, values } = SCHEMA.photo.buildUpdateByIdQuery(photo);

--- a/server/db/sqlite3/migrate.ts
+++ b/server/db/sqlite3/migrate.ts
@@ -16,6 +16,21 @@ interface Migration {
   sql: string;
 }
 
+interface FkViolation {
+  table: string;
+  rowid: number;
+  parent: string;
+  fkid: number;
+}
+
+const formatFkViolations = (issues: unknown[]): string =>
+  issues
+    .map((issue) => {
+      const v = issue as FkViolation;
+      return `  - ${v.table} rowid=${v.rowid} references missing ${v.parent}`;
+    })
+    .join("\n");
+
 const loadMigrations = (): Migration[] => {
   return fs
     .readdirSync(MIGRATIONS_DIR)
@@ -97,9 +112,22 @@ export const migrate = (db: Database): void => {
       apply();
       const fkIssues = db.pragma("foreign_key_check") as unknown[];
       if (fkIssues.length > 0) {
+        // The post-migration check fires after every migration, so a
+        // violation here may pre-date this specific one — particularly
+        // common for legacy data drift surfacing only when migrate runs.
+        // Either way, refuse to advance until the operator inspects the
+        // listed rows and removes the orphans (referenced parent row is
+        // gone) or restores them.
         throw new Error(
-          `Migration ${m.filename} left foreign-key violations: ` +
-            JSON.stringify(fkIssues)
+          `After migration ${m.filename}, foreign-key violations detected:\n` +
+            formatFkViolations(fkIssues) +
+            "\n\n" +
+            "These rows may pre-date this migration. Investigate the listed " +
+            "rows (the referenced parent row no longer exists) and remove the " +
+            "orphans before re-running. Operator scripts surface this directly " +
+            "post-merge — `./bin/photo.ts audit --orphans` finds photo rows " +
+            "with no gallery link; `./bin/gallery.ts audit --orphan-photos` " +
+            "(coming next in #337) finds the reverse case shown above."
         );
       }
     }


### PR DESCRIPTION
## Summary

First slice of #337. Surfaces photos with missing properties, orphan gallery links, or shared `originalFilename` so the operator can find data drift without writing ad-hoc SQL.

```
photo.ts audit                           # all checks
photo.ts audit --missing coords          # one check only
photo.ts audit --missing taken|coords|place|country|author|title|description
photo.ts audit --orphans
photo.ts audit --duplicates
photo.ts audit --missing coords --format ids \
  | xargs -I{} ./bin/photo.ts {} --place "..."     # batch-fix pipeline
```

## Implementation

- Each check is a pure function over `db.loadPhotos()` + an orphan-id set; no per-check DB query.
- Output is either a table (id / originalFilename / taken, plus a "duplicate of" column when the duplicates check runs) or one id per line for piping.
- New `db.loadOrphanPhotoIds()` driver method on sqlite3 + dummy + facade. SQL: `WHERE id NOT IN (SELECT photo_id FROM gallery_photo)`. Dummy walks its in-memory galleryPhotos map for the same effect.
- `isMissing(v)` treats `null`, `undefined`, `""`, `"unknown"`, and `"Invalid date"` as missing. `"Invalid date"` comes from EXIF-less converter imports; `"unknown"` is the legacy country placeholder that `normalizeCountry` already filters in `mapRow`.

## Scope note

This PR ships only the `photo.ts` audit. The `audit` subcommand on `bin/{gallery,user,access,meta}.ts` is out of scope here; subsequent PRs will fill in the rest of #337. The ticket stays open.

## Test plan

- [x] `npm run typecheck --workspaces` — clean.
- [x] `npm run lint --workspaces` — clean.
- [x] `npm test --workspaces` — 634 server + 963 react-app + 7 converter pass.
- [x] Manual on the dev DB (5891 photos): 0 missing taken, **10 missing coords** (matches the operator's expectation of "all photos should be geotagged"), 0 orphans, 0 duplicates.
- [x] `--format ids` output is exactly one id per line, no trailing summary — pipe-friendly.
- [x] `--missing nonsense` rejected by yargs `choices`.

## Drive-by finding

While testing against `db.sqlite3.dailybw` (which is at schema_version=4 and would auto-migrate on load), the 005 → 006 migration hit a foreign-key violation: one `gallery_photo` row points at `photo_id = "2021-12-18 15.59.32.jpg"` which doesn't exist in the photo table. That's exactly what `gallery.ts audit --orphan-photos` would catch in a future installment. The immediate workaround on the dailybw instance is `DELETE FROM gallery_photo WHERE photo_id = '2021-12-18 15.59.32.jpg';` before migrating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)