### PR TITLE
Render geocoded place per UI language in MetadataPanel (closes #247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - Photo modal drag past a gallery edge now stays bounded. The carousel `dragConstraints` were expressed in the wrong reference frame (relative to translate-origin 0 rather than the track's resting `motion.x = -window.innerWidth`), so dragging from the last (or first) photo immediately snapped the track toward 0 and exposed the neighbouring slide. Corrected to `[-2 × innerWidth, 0]` with edge variants that lock at rest.
 - Photo modal photo no longer animates from oversized to fit-size when opening on viewports wider than the modal's 1400 px max-width. The carousel Slide and Content Root each set `min-width: 0` so the flex-item default `min-width: auto` doesn't let those ancestors grow to the photo Frame's explicit width during initial mount; without it the over-large initial Frame triggered a ResizeObserver feedback loop that shrunk the photo by ~16 px per frame over ~7 frames. Same loop also caused a one-frame stretch of the outgoing photo at the end of the slide animation.
 - Photo modal `Content` measures container dimensions in `useLayoutEffect` instead of `useEffect`, so the corrective rect read happens before the first paint.
+- Photo modal MetadataPanel renders the reverse-geocoded place below the operator location row, in the same shape, with the country flag trailed (Nominatim's `display_name` already ends in the country, so the country name isn't repeated). Skipped when both sides agree. Layout polish lives in a separate ticket.
+
+### Server
+
+- `GET /api/v1/gallery-photos/:galleryId` and `GET /api/v1/gallery-photos/:galleryId/:photoId` accept a `?lang=<code>` query parameter. When present and non-`en`, the response merges `photo_localized` rows over the EN-canonical geocoded fields. `db.loadGalleryPhotos` / `loadGalleryPhoto` propagate the parameter. Without `?lang=`, behaviour is unchanged.
 
 ### Tooling
 

--- a/react-app/src/components/Gallery/Photo/MetadataPanel.tsx
+++ b/react-app/src/components/Gallery/Photo/MetadataPanel.tsx
@@ -146,6 +146,32 @@ const MetadataPanel = ({
       </Row>
     );
   };
+  // Nominatim's `display_name` already ends in the country, so we
+  // trail just the flag, not the country name.
+  const renderGeocodedLocation = () => {
+    if (!photo.hasGeocodedPlace()) return null;
+    // Skip when both sides resolve to the same string.
+    const opPlace = photo.place();
+    const opCountry = photo.countryCode();
+    const code = photo.geocodedCountryCode();
+    const samePlace = !!opPlace && opPlace === photo.geocodedPlace();
+    const sameCountry =
+      !!opCountry && opCountry.toLowerCase() === code?.toLowerCase();
+    if (samePlace && sameCountry) return null;
+    return (
+      <Row>
+        <Part>
+          {photo.geocodedPlace()}
+          {code ? (
+            <>
+              {" "}
+              <FlagIcon code={code} />
+            </>
+          ) : null}
+        </Part>
+      </Row>
+    );
+  };
   const renderCoordinates = () => {
     if (!photo.hasCoordinates()) return null;
     return <Muted>{photo.formatCoordinates()}</Muted>;
@@ -262,6 +288,7 @@ const MetadataPanel = ({
       <Body>
         {photo.title() && <Title>{photo.title()}</Title>}
         {renderLocation()}
+        {renderGeocodedLocation()}
         {renderCoordinates()}
         {renderExposure()}
         {renderGear()}

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -120,9 +120,9 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
     !!galleriesQuery.data &&
     galleriesQuery.data.some((g) => g.id() === galleryId);
   const photosQuery = useQuery({
-    queryKey: ["gallery-photos", galleryId, user?.id ?? null],
+    queryKey: ["gallery-photos", galleryId, user?.id ?? null, lang],
     queryFn: async () => {
-      const data = await galleryPhotosService.get(galleryId as string);
+      const data = await galleryPhotosService.get(galleryId as string, lang);
       return data
         .map((photo) => PhotoModel(photo))
         .filter((p): p is PhotoT => !!p);

--- a/react-app/src/lib/api-schema.ts
+++ b/react-app/src/lib/api-schema.ts
@@ -767,7 +767,9 @@ export interface paths {
         /** List photos in a gallery */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    lang?: string;
+                };
                 header?: never;
                 path: {
                     galleryId: string;
@@ -807,7 +809,9 @@ export interface paths {
         /** Get one photo's metadata in a gallery's context */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    lang?: string;
+                };
                 header?: never;
                 path: {
                     galleryId: string;

--- a/react-app/src/models/PhotoModel.ts
+++ b/react-app/src/models/PhotoModel.ts
@@ -31,6 +31,16 @@ interface Location {
   coordinates?: Coordinates;
 }
 
+// Reverse-geocoded from coords; distinct from operator-set
+// `country` / `place` above. Server resolves `place` per-lang.
+interface Geocoded {
+  countryCode?: string;
+  state?: string;
+  city?: string;
+  district?: string;
+  place?: string;
+}
+
 interface Taken {
   author?: string;
   instant: Instant;
@@ -59,6 +69,7 @@ export interface PhotoData {
   camera?: Gear;
   lens?: Gear;
   exposure?: Exposure;
+  geocoded?: Geocoded;
 }
 
 interface CountryData {
@@ -256,6 +267,16 @@ const PhotoModel = (photoData: unknown) => {
         : "",
     hasPlace: (): boolean => !!photo.taken.location?.place,
     place: (): string | undefined => photo.taken.location?.place,
+    hasGeocodedPlace: (): boolean => !!photo.geocoded?.place,
+    geocodedPlace: (): string | undefined => photo.geocoded?.place,
+    hasGeocodedCountry: (): boolean => !!photo.geocoded?.countryCode,
+    geocodedCountryCode: (): string | undefined => photo.geocoded?.countryCode,
+    geocodedCountryName: (lang: string, countryData: CountryData): string =>
+      self.hasGeocodedCountry() && self.geocodedCountryCode()
+        ? format.countryName(lang, countryData)(
+          self.geocodedCountryCode() as string
+        )
+        : "",
     hasCoordinates: (): boolean =>
       !!(
         photo.taken.location?.coordinates?.latitude &&

--- a/react-app/src/services/gallery-photos.ts
+++ b/react-app/src/services/gallery-photos.ts
@@ -1,9 +1,9 @@
 import api, { unwrap } from "../lib/api";
 
-const get = async (galleryId: string) =>
+const get = async (galleryId: string, lang?: string) =>
   unwrap(
     api.GET("/api/v1/gallery-photos/{galleryId}", {
-      params: { path: { galleryId } },
+      params: { path: { galleryId }, query: lang ? { lang } : undefined },
     })
   );
 

--- a/server/controllers/gallery-photos-v1.ts
+++ b/server/controllers/gallery-photos-v1.ts
@@ -18,6 +18,11 @@ const GalleryPhotoParams = Type.Object({
   galleryId: Type.String(),
   photoId: Type.String(),
 });
+// Picks the geocoded place / state / city / district from photo_localized
+// when set; falls back to the EN canonical on the photo row.
+const LangQuery = Type.Object({
+  lang: Type.Optional(Type.String()),
+});
 // Permissive — joined photo metadata, wider than the contract.
 const PhotoItem = Type.Object({}, { additionalProperties: true });
 const GalleryPhotosListResponse = Type.Array(PhotoItem);
@@ -34,6 +39,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         tags: TAGS,
         summary: "List photos in a gallery",
         params: GalleryIdParam,
+        querystring: LangQuery,
         response: { 200: GalleryPhotosListResponse },
       },
     },
@@ -45,7 +51,10 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
           request.user.id,
           request.params.galleryId
         );
-        const photos = await model.getGalleryPhotos(request.params.galleryId);
+        const photos = await model.getGalleryPhotos(
+          request.params.galleryId,
+          request.query.lang
+        );
         if (await shouldHideMap(request.user.id, request.params.galleryId)) {
           maskCoordinates(photos as Parameters<typeof maskCoordinates>[0]);
         }
@@ -69,6 +78,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         tags: TAGS,
         summary: "Get one photo's metadata in a gallery's context",
         params: GalleryPhotoParams,
+        querystring: LangQuery,
         response: { 200: PhotoItem },
       },
     },
@@ -81,7 +91,8 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         );
         const photo = await model.getGalleryPhoto(
           request.params.galleryId,
-          request.params.photoId
+          request.params.photoId,
+          request.query.lang
         );
         if (await shouldHideMap(request.user.id, request.params.galleryId)) {
           maskCoordinates([photo] as Parameters<typeof maskCoordinates>[0]);

--- a/server/db/dummy.ts
+++ b/server/db/dummy.ts
@@ -184,7 +184,7 @@ const updateGallery = async () => {
 const comparePhotos = (a: any, b: any) =>
   a.taken.instant.timestamp.localeCompare(b.taken.instant.timestamp);
 
-const loadGalleryPhotos = async (galleryId: string) => {
+const loadGalleryPhotos = async (galleryId: string, _lang?: string) => {
   switch (galleryId) {
     case CONST.SPECIAL_GALLERY_ALL:
       return Object.values(db.photos).sort(comparePhotos);
@@ -214,7 +214,7 @@ const loadGalleryPhotos = async (galleryId: string) => {
 const linkGalleryPhoto = async () => {
   throw new NotImplementedError();
 };
-const loadGalleryPhoto = async (galleryId: string, photoId: string) => {
+const loadGalleryPhoto = async (galleryId: string, photoId: string, _lang?: string) => {
   const handleGalleryAll = async () => {
     return await loadPhoto(photoId);
   };

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -139,14 +139,14 @@ export default {
     await db.deleteGallery(galleryId);
   },
 
-  loadGalleryPhotos: async (galleryId: string) => {
-    return await db.loadGalleryPhotos(galleryId);
+  loadGalleryPhotos: async (galleryId: string, lang?: string) => {
+    return await db.loadGalleryPhotos(galleryId, lang);
   },
   linkGalleryPhoto: async (galleryIds: string[], photoIds: string[]) => {
     return await db.linkGalleryPhoto(galleryIds, photoIds);
   },
-  loadGalleryPhoto: async (galleryId: string, photoId: string) => {
-    return await db.loadGalleryPhoto(galleryId, photoId);
+  loadGalleryPhoto: async (galleryId: string, photoId: string, lang?: string) => {
+    return await db.loadGalleryPhoto(galleryId, photoId, lang);
   },
   unlinkGalleryPhoto: async (galleryId: string, photoId: string) => {
     return await db.unlinkGalleryPhoto(galleryId, photoId);

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -319,7 +319,7 @@ const updateGallery = async (galleryId: string, gallery: GalleryInput) => {
 const deleteGallery = async (galleryId: string) =>
   deleteById(SCHEMA.gallery, galleryId);
 
-const loadGalleryPhotos = async (galleryId: string) => {
+const loadGalleryPhotos = async (galleryId: string, lang?: string) => {
   const schema = SCHEMA.photo;
   const getQuery = () => {
     switch (galleryId) {
@@ -344,7 +344,13 @@ const loadGalleryPhotos = async (galleryId: string) => {
   const rows = (galleryId.startsWith(CONST.SPECIAL_GALLERY_PREFIX)
     ? stmt.all()
     : stmt.all(galleryId)) as PhotoRow[];
-  return rows.map((row, index) => schema.mapRow(row, index));
+  const localized =
+    lang && lang !== "en"
+      ? loadLocalizedFor(rows.map((r) => r.id), lang)
+      : new Map<string, PhotoLocalizedRow>();
+  return rows.map((row, index) =>
+    schema.mapRow(row, index, localized.get(row.id))
+  );
 };
 const linkGalleryPhoto = async (
   galleryIds: string[],
@@ -361,10 +367,14 @@ const linkGalleryPhoto = async (
   });
   insertAll();
 };
-const loadGalleryPhoto = async (galleryId: string, photoId: string) => {
+const loadGalleryPhoto = async (
+  galleryId: string,
+  photoId: string,
+  lang?: string
+) => {
   if (galleryId === CONST.SPECIAL_GALLERY_ALL) {
     // TODO: fix
-    return loadPhoto(photoId);
+    return loadPhoto(photoId, lang);
   }
   const schema = SCHEMA.photo;
   const getQuery = () => {
@@ -394,7 +404,15 @@ const loadGalleryPhoto = async (galleryId: string, photoId: string) => {
   if (rows.length === 0) {
     throw new NotFoundError();
   }
-  return schema.mapRow(rows[0], 0);
+  const localized =
+    lang && lang !== "en"
+      ? (db
+        .prepare(
+          "SELECT * FROM photo_localized WHERE photo_id = ? AND lang = ?"
+        )
+        .get(photoId, lang) as PhotoLocalizedRow | undefined)
+      : undefined;
+  return schema.mapRow(rows[0], 0, localized);
 };
 const unlinkGalleryPhoto = async (galleryId: string, photoId: string) => {
   db.prepare(SCHEMA.galleryPhoto.buildDeleteByIdQuery()).run([

--- a/server/models/gallery-photo.ts
+++ b/server/models/gallery-photo.ts
@@ -15,13 +15,17 @@ export default () => {
 
 const init = async () => {};
 
-const getGalleryPhotos = async (galleryId: string) => {
+const getGalleryPhotos = async (galleryId: string, lang?: string) => {
   logger.debug("Getting photos from gallery", galleryId);
-  return await db.loadGalleryPhotos(galleryId);
+  return await db.loadGalleryPhotos(galleryId, lang);
 };
-const getGalleryPhoto = async (galleryId: string, photoId: string) => {
+const getGalleryPhoto = async (
+  galleryId: string,
+  photoId: string,
+  lang?: string
+) => {
   logger.debug("Getting photo", photoId, "from gallery", galleryId);
-  return await db.loadGalleryPhoto(galleryId, photoId);
+  return await db.loadGalleryPhoto(galleryId, photoId, lang);
 };
 const linkGalleryPhoto = async (galleryId: string, photoId: string) => {
   logger.debug("Linking photo", photoId, "to gallery", galleryId);

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -763,6 +763,14 @@
             "schema": {
               "type": "string"
             },
+            "in": "query",
+            "name": "lang",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
             "in": "path",
             "name": "galleryId",
             "required": true
@@ -794,6 +802,14 @@
           "gallery-photos"
         ],
         "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "lang",
+            "required": false
+          },
           {
             "schema": {
               "type": "string"


### PR DESCRIPTION
## Summary

Closes #247. The Photo modal MetadataPanel now shows the reverse-geocoded place below the existing operator location row, in the same `Row` / `Part` shape, with the country flag trailing. Picks the current UI language's variant from `photo_localized` when set, falls back to the EN canonical otherwise. Skipped when the operator row already says the same thing.

Per-language plumbing all the way through: DB → model → route → service → query. Switching languages refetches gallery photos with the new `?lang=` and React Query keeps a separate cache entry per language.

## Screenshots

EN (operator country `jp`, no operator `place`, Fukuoka shot):

> Japan 🇯🇵
> Befudanchi, Jonan Ward, Fukuoka, Fukuoka Prefecture, 814-0104, Japan 🇯🇵

JA (same photo, ja UI):

> 日本 🇯🇵
> 別府団地, 城南区, 福岡市, 福岡県, 814-0104, 日本 🇯🇵

Nominatim's verbose `display_name` (postcode + padding admin levels in some locales) reads as noise — that's #349.

## Out of scope / follow-ups

- **#349** — hand-assemble place per-language from the structured `geocoded_state` / `geocoded_city` / `geocoded_district` fields, so we can drop the postcode and the irrelevant intermediate levels Nominatim includes for some locales. To land before #354.
- **#354** — MetadataPanel layout polish (icons, grid, deterministic order).
- **#356** — `hide_map` should suppress all location-derived UI (country, place, geocoded, filters, Stats Places). Independent of this PR.

## Test plan

- [x] `npm run typecheck --workspaces` clean
- [x] `npm test` clean (server 634, react-app 964)
- [x] `npm run lint --workspaces` clean
- [x] Live verified in browser: switching `EN` ↔ `JA` swaps the geocoded line to the Japanese variant and back; React Query refetches cleanly without flicker
- [x] OpenAPI regenerated with the new `?lang=` query param; frontend API codegen regenerated to match