### PR TITLE
hide_map suppresses all location-derived UI (closes #356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Photo modal photo no longer animates from oversized to fit-size when opening on viewports wider than the modal's 1400 px max-width. The carousel Slide and Content Root each set `min-width: 0` so the flex-item default `min-width: auto` doesn't let those ancestors grow to the photo Frame's explicit width during initial mount; without it the over-large initial Frame triggered a ResizeObserver feedback loop that shrunk the photo by ~16 px per frame over ~7 frames. Same loop also caused a one-frame stretch of the outgoing photo at the end of the slide animation.
 - Photo modal `Content` measures container dimensions in `useLayoutEffect` instead of `useEffect`, so the corrective rect read happens before the first paint.
 - Photo modal MetadataPanel renders the reverse-geocoded place below the operator location row, in the same shape, with the country flag trailed (Nominatim's `display_name` already ends in the country, so the country name isn't repeated). Skipped when both sides agree. Layout polish lives in a separate ticket.
+- `hide_map` privacy toggle now suppresses every location-derived surface — Photo modal location rows (operator place / country flag and geocoded line), the Stats General topic's Country category, and the country / geotagged filter categories (both the new-filter category picker and any already-applied chips). Coordinates and map were already hidden today.
 
 ### Server
 

--- a/react-app/src/components/Gallery/Filters/Topic.tsx
+++ b/react-app/src/components/Gallery/Filters/Topic.tsx
@@ -54,7 +54,11 @@ interface Props {
   uniqueValues: UniqueValues;
   lang: string;
   countryData: CountryData;
+  hideMap: boolean;
 }
+
+// Mirror of Filters/index.tsx — keep in sync.
+const LOCATION_CATEGORIES = new Set(["country", "geotagged"]);
 
 const Topic = ({
   topic,
@@ -63,6 +67,7 @@ const Topic = ({
   uniqueValues,
   lang,
   countryData,
+  hideMap,
 }: Props): React.ReactElement => {
   const [categorySelector, setCategorySelector] = React.useState<
     Record<string, boolean>
@@ -137,7 +142,10 @@ const Topic = ({
         <>
           <NewCategories defaultValue="" onChange={handleSelect}>
             <NewCategory value="">Select...</NewCategory>
-            {filter.categories(topic).map((category) => (
+            {filter
+              .categories(topic)
+              .filter((category) => !(hideMap && LOCATION_CATEGORIES.has(category)))
+              .map((category) => (
               <NewCategoryGroup
                 key={`${topic}:${category}`}
                 label={t(`stats-category-${category}`)}
@@ -175,6 +183,7 @@ const Topic = ({
       {filter
         .categories(topic)
         .filter((category) => category in filters[topic])
+        .filter((category) => !(hideMap && LOCATION_CATEGORIES.has(category)))
         .map((category) => (
           <Category
             key={`filter:${topic}:${category}`}

--- a/react-app/src/components/Gallery/Filters/index.tsx
+++ b/react-app/src/components/Gallery/Filters/index.tsx
@@ -55,7 +55,12 @@ interface Props {
   uniqueValues: UniqueValues;
   lang: string;
   countryData: CountryData;
+  hideMap: boolean;
 }
+
+// Categories derived from photo location data — suppressed when
+// hide_map is set (cascade from user_gallery.hide_map).
+const LOCATION_CATEGORIES = new Set(["country", "geotagged"]);
 
 const Filters = ({
   filters,
@@ -63,6 +68,7 @@ const Filters = ({
   uniqueValues,
   lang,
   countryData,
+  hideMap,
 }: Props): React.ReactElement => {
   const [topicSelector, setTopicSelector] = React.useState(false);
 
@@ -109,6 +115,7 @@ const Filters = ({
                   .filter(
                     (category) => !alreadyFilteredCategory(topic, category)
                   )
+                  .filter((category) => !(hideMap && LOCATION_CATEGORIES.has(category)))
                   .map((category) => (
                     <NewCategory key={`${topic}:${category}`} value={category}>
                       {t(`stats-category-${category}`)}
@@ -142,6 +149,7 @@ const Filters = ({
               uniqueValues={uniqueValues}
               lang={lang}
               countryData={countryData}
+              hideMap={hideMap}
             />
           ))}
         {renderTopicAdder()}

--- a/react-app/src/components/Gallery/Photo/MetadataPanel.tsx
+++ b/react-app/src/components/Gallery/Photo/MetadataPanel.tsx
@@ -135,6 +135,7 @@ const MetadataPanel = ({
     );
   };
   const renderLocation = () => {
+    if (gallery.hideMap()) return null;
     const country = renderCountry();
     const place = renderPlace();
     if (!country && !place) return null;
@@ -149,6 +150,7 @@ const MetadataPanel = ({
   // Nominatim's `display_name` already ends in the country, so we
   // trail just the flag, not the country name.
   const renderGeocodedLocation = () => {
+    if (gallery.hideMap()) return null;
     if (!photo.hasGeocodedPlace()) return null;
     // Skip when both sides resolve to the same string.
     const opPlace = photo.place();

--- a/react-app/src/components/Gallery/Stats/index.tsx
+++ b/react-app/src/components/Gallery/Stats/index.tsx
@@ -69,9 +69,9 @@ const Stats = ({
   const topics = React.useMemo(
     () =>
       data
-        ? stats.collectTopics(data, lang, t, countryData, theme, mapPhotos)
+        ? stats.collectTopics(data, lang, t, countryData, theme, mapPhotos, hideMap)
         : [],
-    [data, lang, t, countryData, theme, mapPhotos]
+    [data, lang, t, countryData, theme, mapPhotos, hideMap]
   );
 
   if (!data) {

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -327,6 +327,7 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
             uniqueValues={uniqueValues}
             lang={lang}
             countryData={countryData}
+            hideMap={gallery.hideMap()}
           />
         </Stats>
       );
@@ -341,6 +342,7 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
             uniqueValues={uniqueValues}
             lang={lang}
             countryData={countryData}
+            hideMap={gallery.hideMap()}
           />
         </Empty>
       );
@@ -355,6 +357,7 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
             uniqueValues={uniqueValues}
             lang={lang}
             countryData={countryData}
+            hideMap={gallery.hideMap()}
           />
         </Full>
       );
@@ -374,6 +377,7 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
             uniqueValues={uniqueValues}
             lang={lang}
             countryData={countryData}
+            hideMap={gallery.hideMap()}
           />
         </Year>
       );
@@ -404,6 +408,7 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
             uniqueValues={uniqueValues}
             lang={lang}
             countryData={countryData}
+            hideMap={gallery.hideMap()}
           />
         </Month>
       );
@@ -441,6 +446,7 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
             uniqueValues={uniqueValues}
             lang={lang}
             countryData={countryData}
+            hideMap={gallery.hideMap()}
           />
         </Month>
         <Photo

--- a/react-app/src/lib/stats.tsx
+++ b/react-app/src/lib/stats.tsx
@@ -236,7 +236,8 @@ const collectTopics = (
   t: TFunction,
   countryData: CountryData,
   theme: Theme,
-  mapPhotos: Photo[] = []
+  mapPhotos: Photo[] = [],
+  hideMap = false
 ): StatsTopic[] => {
   const formatNumber = format.number(lang);
   const formatExposure = format.exposure(lang, t);
@@ -611,10 +612,14 @@ const collectTopics = (
     const categories: any[] = [
       collectSummary(count),
       collectAuthor(count.byAuthor, total),
-      collectCountry(count.byCountry, total),
     ];
-    if (mapPhotos.length > 0) {
-      categories.push(collectLocation(mapPhotos, total));
+    // hide_map suppresses country and location categories (both
+    // location-derived). mapPhotos is already empty when hideMap.
+    if (!hideMap) {
+      categories.push(collectCountry(count.byCountry, total));
+      if (mapPhotos.length > 0) {
+        categories.push(collectLocation(mapPhotos, total));
+      }
     }
     return {
       key: "general",


### PR DESCRIPTION
## Summary

Closes #356. The `hide_map` privacy toggle now hides every location-derived UI surface, not just the map view. Three places gated:

- **Photo modal MetadataPanel.** `renderLocation` (operator country + place) and `renderGeocodedLocation` both short-circuit when `gallery.hideMap()` is true. Coordinates and the inline map were already gated.
- **Filter UI.** New `hideMap` prop on `Filters` / `Topic` suppresses the `country` and `geotagged` categories in both the new-filter category picker and any already-applied filter chips.
- **Stats.** `stats.collectTopics` accepts a `hideMap` flag; the General topic skips both Country and Location (geotagged split) categories when set.

The cascade resolution (`user > guest, gallery > :public > :all`) is unchanged — the existing server-side `shouldHideMap` still produces the boolean fed into the UI tree.

## Out of scope

- **Server-side data masking.** Coords are already masked via `maskCoordinates` in the gallery-photos route when `hide_map`; other location fields (`country_code`, `place`, `geocoded_*`) are still returned in the API response but not rendered. Filed as a stronger guarantee — needs a separate ticket if/when desired.
- **Deferred geocoded surfaces** — #344 (filter chain for state/city/district) and #345 (Stats Places topic) are both deferred outside 0.12 on data-quality grounds, so the gating noted in #356's scope for those features is moot for now. The location-category gating in this PR is forward-compatible.

## Test plan

- [x] `npm run typecheck --workspaces` clean
- [x] `npm test` clean (server 634, react-app 964)
- [x] `npm run lint --workspaces` clean
- [x] Live verified: flipped `user_gallery.hide_map = 1` on `:guest:dailybw`, confirmed in browser that:
  - Photo modal shows only exposure / camera / day-number / copyright — no country, no geocoded line, no coords, no map.
  - Stats General topic shows only Summary + Author — no Country, no Location.
  - Title-row map button is hidden.
  - Filter UI offers no `country` / `geotagged` categories.
- [x] `hide_map = NULL` restored after testing