### PR TITLE
Framework: per-lang script rules for photo_localized.geocoded_city

### DIFF
--- a/server/bin/photo.ts
+++ b/server/bin/photo.ts
@@ -8,6 +8,10 @@ import { hideBin } from "yargs/helpers";
 
 import logger from "../lib/logger.js";
 import db from "../db/index.js";
+import {
+  acceptLocalizedCity,
+  RULED_LANGS,
+} from "../lib/localized-script.js";
 import { normalizeCity } from "photo-diary-converter/reverse-geocode/normalize.js";
 
 const formatTable = (rows: string[][]): string => {
@@ -653,36 +657,51 @@ await yargs(hideBin(process.argv))
   )
   .command(
     "cleanup-localized-cities",
-    "Clear photo_localized.geocoded_city where Nominatim returned a value that doesn't actually match the target language's script. Currently only `ja`: clears rows whose city has no Japanese characters (typically Nominatim fell back to en or local Latin form). Sets the column to NULL — keeps the row + raw geocoded_address blob, so the daemon won't re-fetch and re-introduce the bad value. Dry-run by default; --apply to write.",
+    "Clear photo_localized.geocoded_city values that don't match their language's script rule (see server/lib/localized-script.ts). Sets the column to NULL — keeps the row + raw geocoded_address blob, so the daemon won't re-fetch and re-introduce the bad value. Dry-run by default; --apply to write.",
     (y) =>
-      y.option("apply", {
-        type: "boolean",
-        default: false,
-        describe: "Clear the matching values (default: dry-run, just print)",
-      }),
+      y
+        .option("apply", {
+          type: "boolean",
+          default: false,
+          describe: "Clear the matching values (default: dry-run, just print)",
+        })
+        .option("lang", {
+          type: "array",
+          string: true,
+          describe: `Languages to check (default: all configured: ${RULED_LANGS.join(", ")})`,
+        }),
     async (argv) => {
-      const rows = (await db.loadPhotoLocalized("ja")) as Array<{
-        photo_id: string;
-        geocoded_city: string | null;
-      }>;
-      const isJapanese = (s: string) =>
-        /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(s);
-      const offenders = rows.filter(
-        (r) => r.geocoded_city && !isJapanese(r.geocoded_city)
-      );
+      const langs = (argv.lang as string[] | undefined) ?? RULED_LANGS;
+      type Offender = { lang: string; photo_id: string; value: string };
+      const offenders: Offender[] = [];
+      for (const lang of langs) {
+        const rows = (await db.loadPhotoLocalized(lang)) as Array<{
+          photo_id: string;
+          geocoded_city: string | null;
+        }>;
+        for (const r of rows) {
+          if (r.geocoded_city && !acceptLocalizedCity(r.geocoded_city, lang)) {
+            offenders.push({
+              lang,
+              photo_id: r.photo_id,
+              value: r.geocoded_city,
+            });
+          }
+        }
+      }
       if (offenders.length === 0) {
-        console.log("No ja photo_localized rows need cleanup.");
+        console.log("No photo_localized rows need cleanup.");
         return;
       }
-      const table: string[][] = [["photo_id", "stored ja value"]];
-      for (const o of offenders) table.push([o.photo_id, o.geocoded_city ?? ""]);
+      const table: string[][] = [["lang", "photo_id", "stored value"]];
+      for (const o of offenders) table.push([o.lang, o.photo_id, o.value]);
       console.log(formatTable(table));
       console.log(
         `\n${offenders.length} row(s) ${argv.apply ? "cleared" : "would be cleared (dry-run, pass --apply to write)"}.`
       );
       if (argv.apply) {
         for (const o of offenders) {
-          await db.clearLocalizedCity(o.photo_id, "ja");
+          await db.clearLocalizedCity(o.photo_id, o.lang);
         }
       }
     }

--- a/server/db/dummy.ts
+++ b/server/db/dummy.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 
 import CONST from "../lib/constants.js";
 import { NotFoundError, NotImplementedError } from "../lib/errors.js";
+import { acceptLocalizedCity } from "../lib/localized-script.js";
 
 const notImplemented = async (): Promise<never> => {
   throw new NotImplementedError();
@@ -411,9 +412,8 @@ const upsertGeocoded = async (
   const key = `${photoId}:${lang}`;
   const merged = { ...(db.photoLocalized[key] ?? {}), ...fields };
   if (
-    lang === "ja" &&
     typeof merged.city === "string" &&
-    !/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(merged.city)
+    !acceptLocalizedCity(merged.city, lang)
   ) {
     merged.city = null;
   }

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -4,6 +4,7 @@ import CONST from "../../lib/constants.js";
 import { NotFoundError } from "../../lib/errors.js";
 import config from "../../lib/config/index.js";
 import logger from "../../lib/logger.js";
+import { acceptLocalizedCity } from "../../lib/localized-script.js";
 import { migrate } from "./migrate.js";
 
 import schemaFactory, {
@@ -654,14 +655,13 @@ const upsertGeocoded = async (
     }
     return;
   }
-  // For ja: Nominatim falls back to OSM's local label when there's
-  // no Japanese form, so the value can be plain Latin / Cyrillic /
-  // etc. Reject those at write time (drop the city, keep the row +
-  // raw address blob).
-  const city =
-    lang === "ja" && fields.city && !hasJapaneseScript(fields.city)
-      ? null
-      : (fields.city ?? null);
+  // Per-lang validation drops values whose script doesn't match the
+  // language (Nominatim's `?accept-language=<lang>` falls back to OSM
+  // local labels when no localized form exists). Keeps the row + raw
+  // address blob, only the city goes NULL.
+  const city = acceptLocalizedCity(fields.city, lang)
+    ? (fields.city ?? null)
+    : null;
   db.prepare(
     `INSERT INTO photo_localized
        (photo_id, lang, geocoded_city, geocoded_address)
@@ -671,9 +671,6 @@ const upsertGeocoded = async (
        geocoded_address = COALESCE(excluded.geocoded_address, photo_localized.geocoded_address)`
   ).run(photoId, lang, city, fields.address ?? null);
 };
-
-const hasJapaneseScript = (s: string): boolean =>
-  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(s);
 
 // Flag a photo as "Nominatim has no address for these coordinates" so
 // subsequent intake / daemon runs skip it instead of retrying. Operator

--- a/server/db/sqlite3/schema.ts
+++ b/server/db/sqlite3/schema.ts
@@ -1,4 +1,5 @@
 import { NotImplementedError } from "../../lib/errors.js";
+import { acceptLocalizedCity } from "../../lib/localized-script.js";
 
 // Raw DB row shapes (one per table). Mirror the SELECT column list exactly.
 export interface MetaRow {
@@ -340,24 +341,16 @@ export default () => {
           loc: string | null | undefined,
           en: string | null
         ): string | undefined => loc ?? en ?? undefined;
-        // For ja: Nominatim's `?accept-language=ja` falls back to the
-        // local form when OSM has no Japanese label, so ja-flagged
-        // rows can contain plain ASCII names. Skip those at the merge
-        // (treat as missing) and let the en column + city overlay
-        // take over.
+        // Per-lang validation rejects values whose script doesn't
+        // match the language (Nominatim falls back to local OSM
+        // labels when no localized form exists). Falls through to en.
         const pickLocalizedCity = (
           loc: string | null | undefined,
           en: string | null
-        ): string | undefined => {
-          if (
-            localized?.lang === "ja" &&
-            loc &&
-            !/[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u.test(loc)
-          ) {
-            return en ?? undefined;
-          }
-          return pick(loc, en);
-        };
+        ): string | undefined =>
+          acceptLocalizedCity(loc, localized?.lang ?? "")
+            ? pick(loc, en)
+            : en ?? undefined;
 
         return {
           id: toString(row.id),

--- a/server/lib/localized-script.ts
+++ b/server/lib/localized-script.ts
@@ -1,0 +1,46 @@
+// Per-language acceptance rules for `photo_localized.geocoded_city`.
+// Nominatim's `?accept-language=<lang>` falls back to the local OSM
+// label when no localized form exists for a place — so a fi query
+// can return Japanese kanji, a ja query can return plain Latin, etc.
+// Each rule rejects values that clearly aren't in the expected
+// script(s); the read merge + write upsert + cleanup tool all use
+// `acceptLocalizedCity()` to enforce them uniformly.
+//
+// Rules are pure configuration. Add a language: drop an entry here.
+
+interface LangRule {
+  // Reject if `value` doesn't match `require` (used for scripts the
+  // value MUST contain at least one character of).
+  require?: RegExp;
+  // Reject if `value` matches `forbid` (used to say "no characters
+  // outside this whitelist allowed").
+  forbid?: RegExp;
+}
+
+export const LOCALIZED_CITY_RULES: Record<string, LangRule> = {
+  ja: {
+    // Must contain at least one CJK char Nominatim ja should return.
+    require: /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u,
+  },
+  fi: {
+    // Must be Latin-script: anything outside Latin / Common (digits,
+    // punctuation, spaces) / Inherited (diacritics) is rejected. Catches
+    // kanji / kana / Cyrillic / Hangul leaking through when Nominatim
+    // had no Finnish label.
+    forbid: /[^\p{Script=Latin}\p{Script=Common}\p{Script=Inherited}]/u,
+  },
+};
+
+export const acceptLocalizedCity = (
+  value: string | null | undefined,
+  lang: string
+): boolean => {
+  if (!value) return true;
+  const rule = LOCALIZED_CITY_RULES[lang];
+  if (!rule) return true;
+  if (rule.require && !rule.require.test(value)) return false;
+  if (rule.forbid && rule.forbid.test(value)) return false;
+  return true;
+};
+
+export const RULED_LANGS = Object.keys(LOCALIZED_CITY_RULES);

--- a/server/tests/lib/localized-script.test.ts
+++ b/server/tests/lib/localized-script.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "vitest";
+
+import {
+  acceptLocalizedCity,
+  RULED_LANGS,
+} from "../../lib/localized-script.js";
+
+describe("acceptLocalizedCity", () => {
+  test("null / undefined / empty pass through (treated as missing, not bad)", () => {
+    expect(acceptLocalizedCity(null, "ja")).toBe(true);
+    expect(acceptLocalizedCity(undefined, "ja")).toBe(true);
+    expect(acceptLocalizedCity("", "ja")).toBe(true);
+  });
+
+  test("unknown lang accepts anything", () => {
+    expect(acceptLocalizedCity("Helsinki", "sv")).toBe(true);
+    expect(acceptLocalizedCity("東京", "sv")).toBe(true);
+  });
+
+  describe("ja: must contain Japanese script", () => {
+    test("kanji accepted", () => {
+      expect(acceptLocalizedCity("東京都", "ja")).toBe(true);
+      expect(acceptLocalizedCity("京都市", "ja")).toBe(true);
+    });
+    test("hiragana accepted", () => {
+      expect(acceptLocalizedCity("ひろしま", "ja")).toBe(true);
+    });
+    test("katakana accepted", () => {
+      expect(acceptLocalizedCity("ヘルシンキ", "ja")).toBe(true);
+    });
+    test("Latin-only rejected", () => {
+      expect(acceptLocalizedCity("Helsinki", "ja")).toBe(false);
+      expect(acceptLocalizedCity("Stockholm", "ja")).toBe(false);
+    });
+    test("Cyrillic-only rejected", () => {
+      expect(acceptLocalizedCity("Москва", "ja")).toBe(false);
+    });
+    test("mixed kanji + Latin accepted (the kanji satisfies the rule)", () => {
+      expect(acceptLocalizedCity("東京 (Tokyo)", "ja")).toBe(true);
+    });
+  });
+
+  describe("fi: must be Latin-script only", () => {
+    test("Latin accepted", () => {
+      expect(acceptLocalizedCity("Helsinki", "fi")).toBe(true);
+      expect(acceptLocalizedCity("Espoo", "fi")).toBe(true);
+    });
+    test("accented Latin accepted", () => {
+      expect(acceptLocalizedCity("Pohjois-Pohjanmaa", "fi")).toBe(true);
+      expect(acceptLocalizedCity("Côte d'Azur", "fi")).toBe(true);
+    });
+    test("kanji rejected", () => {
+      expect(acceptLocalizedCity("東京都", "fi")).toBe(false);
+      expect(acceptLocalizedCity("新宿区", "fi")).toBe(false);
+    });
+    test("Cyrillic rejected", () => {
+      expect(acceptLocalizedCity("Москва", "fi")).toBe(false);
+    });
+    test("mixed Latin + kanji rejected", () => {
+      expect(acceptLocalizedCity("Tokyo 東京", "fi")).toBe(false);
+    });
+  });
+
+  test("RULED_LANGS lists every configured language", () => {
+    expect(RULED_LANGS).toContain("ja");
+    expect(RULED_LANGS).toContain("fi");
+  });
+});


### PR DESCRIPTION
## Summary

Refactors the ad-hoc inline ja regex (from PR #373) into a small config-driven framework, and adds a fi rule on top.

### New module: `server/lib/localized-script.ts`

```ts
interface LangRule {
  require?: RegExp;  // value MUST contain at least one matching char
  forbid?: RegExp;   // value MUST NOT contain any matching char
}

const LOCALIZED_CITY_RULES: Record<string, LangRule> = {
  ja: { require: /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}]/u },
  fi: { forbid:  /[^\p{Script=Latin}\p{Script=Common}\p{Script=Inherited}]/u },
};

acceptLocalizedCity(value, lang): boolean
```

Each lang's rule is pure data. Adding a language is one entry. Adding a different shape of rule (require + forbid combined, multi-script-set, etc.) is one regex or property.

### Three call sites unified

All inline regexes / inline ja-special-cases removed. `schema.ts` mapRow's `pickLocalizedCity`, sqlite + dummy `upsertGeocoded`, and `bin/photo.ts cleanup-localized-cities` now all call `acceptLocalizedCity()`.

### New fi rule

Nominatim's `?accept-language=fi` falls back to OSM's local label when no Finnish form exists — so Tokyo ward names come back in kanji, etc. The `forbid` rule rejects anything outside Latin / Common (digits, punctuation, spaces) / Inherited (combining diacritics). Operator can now re-enable fi in `REVERSE_GEOCODE_EXTRA_LANGS` without polluting the fi column with non-Latin scripts.

### Cleanup tool now lang-aware

`bin/photo.ts cleanup-localized-cities` accepts `--lang <code>` (repeatable). Default scans all configured languages (`ja`, `fi`).

## Test plan

- [x] `npm run typecheck` clean (server + react-app + converter).
- [x] `npm test` green: server 648 (14 new for `acceptLocalizedCity`), react-app 975, converter 16.
- [ ] `./bin/photo.ts cleanup-localized-cities` against dailybw to confirm rules behave on real data.
- [ ] If fi is re-enabled in `REVERSE_GEOCODE_EXTRA_LANGS`: re-fetch a sample, confirm Tokyo ward names land as NULL on the fi side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)