### PR TITLE
bin/photo.ts audit: distinguish 'no Nominatim coverage' from pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Photo modal photo no longer animates from oversized to fit-size when opening on viewports wider than the modal's 1400 px max-width. The carousel Slide and Content Root each set `min-width: 0` so the flex-item default `min-width: auto` doesn't let those ancestors grow to the photo Frame's explicit width during initial mount; without it the over-large initial Frame triggered a ResizeObserver feedback loop that shrunk the photo by ~16 px per frame over ~7 frames. Same loop also caused a one-frame stretch of the outgoing photo at the end of the slide animation.
 - Photo modal `Content` measures container dimensions in `useLayoutEffect` instead of `useEffect`, so the corrective rect read happens before the first paint.
 
+### Tooling
+
+- `bin/photo.ts audit --country-mismatch` footer now distinguishes "still need geocoding" from "no Nominatim coverage" (the `geocode_no_data` flag set by intake / `photo-geocode.ts` when Nominatim returned no address). Previously rows flagged as no-data were still counted as "not yet geocoded" and pointed the operator at `./bin/photo-geocode.ts` — re-running the daemon found nothing to do and the audit kept nagging. The `noData` flag is also surfaced on the mapped `Photo.geocoded` so the audit (and any other consumer) can read it.
+
 ## [0.11.0] - 2026-05-28
 
 ### Server

--- a/server/bin/photo.ts
+++ b/server/bin/photo.ts
@@ -316,17 +316,30 @@ const buildChecks = (
     },
     footer: () => {
       let withCoords = 0;
-      let withoutGeocoded = 0;
+      let pending = 0;
+      let noData = 0;
       for (const p of photos) {
         const lat = p.taken?.location?.coordinates?.latitude;
         const lon = p.taken?.location?.coordinates?.longitude;
         if (lat === null || lat === undefined) continue;
         if (lon === null || lon === undefined) continue;
         withCoords += 1;
-        if (!p.geocoded?.countryCode) withoutGeocoded += 1;
+        if (p.geocoded?.countryCode) continue;
+        if (p.geocoded?.noData) noData += 1;
+        else pending += 1;
       }
-      if (withoutGeocoded === 0) return undefined;
-      return `(${withoutGeocoded} of ${withCoords} photo(s) with coords not yet geocoded — run \`./bin/photo-geocode.ts\` first)`;
+      const lines: string[] = [];
+      if (pending > 0) {
+        lines.push(
+          `(${pending} of ${withCoords} photo(s) with coords still need geocoding — run \`./bin/photo-geocode.ts\` first)`
+        );
+      }
+      if (noData > 0) {
+        lines.push(
+          `(${noData} of ${withCoords} photo(s) with coords have no Nominatim coverage; flagged \`geocode_no_data\`)`
+        );
+      }
+      return lines.length > 0 ? lines.join("\n") : undefined;
     },
   });
 

--- a/server/db/sqlite3/schema.ts
+++ b/server/db/sqlite3/schema.ts
@@ -166,6 +166,11 @@ export interface Photo {
     // (parsed from the stored JSON). Kept for future re-derivation
     // if the state/city/district mapping changes.
     address: Record<string, unknown> | undefined;
+    // Negative-result cache: true when intake or the backfill daemon
+    // found Nominatim had no address for these coordinates. Operator
+    // tools (`bin/photo.ts audit --country-mismatch` etc.) consult
+    // this to distinguish "not yet geocoded" from "no data available".
+    noData: boolean;
   };
 }
 
@@ -426,6 +431,7 @@ export default () => {
                 return undefined;
               }
             })(),
+            noData: row.geocode_no_data === 1,
           },
         };
       },


### PR DESCRIPTION
## Summary

Reported by operator after a real-instance run: `photo-geocode.ts --apply` reports "nothing to do" but `bin/photo.ts audit --country-mismatch` immediately after still claims "N photos with coords not yet geocoded — run `./bin/photo-geocode.ts` first". Re-running the daemon doesn't change anything; the audit keeps nagging.

## Root cause

0.11 added `photo.geocode_no_data` — a negative-result cache the converter intake and the daemon set when Nominatim returns a 200 with no `address` (open ocean, disputed boundaries, etc.). The DB column and the `loadPhotosMissingGeocoded` query skip those rows, but the flag wasn't surfaced on the mapped `Photo` interface, so the audit (which reads through `db.loadPhotos`) couldn't tell apart "pending" and "no data available". Its footer counted both groups as pending and pointed the operator at the daemon.

## Fix

- `Photo.geocoded.noData: boolean` added to the mapped shape, driven by `row.geocode_no_data === 1`. Internal-only — OpenAPI dump is unchanged (no API caller reaches in).
- Audit footer splits the count: rows without a geocoded country and `noData = false` get "still need geocoding"; rows with `noData = true` get "no Nominatim coverage; flagged `geocode_no_data`". Either / both lines print only when non-zero.

## Verification

`dev/db.sqlite3.dailybw_0_11` (has the South-China-Sea row flagged from earlier):

```
$ ./bin/photo.ts audit --country-mismatch
Audited 3382 photo(s).

Photos where operator country and geocoded country disagree: 0
(1 of 3382 photo(s) with coords have no Nominatim coverage; flagged `geocode_no_data`)
```

## Test plan

- [x] `npm run typecheck` clean across all three workspaces
- [x] `npm test` clean (server 634, react-app 964)
- [x] `npm run lint` clean across all three workspaces
- [x] Manual run on the dailybw post-0.11 DB shows the expected footer split
- [x] OpenAPI regenerated; no diff (flag is internal)

Will ride along with the next release — no urgency to merge.