### PR TITLE
Reverse-geocode foundation: schema + module + intake (PR 1 of #246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Server
+
+- New `photo` columns (`geocoded_country_code`, `geocoded_state`, `geocoded_city`, `geocoded_district`, `geocoded_place`, `geocoded_address`) and a sibling `photo_localized` table for non-English language variants — schema migration 007. English is the canonical / filter-keyed language stored on the photo row; other languages live in `photo_localized` only when actually translated. Indexes on the three drill-down levels cover the future filter / Stats Places work. Operator-set `photo.country_code` and `photo.place` stay untouched (additive — auto-populated reverse-geocode data sits alongside, doesn't replace operator-controlled values). (part of #246)
+- `db.upsertGeocoded(photoId, lang, fields)` driver method (sqlite3 + dummy + facade) that routes English to the photo columns and other languages to `photo_localized` via an upsert. `db.loadPhotosMissingGeocoded(lang, limit)` walks photos with coords that still need geocoding for a language, ordered by `taken` DESC (recent first, NULLs at the back) so the daemon fills in the visible / recently-shot photos earliest.
+- `db.loadPhoto` / `db.loadPhotos` accept an optional `lang` parameter — when present and non-English, joins `photo_localized` and merges the localized values over the English photo columns per photo.
+
+### Converter
+
+- New `converter/reverse-geocode/` module: Nominatim client with custom `User-Agent: photo-diary/<version> (<repo-url>)`, 1 RPS queue (Nominatim public usage policy), per-`(lang, coord)` file cache at `${GEOCODE_DIR}/cache/<lang>/<lat>:<lon>.json` (coords rounded to 4 decimals ≈ 11 m precision). `NOMINATIM_BASE_URL` env points at a self-hosted Nominatim if needed; `GEOCODE_DIR` defaults to `<cwd>/.geocode/`. (part of #246)
+- Converter intake reverse-geocodes new photos with coords when `REVERSE_GEOCODE=1` is set in the instance's `.env`. English is always written (canonical / filter-keyed); `REVERSE_GEOCODE_EXTRA_LANGS=ja,fi` lists additional languages to fetch at intake. Each extra language is one extra 1 RPS Nominatim call per photo. Failures (network, no address) leave the geocoded fields empty with a log line. Opt-in by default — privacy trade-off (coords go to a third-party service). The backfill daemon (PR 2 of #246) fills in existing photos and adds languages later without touching the hot path. (part of #246)
+
 ### Tooling
 
 - `bin/photo.ts audit` subcommand: surfaces rows with missing data (`--missing taken|coords|place|country|author|title|description`), orphan gallery links (`--orphans`), or shared `originalFilename` (`--duplicates`); no flag runs every check. `--format ids` emits one id per line for piping into batch fixers (`xargs -I{} ./bin/photo.ts {} --place "..."` etc.). New `db.loadOrphanPhotoIds()` driver method (sqlite3 + dummy + facade) powers the orphan check. (part of #337)

--- a/converter/lib/version.ts
+++ b/converter/lib/version.ts
@@ -1,0 +1,18 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Read the converter workspace's package.json — `import.meta.dirname`
+// resolves to this file's directory, so step up to the workspace root.
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgPath = path.join(here, "..", "package.json");
+
+let cached: string | undefined;
+export const readPackageVersion = (): string => {
+  if (cached) return cached;
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as {
+    version?: string;
+  };
+  cached = pkg.version ?? "0.0.0";
+  return cached;
+};

--- a/converter/process-file.ts
+++ b/converter/process-file.ts
@@ -9,6 +9,40 @@ import extractProperties from "./extract-properties/index.js";
 import saveJson from "./extract-properties/save-json.js";
 import convertImage from "./convert-image/index.js";
 import generateId from "./generate-id.js";
+import { geocode } from "./reverse-geocode/index.js";
+
+// Reverse-geocode is opt-in: privacy trade-off, third-party API call
+// per new photo. English is always written when enabled (canonical /
+// filter-keyed language); REVERSE_GEOCODE_EXTRA_LANGS lists additional
+// languages. Each extra adds one 1-RPS Nominatim call per photo at
+// intake. Use `bin/photo-geocode.ts` (PR 2 of #246) to backfill
+// existing photos or add languages later without touching the hot path.
+const geocodeAtIntake = async (
+  photoId: string,
+  lat: number | null | undefined,
+  lon: number | null | undefined
+): Promise<void> => {
+  if (!process.env.REVERSE_GEOCODE) return;
+  if (lat === null || lat === undefined) return;
+  if (lon === null || lon === undefined) return;
+  const extra = (process.env.REVERSE_GEOCODE_EXTRA_LANGS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s && s !== "en");
+  const langs = ["en", ...extra];
+  for (const lang of langs) {
+    const result = await geocode(lat, lon, lang);
+    if (!result) continue;
+    await db.upsertGeocoded(photoId, lang, {
+      countryCode: lang === "en" ? (result.countryCode ?? null) : undefined,
+      state: result.state ?? null,
+      city: result.city ?? null,
+      district: result.district ?? null,
+      place: result.place,
+      address: JSON.stringify(result.address),
+    });
+  }
+};
 
 export default async (
   originalFilename: string,
@@ -94,6 +128,20 @@ export default async (
     await db.createPhoto(properties);
     logger.debug(`[${originalFilename}] Created DB row ${id}`);
   }
+
+  // Reverse-geocode at intake when enabled. Runs after the DB row
+  // exists so the geocoder's upsertGeocoded calls always have a
+  // target row.
+  const coords = (
+    properties as {
+      taken?: {
+        location?: {
+          coordinates?: { latitude?: number; longitude?: number };
+        };
+      };
+    }
+  ).taken?.location?.coordinates;
+  await geocodeAtIntake(id, coords?.latitude, coords?.longitude);
 
   logger.debug(`[${originalFilename}] Moving file`);
   // fs.rename overwrites on POSIX; deliberately replaces the prior

--- a/converter/reverse-geocode/index.ts
+++ b/converter/reverse-geocode/index.ts
@@ -1,0 +1,187 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { readPackageVersion } from "../lib/version.js";
+import * as logger from "../lib/logger.js";
+
+// Per Nominatim's usage policy:
+//   - Public instance: absolute maximum 1 request per second.
+//   - Custom, descriptive User-Agent required.
+//   - Caching encouraged.
+// https://operations.osmfoundation.org/policies/nominatim/
+const DEFAULT_BASE_URL = "https://nominatim.openstreetmap.org";
+const MIN_INTERVAL_MS = 1000;
+const REPO_URL = "https://github.com/vlumi/photo-diary";
+
+const baseUrl = (): string =>
+  (process.env.NOMINATIM_BASE_URL || DEFAULT_BASE_URL).replace(/\/+$/, "");
+
+const userAgent = (): string => {
+  try {
+    return `photo-diary/${readPackageVersion()} (${REPO_URL})`;
+  } catch {
+    return `photo-diary (${REPO_URL})`;
+  }
+};
+
+const geocodeDir = (): string =>
+  process.env.GEOCODE_DIR ?? path.join(process.cwd(), ".geocode");
+
+const cacheDirFor = (lang: string): string =>
+  path.join(geocodeDir(), "cache", lang);
+
+const cachePathFor = (lat: number, lon: number, lang: string): string => {
+  // Rounded to 4 decimals (~11 m) so micro-jitter doesn't bust the cache.
+  // The reverse-geocode result is identical for any two points within
+  // that radius in practice.
+  const key = `${lat.toFixed(4)}:${lon.toFixed(4)}.json`;
+  return path.join(cacheDirFor(lang), key);
+};
+
+// One-line summary fields extracted from Nominatim's structured response,
+// matching what the schema stores (state / city / district / place /
+// country_code / raw address JSON).
+export interface NominatimResult {
+  countryCode: string | undefined;
+  state: string | undefined;
+  city: string | undefined;
+  district: string | undefined;
+  place: string;
+  address: Record<string, unknown>;
+}
+
+interface NominatimResponse {
+  display_name?: string;
+  address?: Record<string, unknown>;
+}
+
+const extract = (raw: NominatimResponse): NominatimResult | null => {
+  const a = raw.address;
+  if (!a) return null;
+  const get = (key: string): string | undefined => {
+    const v = a[key];
+    return typeof v === "string" && v ? v : undefined;
+  };
+  // Fallback chains per level — Nominatim's address fields are
+  // country-specific and we want sensible coverage across conventions.
+  const state =
+    get("state") ?? get("province") ?? get("region") ?? get("state_district");
+  const city =
+    get("city") ??
+    get("town") ??
+    get("village") ??
+    get("municipality") ??
+    get("hamlet");
+  const district =
+    get("borough") ??
+    get("city_district") ??
+    get("suburb") ??
+    get("quarter") ??
+    get("neighbourhood") ??
+    get("district") ??
+    get("subdistrict");
+  const countryCode = (() => {
+    const cc = a.country_code;
+    return typeof cc === "string" ? cc : undefined;
+  })();
+  return {
+    countryCode,
+    state,
+    city,
+    district,
+    place: raw.display_name ?? "",
+    address: a,
+  };
+};
+
+// Tiny serial queue — every fetch waits at least MIN_INTERVAL_MS after the
+// previous one started. Single global queue per process; the daemon and
+// converter intake share it (both run inside one process at a time per
+// the operator workflow).
+let nextSlot = 0;
+const acquireSlot = async (): Promise<void> => {
+  const now = Date.now();
+  const wait = Math.max(0, nextSlot - now);
+  nextSlot = Math.max(now, nextSlot) + MIN_INTERVAL_MS;
+  if (wait > 0) {
+    await new Promise((resolve) => setTimeout(resolve, wait));
+  }
+};
+
+const readCache = (
+  lat: number,
+  lon: number,
+  lang: string
+): NominatimResult | null => {
+  try {
+    const raw = fs.readFileSync(cachePathFor(lat, lon, lang), "utf8");
+    return JSON.parse(raw) as NominatimResult;
+  } catch {
+    return null;
+  }
+};
+
+const writeCache = (
+  lat: number,
+  lon: number,
+  lang: string,
+  result: NominatimResult
+): void => {
+  const dir = cacheDirFor(lang);
+  fs.mkdirSync(dir, { recursive: true });
+  // Atomic write so a partial JSON never gets read back as a cache hit.
+  const finalPath = cachePathFor(lat, lon, lang);
+  const tmpPath = `${finalPath}.${process.pid}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(result), "utf8");
+  fs.renameSync(tmpPath, finalPath);
+};
+
+// Reverse-geocode `(lat, lon)` in `lang`. Returns null on:
+//   - No `address` in Nominatim's response (very rare — usually open
+//     ocean or null island).
+//   - Network / HTTP failure (logged, but doesn't throw — the caller
+//     should treat it as "no data yet, try again later").
+export const geocode = async (
+  lat: number,
+  lon: number,
+  lang: string
+): Promise<NominatimResult | null> => {
+  const cached = readCache(lat, lon, lang);
+  if (cached) return cached;
+
+  await acquireSlot();
+
+  const url = new URL(`${baseUrl()}/reverse`);
+  url.searchParams.set("lat", String(lat));
+  url.searchParams.set("lon", String(lon));
+  url.searchParams.set("format", "json");
+  url.searchParams.set("zoom", "14"); // suburb / neighbourhood level
+  url.searchParams.set("addressdetails", "1");
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        "User-Agent": userAgent(),
+        "Accept-Language": lang,
+      },
+    });
+  } catch (err) {
+    logger.error(`[geocode] ${lat},${lon} (${lang}): network error`, err);
+    return null;
+  }
+  if (!response.ok) {
+    logger.error(
+      `[geocode] ${lat},${lon} (${lang}): HTTP ${response.status} ${response.statusText}`
+    );
+    return null;
+  }
+  const raw = (await response.json()) as NominatimResponse;
+  const result = extract(raw);
+  if (!result) {
+    logger.info(`[geocode] ${lat},${lon} (${lang}): no address in response`);
+    return null;
+  }
+  writeCache(lat, lon, lang, result);
+  return result;
+};

--- a/server/db/dummy.ts
+++ b/server/db/dummy.ts
@@ -62,6 +62,8 @@ export default () => {
     loadOrphanUserGalleryRows,
     updatePhoto,
     renamePhoto,
+    upsertGeocoded,
+    loadPhotosMissingGeocoded,
     deletePhoto: notImplemented,
   };
 };
@@ -380,6 +382,44 @@ const updatePhoto = async (photoId: string, patch: Record<string, unknown>) => {
   }
   deepMerge(db.photos[photoId], patch);
 };
+// Geocoded fields — English-canonical lives on the photo "row";
+// other languages live in db.photoLocalized keyed by (photo_id, lang).
+const upsertGeocoded = async (
+  photoId: string,
+  lang: string,
+  fields: Record<string, unknown>
+) => {
+  if (!(photoId in db.photos)) return;
+  if (lang === "en") {
+    db.photos[photoId].geocoded = db.photos[photoId].geocoded || {};
+    Object.assign(db.photos[photoId].geocoded, fields);
+    return;
+  }
+  if (!db.photoLocalized) db.photoLocalized = {};
+  const key = `${photoId}:${lang}`;
+  db.photoLocalized[key] = { ...(db.photoLocalized[key] ?? {}), ...fields };
+};
+const loadPhotosMissingGeocoded = async (
+  lang: string,
+  limit: number
+): Promise<Array<{ id: string; lat: number; lon: number }>> => {
+  const out: Array<{ id: string; lat: number; lon: number }> = [];
+  for (const [id, photo] of Object.entries(db.photos) as Array<[string, any]>) {
+    const lat = photo.taken?.location?.coordinates?.latitude;
+    const lon = photo.taken?.location?.coordinates?.longitude;
+    if (lat === null || lat === undefined) continue;
+    if (lon === null || lon === undefined) continue;
+    const hasEn = !!photo.geocoded?.place;
+    const hasLocalized =
+      lang === "en"
+        ? hasEn
+        : !!db.photoLocalized?.[`${id}:${lang}`]?.place;
+    if (!hasLocalized) out.push({ id, lat, lon });
+    if (out.length >= limit) break;
+  }
+  return out;
+};
+
 const renamePhoto = async (oldId: string, newId: string) => {
   if (!(oldId in db.photos)) {
     throw new NotFoundError();

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -158,14 +158,14 @@ export default {
     return await db.unlinkAllGalleries(photoId);
   },
 
-  loadPhotos: async () => {
-    return await db.loadPhotos();
+  loadPhotos: async (lang?: string) => {
+    return await db.loadPhotos(lang);
   },
   createPhoto: async (photo: PhotoInput) => {
     await db.createPhoto(photo);
   },
-  loadPhoto: async (photoId: string) => {
-    return await db.loadPhoto(photoId);
+  loadPhoto: async (photoId: string, lang?: string) => {
+    return await db.loadPhoto(photoId, lang);
   },
   loadPhotosByOriginalFilename: async (originalFilename: string) => {
     return await db.loadPhotosByOriginalFilename(originalFilename);
@@ -191,6 +191,23 @@ export default {
   },
   renamePhoto: async (oldId: string, newId: string) => {
     await db.renamePhoto(oldId, newId);
+  },
+  upsertGeocoded: async (
+    photoId: string,
+    lang: string,
+    fields: {
+      countryCode?: string | null;
+      state?: string | null;
+      city?: string | null;
+      district?: string | null;
+      place?: string | null;
+      address?: string | null;
+    }
+  ) => {
+    await db.upsertGeocoded(photoId, lang, fields);
+  },
+  loadPhotosMissingGeocoded: async (lang: string, limit: number) => {
+    return await db.loadPhotosMissingGeocoded(lang, limit);
   },
   deletePhoto: async (photoId: string) => {
     await db.deletePhoto(photoId);

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -13,6 +13,7 @@ import schemaFactory, {
   type GalleryRow,
   type MetaRow,
   type PhotoInput,
+  type PhotoLocalizedRow,
   type PhotoRow,
   type SessionRow,
   type User,
@@ -71,6 +72,8 @@ export default () => {
     loadOrphanUserGalleryRows,
     updatePhoto,
     renamePhoto,
+    upsertGeocoded,
+    loadPhotosMissingGeocoded,
     deletePhoto,
   };
 };
@@ -409,21 +412,59 @@ const unlinkAllGalleries = async (photoId: string) => {
   ]);
 };
 
-const loadPhotos = async () => {
+// English is the canonical reverse-geocoded language stored on the
+// photo row directly. For other languages, we load the matching
+// photo_localized row(s) for the requested ids and merge per-photo
+// in mapRow (which takes the localized row as an optional third arg).
+const loadLocalizedFor = (
+  photoIds: string[],
+  lang: string
+): Map<string, PhotoLocalizedRow> => {
+  if (photoIds.length === 0) return new Map();
+  const placeholders = photoIds.map(() => "?").join(",");
+  const rows = db
+    .prepare(
+      `SELECT * FROM photo_localized
+        WHERE lang = ? AND photo_id IN (${placeholders})`
+    )
+    .all(lang, ...photoIds) as PhotoLocalizedRow[];
+  const byId = new Map<string, PhotoLocalizedRow>();
+  for (const r of rows) byId.set(r.photo_id, r);
+  return byId;
+};
+
+const loadPhotos = async (lang?: string) => {
   const rows = db.prepare(SCHEMA.photo.buildSelectQuery()).all() as PhotoRow[];
-  return rows.map((row, index) => SCHEMA.photo.mapRow(row, index));
+  const localized =
+    lang && lang !== "en"
+      ? loadLocalizedFor(
+        rows.map((r) => r.id),
+        lang
+      )
+      : new Map<string, PhotoLocalizedRow>();
+  return rows.map((row, index) =>
+    SCHEMA.photo.mapRow(row, index, localized.get(row.id))
+  );
 };
 const createPhoto = async (photo: PhotoInput) => {
   db.prepare(SCHEMA.photo.buildCreateQuery()).run(
     SCHEMA.photo.mapInsert(photo)
   );
 };
-const loadPhoto = async (photoId: string) => {
+const loadPhoto = async (photoId: string, lang?: string) => {
   const row = db.prepare(SCHEMA.photo.buildSelectByIdQuery()).get(photoId) as
     | PhotoRow
     | undefined;
   if (!row) throw new NotFoundError();
-  return SCHEMA.photo.mapRow(row, 0);
+  const localized =
+    lang && lang !== "en"
+      ? (db
+        .prepare(
+          "SELECT * FROM photo_localized WHERE photo_id = ? AND lang = ?"
+        )
+        .get(photoId, lang) as PhotoLocalizedRow | undefined)
+      : undefined;
+  return SCHEMA.photo.mapRow(row, 0, localized);
 };
 const loadPhotosByOriginalFilename = async (originalFilename: string) => {
   const rows = db
@@ -551,3 +592,100 @@ const renamePhoto = async (oldId: string, newId: string) => {
 };
 const deletePhoto = async (photoId: string) =>
   deleteById(SCHEMA.photo, photoId);
+
+// Geocoded fields for one (photo, lang) pair. English routes to the
+// photo columns directly; everything else goes to photo_localized
+// (upsert). `address` is stringified JSON; pass `null` to clear.
+export interface GeocodedFields {
+  countryCode?: string | null; // English-only meaningful (column on photo)
+  state?: string | null;
+  city?: string | null;
+  district?: string | null;
+  place?: string | null;
+  address?: string | null; // JSON
+}
+const upsertGeocoded = async (
+  photoId: string,
+  lang: string,
+  fields: GeocodedFields
+) => {
+  if (lang === "en") {
+    // Patch the photo row's English-canonical columns.
+    const updates: string[] = [];
+    const values: unknown[] = [];
+    const addField = (col: string, val: unknown) => {
+      if (val === undefined) return;
+      updates.push(`${col} = ?`);
+      values.push(val);
+    };
+    addField("geocoded_country_code", fields.countryCode);
+    addField("geocoded_state", fields.state);
+    addField("geocoded_city", fields.city);
+    addField("geocoded_district", fields.district);
+    addField("geocoded_place", fields.place);
+    addField("geocoded_address", fields.address);
+    if (updates.length === 0) return;
+    db.prepare(
+      `UPDATE photo SET ${updates.join(", ")} WHERE id = ?`
+    ).run(...values, photoId);
+    return;
+  }
+  // Non-English: upsert into photo_localized. countryCode is
+  // language-independent so we ignore it on this path.
+  db.prepare(
+    `INSERT INTO photo_localized
+       (photo_id, lang, geocoded_state, geocoded_city,
+        geocoded_district, geocoded_place, geocoded_address)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT (photo_id, lang) DO UPDATE SET
+       geocoded_state    = COALESCE(excluded.geocoded_state, photo_localized.geocoded_state),
+       geocoded_city     = COALESCE(excluded.geocoded_city, photo_localized.geocoded_city),
+       geocoded_district = COALESCE(excluded.geocoded_district, photo_localized.geocoded_district),
+       geocoded_place    = COALESCE(excluded.geocoded_place, photo_localized.geocoded_place),
+       geocoded_address  = COALESCE(excluded.geocoded_address, photo_localized.geocoded_address)`
+  ).run(
+    photoId,
+    lang,
+    fields.state ?? null,
+    fields.city ?? null,
+    fields.district ?? null,
+    fields.place ?? null,
+    fields.address ?? null
+  );
+};
+
+// Daemon's "give me work" query — photos with coords that are missing
+// geocoded data for the requested language. Recent first by capture
+// timestamp; rows with no timestamp (EXIF-less imports) go to the back
+// so the visible / recently-shot photos get filled in earliest.
+const loadPhotosMissingGeocoded = async (
+  lang: string,
+  limit: number
+): Promise<Array<{ id: string; lat: number; lon: number }>> => {
+  const sql =
+    lang === "en"
+      ? `SELECT id, coord_lat, coord_lon FROM photo
+           WHERE coord_lat IS NOT NULL AND coord_lon IS NOT NULL
+             AND geocoded_place IS NULL
+           ORDER BY taken IS NULL, taken DESC, id ASC
+           LIMIT ?`
+      : `SELECT p.id, p.coord_lat, p.coord_lon FROM photo p
+           LEFT JOIN photo_localized pl
+             ON pl.photo_id = p.id AND pl.lang = ?
+           WHERE p.coord_lat IS NOT NULL AND p.coord_lon IS NOT NULL
+             AND pl.photo_id IS NULL
+           ORDER BY p.taken IS NULL, p.taken DESC, p.id ASC
+           LIMIT ?`;
+  const rows = (lang === "en"
+    ? db.prepare(sql).all(limit)
+    : db.prepare(sql).all(lang, limit)) as Array<{
+    id: string;
+    coord_lat: number;
+    coord_lon: number;
+  }>;
+  return rows.map((r) => ({
+    id: r.id,
+    lat: r.coord_lat,
+    lon: r.coord_lon,
+  }));
+};

--- a/server/db/sqlite3/migrations/007_add_geocoded_place.sql
+++ b/server/db/sqlite3/migrations/007_add_geocoded_place.sql
@@ -1,0 +1,40 @@
+-- Reverse-geocoded place hierarchy, derived from the photo's coords via
+-- Nominatim at intake (and via `bin/photo-geocode.ts` for backfill).
+-- Additive to the existing `country_code` / `place` columns — those keep
+-- their operator-set meaning (place can be "home" or any custom label;
+-- country_code is operator-set with a default at insert time).
+--
+-- English is the canonical / filter-keyed language, stored directly on
+-- the photo row so filter queries and the English read path don't need
+-- a join. Other languages live in `photo_localized` — exists only when
+-- actually translated, no `lang='en'` rows there.
+--
+-- `geocoded_address` keeps Nominatim's raw `address` object as JSON so
+-- the field mapping (state ← state || province || region || ...) can
+-- be revised without re-fetching.
+
+ALTER TABLE photo ADD COLUMN geocoded_country_code TEXT;
+ALTER TABLE photo ADD COLUMN geocoded_state TEXT;
+ALTER TABLE photo ADD COLUMN geocoded_city TEXT;
+ALTER TABLE photo ADD COLUMN geocoded_district TEXT;
+ALTER TABLE photo ADD COLUMN geocoded_place TEXT;
+ALTER TABLE photo ADD COLUMN geocoded_address TEXT;
+
+CREATE INDEX photo_geocoded_country_idx  ON photo (geocoded_country_code);
+CREATE INDEX photo_geocoded_state_idx    ON photo (geocoded_state);
+CREATE INDEX photo_geocoded_city_idx     ON photo (geocoded_city);
+CREATE INDEX photo_geocoded_district_idx ON photo (geocoded_district);
+
+CREATE TABLE photo_localized (
+  photo_id          TEXT NOT NULL,
+  lang              TEXT NOT NULL,
+  geocoded_state    TEXT,
+  geocoded_city     TEXT,
+  geocoded_district TEXT,
+  geocoded_place    TEXT,
+  geocoded_address  TEXT,
+  PRIMARY KEY (photo_id, lang),
+  FOREIGN KEY (photo_id) REFERENCES photo(id) ON DELETE CASCADE
+);
+
+UPDATE meta SET value='7' WHERE key='schema_version';

--- a/server/db/sqlite3/schema.ts
+++ b/server/db/sqlite3/schema.ts
@@ -68,6 +68,26 @@ export interface PhotoRow {
   disp_height: number | null;
   thumb_width: number | null;
   thumb_height: number | null;
+  // English-canonical reverse-geocoded fields. Other languages live
+  // in `photo_localized`. See migration 007.
+  geocoded_country_code: string | null;
+  geocoded_state: string | null;
+  geocoded_city: string | null;
+  geocoded_district: string | null;
+  geocoded_place: string | null;
+  geocoded_address: string | null; // raw Nominatim address JSON
+}
+
+// `photo_localized` row — non-English geocoded place data per
+// (photo_id, lang) pair.
+export interface PhotoLocalizedRow {
+  photo_id: string;
+  lang: string;
+  geocoded_state: string | null;
+  geocoded_city: string | null;
+  geocoded_district: string | null;
+  geocoded_place: string | null;
+  geocoded_address: string | null;
 }
 
 // App-side shapes (what mapRow returns / mapInsert and mapToRow take).
@@ -128,6 +148,20 @@ export interface Photo {
     original: { width: number | undefined; height: number | undefined };
     display: { width: number | undefined; height: number | undefined };
     thumbnail: { width: number | undefined; height: number | undefined };
+  };
+  // Reverse-geocoded location, resolved for the requesting language
+  // (falls back to the English photo columns when no `photo_localized`
+  // row exists for that language). See migration 007 + #246.
+  geocoded: {
+    countryCode: string | undefined;
+    state: string | undefined;
+    city: string | undefined;
+    district: string | undefined;
+    place: string | undefined;
+    // Nominatim's raw `address` object as returned at fetch time
+    // (parsed from the stored JSON). Kept for future re-derivation
+    // if the state/city/district mapping changes.
+    address: Record<string, unknown> | undefined;
   };
 }
 
@@ -293,10 +327,22 @@ export default () => {
         buildDeleteQuery(SCHEMA.galleryPhoto, conditions),
     },
     photo: {
-      mapRow: (row: PhotoRow, index: number): Photo => {
+      // `localized` (optional) is the photo_localized row for the
+      // requesting language. When present, its non-null fields take
+      // precedence over the English columns on `row`. Callers that
+      // don't need localized data omit it; mapRow returns English.
+      mapRow: (
+        row: PhotoRow,
+        index: number,
+        localized?: PhotoLocalizedRow
+      ): Photo => {
         const taken = new Date(toString(row.taken).substring(0, 19));
         const normalizeCountry = (country: string | null) =>
           !country || country === "unknown" ? undefined : country;
+        const pick = (
+          loc: string | null | undefined,
+          en: string | null
+        ): string | undefined => loc ?? en ?? undefined;
 
         return {
           id: toString(row.id),
@@ -355,6 +401,28 @@ export default () => {
               height: toNumber(row.thumb_height),
             },
           },
+          geocoded: {
+            // country_code is language-independent — only ever from the
+            // photo column, never `photo_localized`.
+            countryCode: normalizeCountry(row.geocoded_country_code),
+            state: pick(localized?.geocoded_state, row.geocoded_state),
+            city: pick(localized?.geocoded_city, row.geocoded_city),
+            district: pick(
+              localized?.geocoded_district,
+              row.geocoded_district
+            ),
+            place: pick(localized?.geocoded_place, row.geocoded_place),
+            address: (() => {
+              const raw =
+                localized?.geocoded_address ?? row.geocoded_address;
+              if (!raw) return undefined;
+              try {
+                return JSON.parse(raw) as Record<string, unknown>;
+              } catch {
+                return undefined;
+              }
+            })(),
+          },
         };
       },
       mapInsert: (photo: PhotoInput): unknown[] => {
@@ -391,6 +459,13 @@ export default () => {
           map.disp_height,
           map.thumb_width,
           map.thumb_height,
+
+          map.geocoded_country_code,
+          map.geocoded_state,
+          map.geocoded_city,
+          map.geocoded_district,
+          map.geocoded_place,
+          map.geocoded_address,
         ];
       },
 
@@ -514,6 +589,24 @@ const photoMapToRow = (photo: PhotoInput): Record<string, unknown> => {
       if ("height" in thumbnail) result.thumb_height = thumbnail.height;
     }
   }
+  if (photo.geocoded) {
+    const g = photo.geocoded;
+    if ("countryCode" in g) result.geocoded_country_code = g.countryCode;
+    if ("state" in g) result.geocoded_state = g.state;
+    if ("city" in g) result.geocoded_city = g.city;
+    if ("district" in g) result.geocoded_district = g.district;
+    if ("place" in g) result.geocoded_place = g.place;
+    if ("address" in g) {
+      // Address is a Nominatim raw object; store as JSON string.
+      // Pass-through if already string.
+      result.geocoded_address =
+        typeof g.address === "string"
+          ? g.address
+          : g.address === undefined
+            ? undefined
+            : JSON.stringify(g.address);
+    }
+  }
   return result;
 };
 
@@ -610,6 +703,13 @@ const SCHEMA = {
       "disp_height",
       "thumb_width",
       "thumb_height",
+
+      "geocoded_country_code",
+      "geocoded_state",
+      "geocoded_city",
+      "geocoded_district",
+      "geocoded_place",
+      "geocoded_address",
     ],
     primaryKey: ["id"],
     order: ["taken ASC", "id ASC"],

--- a/server/tests/db/sqlite3/migrate.test.ts
+++ b/server/tests/db/sqlite3/migrate.test.ts
@@ -33,7 +33,7 @@ describe("migrate", () => {
   test("fresh DB runs every migration and lands at the highest version", () => {
     const db = open();
     migrate(db);
-    expect(schemaVersion(db)).toBe(6);
+    expect(schemaVersion(db)).toBe(7);
     expect(tableNames(db)).toEqual(
       expect.arrayContaining([
         "gallery",
@@ -100,7 +100,7 @@ describe("migrate", () => {
 
     migrate(db);
 
-    expect(schemaVersion(db)).toBe(6);
+    expect(schemaVersion(db)).toBe(7);
     expect(gallerPhotoFkRefs(db).sort()).toEqual(["gallery", "photo"]);
     const rows = db.prepare("SELECT * FROM gallery_photo").all();
     expect(rows).toEqual([{ gallery_id: "g1", photo_id: "p1" }]);

--- a/server/tests/db/sqlite3/schema.test.ts
+++ b/server/tests/db/sqlite3/schema.test.ts
@@ -328,10 +328,17 @@ describe("Photo", () => {
     "disp_height",
     "thumb_width",
     "thumb_height",
+
+    "geocoded_country_code",
+    "geocoded_state",
+    "geocoded_city",
+    "geocoded_district",
+    "geocoded_place",
+    "geocoded_address",
   ].join(",");
   test("Build create query", () =>
     expect(schema.photo.buildCreateQuery()).toBe(
-      `INSERT INTO photo (${cols}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
+      `INSERT INTO photo (${cols}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`
     ));
   test("Build select by id query", () =>
     expect(schema.photo.buildSelectByIdQuery()).toBe(


### PR DESCRIPTION
## Summary

The data-side of #246. After this lands, fresh JPEGs with EXIF GPS imported through the converter get their place hierarchy populated in the DB at intake time. PR 2 of #246 will add the `bin/photo-geocode.ts` daemon for backfilling existing photos and adding languages later; PR 3 adds `bin/photo.ts audit --country-mismatch` (#346).

## Schema (migration 007)

```sql
ALTER TABLE photo ADD COLUMN geocoded_country_code TEXT;
ALTER TABLE photo ADD COLUMN geocoded_state        TEXT;
ALTER TABLE photo ADD COLUMN geocoded_city         TEXT;
ALTER TABLE photo ADD COLUMN geocoded_district     TEXT;
ALTER TABLE photo ADD COLUMN geocoded_place        TEXT;
ALTER TABLE photo ADD COLUMN geocoded_address      TEXT;     -- raw Nominatim address JSON

CREATE INDEX photo_geocoded_country_idx  ON photo (geocoded_country_code);
CREATE INDEX photo_geocoded_state_idx    ON photo (geocoded_state);
CREATE INDEX photo_geocoded_city_idx     ON photo (geocoded_city);
CREATE INDEX photo_geocoded_district_idx ON photo (geocoded_district);

CREATE TABLE photo_localized (
  photo_id          TEXT NOT NULL,
  lang              TEXT NOT NULL,   -- never 'en'
  geocoded_state    TEXT,
  geocoded_city     TEXT,
  geocoded_district TEXT,
  geocoded_place    TEXT,
  geocoded_address  TEXT,
  PRIMARY KEY (photo_id, lang),
  FOREIGN KEY (photo_id) REFERENCES photo(id) ON DELETE CASCADE
);
```

English is the canonical / filter-keyed language; lives on the photo row directly so filter queries and the English read path don't need a join. Other languages live in `photo_localized` only when actually translated. `geocoded_address` keeps Nominatim's raw response so the field mapping can be revised without re-fetching.

Operator-set `photo.country_code` and `photo.place` are **untouched** — the reverse-geocode data sits alongside.

## Module

`converter/reverse-geocode/`:

- Nominatim client with custom `User-Agent: photo-diary/<version> (<repo-url>)` and 1 RPS queue (per Nominatim's public usage policy).
- Per-`(lang, coord)` file cache at `${GEOCODE_DIR}/cache/<lang>/<lat>:<lon>.json` (coords rounded to 4 decimals ≈ 11 m precision). Atomic writes via temp + rename so partial JSONs never read back as cache hits.
- Country-specific fallback chains for `state` / `city` / `district`. Singapore-style city-states leave `state` NULL and that's fine — `display_name` still renders.
- Env: `NOMINATIM_BASE_URL` (self-host escape), `GEOCODE_DIR` (defaults to `<cwd>/.geocode/`).
- Network / no-address failures log but don't throw — caller gets `null` and moves on.

## Converter intake

- Opt-in via `REVERSE_GEOCODE=1` in the instance's `.env`.
- `REVERSE_GEOCODE_EXTRA_LANGS=ja,fi` lists languages beyond the always-on English. Each extra is one additional Nominatim call per photo at intake (at 1 RPS, so a 3-language setup adds ~3 s per photo with coords on cache miss).

## Driver layer

- `db.upsertGeocoded(photoId, lang, fields)` routes English to photo columns, other languages to `photo_localized` via upsert that doesn't clobber existing non-NULL fields.
- `db.loadPhotosMissingGeocoded(lang, limit)` is the daemon's "give me work" query (PR 2's consumer). Ordered by `taken DESC NULLS LAST, id ASC` so recent photos (more likely to be visited) get filled in first; EXIF-less photos go to the back.
- `db.loadPhoto` / `db.loadPhotos` accept optional `lang`. When non-English, joins `photo_localized` and merges localized values over English photo columns in `mapRow`.

## Backend API exposure

Photo response gains a `geocoded` field:

```ts
{
  geocoded: {
    countryCode: string | undefined,
    state: string | undefined,
    city: string | undefined,
    district: string | undefined,
    place: string | undefined,
    address: Record<string, unknown> | undefined,   // parsed raw JSON
  }
}
```

Controllers don't yet thread `lang` from the request — EN-for-everyone for now. The driver-layer plumbing is ready; controller plumbing comes in a tiny follow-up paired with #247's frontend work in 0.12.

## Test plan

- [x] `npm run typecheck --workspaces` — clean.
- [x] `npm run lint --workspaces` — clean.
- [x] `npm test --workspaces` — 634 server + 963 react-app + 7 converter pass.
- [x] Migration tests updated to expect schema version 7 + the new columns in the photo schema's column list.
- [x] Manual against the dev DB:
  - Direct `geocode(35.6586, 139.7454, "en")` returns Minato / Tokyo / Japan structured data + display_name; cache file written; second call cache-hits.
  - Same coords in `ja` and `fi` return localized strings.
  - `db.upsertGeocoded(id, "en", ...)` writes to photo columns; `loadPhoto(id)` returns those.
  - `db.upsertGeocoded(id, "ja", ...)` writes to `photo_localized`; `loadPhoto(id, "ja")` returns Japanese values; `loadPhoto(id)` (no lang) still returns English.
  - `country_code` stays language-independent (lives on photo, not photo_localized).

## What's next

- **PR 2 of #246**: `bin/photo-geocode.ts` daemon for backfilling existing photos + adding languages later. Operator-side tool, long-running, lock-file + resumable.
- **PR 3 (#346)**: `bin/photo.ts audit --country-mismatch` — small audit addition using the new `geocoded_country_code`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)