### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.12.0] - 2026-05-31
 
 ### Frontend
 
@@ -15,6 +15,10 @@
 - Per-language city overlay layered on top of the Nominatim merge. `cities/{en,fi,ja}.json` keyed by `<country>:<en_city>` (Tokio, Soul, Tukholma, Peking, Pietari, …) — overrides apply at every city display surface (metadata address line, filter chip, Stats Places, Summary Top City). Always-on (no beta gate), purely additive. Seed includes the well-known foreign exonyms for fi + ja; entries without overrides fall through to the existing merged Nominatim value.
 - `photo_localized.geocoded_city` for `lang=ja` is now ignored at the read merge if it contains no Japanese script (kanji / hiragana / katakana). Nominatim's `?accept-language=ja` falls back to local Latin forms when OSM has no Japanese label, so those values were leaking through as "ja" but were actually English / Swedish / etc. The fallback chain now skips them automatically and lands on the en canonical + city overlay.
 - New opt-in beta feature "Focal length 35mm equivalent" (UserMenu → "Beta features") surfaces a `focal-length-eq` filter category and a Stats Settings category keyed by the 35mm-equivalent value. Uses EXIF `FocalLengthIn35mmFormat` when present; falls back to `focalLength × cropFactor` for the small `react-app/src/lib/crop-factors.json` table (currently X100F, 5D Mark II, 30D, GX7, FinePix F50fd — covers ~85% of the gap in the operator's gallery). Unknown body + missing EXIF → `unknown` bucket. Always-on derivation in the model; the beta gate only controls UI visibility, so flipping it on/off doesn't touch the DB.
+- Photo modal MetadataPanel polished into a single coherent layout: author moved out of the panel onto a small bottom-left overlay on the photo Frame (only renders when set); description renders below the title; EXIF data flows into a 2-col label / value table (`CAMERA`, `LENS`, `SETTINGS`, `IMAGE`, `LIGHT`) with right-aligned headers; operator place keeps its own row separate from the geocoded address line (mixing them jumbled CJK ordering); coordinates row dropped (the embedded map carries that signal); map sits next to the address instead of after the EXIF table; epoch (age / day-index) lifts up under the description and gets its own slightly-more-prominent row at 85% white instead of the muted 55%; operator place / address / epoch rows right-align to visually separate the "where / when" context from the left-aligned title / description story block. Panel pinned to a fixed 360 px width so short content doesn't shrink the embedded map. (closes #354)
+- Stats "Exposure" topic splits into three narrower topics — Settings (aperture · shutter · ISO · focal length), Image (resolution · aspect ratio · orientation), Light (EV · LV). The previous lumped category mixed per-shot capture parameters with derived image properties under one name; the split matches how the MetadataPanel renders the same data on the photo modal.
+- Stats expanded modal in "By value" sort mode now drops the "Other (N+)" aggregation entirely and shows every actual value. `transformData` stashes an unlimited chart-data variant on the truncated default; `Charts.tsx` swaps in the full data when `sortMode === "value"`. The "Top" mode still aggregates the long tail, since that's what keeps the chart readable at a glance.
+- `EpochAge` renders a localized "0 days" string when the photo is the same day as the gallery epoch instead of emitting the raw `0days-long` key — the same-day fallback was calling `t()` without a `count` parameter so i18next couldn't resolve the plural suffix.
 
 ### Server
 
@@ -23,6 +27,9 @@
 - New `photo.geocoded_state_code` column (schema migration `008`) stores Nominatim's ISO 3166-2 subdivision code (`JP-13`, `US-MA`, …) — language-independent, so it lives on the photo row, not `photo_localized`. Migration backfills the column from the JSON in `geocoded_address` for any row that has one, so existing data picks the code up without a re-geocode run. Used client-side as the city filter's disambiguating key when the localized state name is missing (Tokyo returns no `state` but does return `ISO3166-2-lvl4`).
 - Schema migration `009` drops the now-dead Nominatim columns: `photo.geocoded_state`, `geocoded_district`, `geocoded_place`, plus the matching `photo_localized` columns. State names are derived from `geocoded_state_code` via curated subdivision JSON, district was never displayed, and the hand-assembled City+State+Country address line replaced `display_name`. Intake / daemon write paths and the city tuple key's Nominatim-state fallback all prune alongside.
 - `db.linkGalleryPhoto` is idempotent (`INSERT OR IGNORE`) — re-linking a photo already in a gallery is a no-op instead of a `UNIQUE` error. Also makes `PUT /api/v1/gallery-photos/:galleryId/:photoId` properly idempotent.
+- New `photo.focal_35mm_equiv` column (schema migration `010`) holds EXIF `FocalLengthIn35mmFormat` (the converter already extracted the value, but it was silently dropped at the write layer until now — no column existed). Schema-only — backfill of existing rows is an operator step. Used by the new Stats Settings 35mm-equiv category and the matching filter category when the beta toggle is on.
+- `meta-v1` camelizes the env-driven `BETA_FEATURE_<NAME>=user|on|off` keys so multi-word feature names like `focalLengthEquiv` round-trip cleanly. `BETA_FEATURE_FOCAL_LENGTH_EQUIV=on` now reaches `betaFeatures.focalLengthEquiv`; the previous lower-only conversion only worked for single-word names like `regions`.
+- Migration post-check error now explicitly names the FK shape ("child gallery_photo row references missing photo") and points at `bin/gallery.ts audit --orphan-photos` instead of just saying "foreign-key violations detected", so an operator hitting it doesn't have to dig through the migration log to figure out what to fix.
 
 ### Converter
 
@@ -399,7 +406,6 @@
 
 ## Initial commit - 2020-07-04
 
-[Unreleased]: https://github.com/vlumi/photo-diary/compare/v0.7.4...HEAD
 [0.7.4]: https://github.com/vlumi/photo-diary/compare/v0.7.3...v0.7.4
 [0.7.3]: https://github.com/vlumi/photo-diary/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/vlumi/photo-diary/compare/v0.7.1...v0.7.2

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Key features include:
   - [Multi-instance deployment](#multi-instance-deployment)
     - [Host prep](#one-time-host-prep) · [Getting the code](#getting-the-code-onto-the-host) · [Bootstrap](#bootstrapping-a-new-instance) · [Start](#starting-an-instance) · [Upgrade](#upgrading-an-instance) · [nginx](#nginx) · [Per-gallery vhost](#per-gallery-vhost-mapping) · [Day-to-day ops](#operating-an-instance)
 - [Features](#features)
+  - [Beta features](#beta-features)
 - [Photo pipeline](#photo-pipeline)
 - [Roadmap](#roadmap)
 - [Backlog](#backlog)
@@ -101,20 +102,20 @@ Directory layout:
 
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
-  0.8.0/                                #   each version unpacked into its own subdir
-  0.11.0/                                #   so different instances can run different versions
+  0.11.0/                               #   each version unpacked into its own subdir
+  0.12.0/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/0.11.0      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/0.12.0      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  display/  thumbnail/
   travel/
     .env
-    code -> /opt/photo-diary/0.8.0      # different instance, possibly on a different version
+    code -> /opt/photo-diary/0.11.0     # different instance, possibly on a different version
     db.sqlite3
     photos/
       …
@@ -135,7 +136,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.11.0
+V=0.12.0
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -150,7 +151,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.11.0/bin/instance.ts dailybw
+/opt/photo-diary/0.12.0/bin/instance.ts dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The script can be invoked from any working directory; the instance dir is derived from the name (and the `--base <dir>` flag, default `/var/photo-diary`, if you want instances under a different parent). Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -181,7 +182,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.11.0/bin/instance.ts dailybw          # backs up the DB, flips the symlink
+/opt/photo-diary/0.12.0/bin/instance.ts dailybw          # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                    # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                         # migration runner applies any schema bumps
@@ -382,6 +383,13 @@ The `bin/instance.ts` upgrade flow already creates `db.sqlite3.pre-<version>` sn
     - Through guest user (:guest), inherited by all users
     - Inheritance may be overridden by broadening or narrowing access
 
+### Beta features
+
+Opt-in surfaces that aren't part of the default UI. Per-visitor toggle in UserMenu → "Beta features", or per-instance lock via `BETA_FEATURE_<NAME>=user|on|off` in the instance's `.env` (`user` (default) shows the toggle, `on`/`off` forces it for every visitor).
+
+- **`regions`** (`BETA_FEATURE_REGIONS`) — adds a State row to the photo metadata's address line, a State filter category, a Stats State topic, and Summary "Top State" + "States variety" tiles. Backed by curated `subdivisions/{en,fi,ja}.json` keyed by ISO 3166-2. Coverage: JP, FI, DE, MY, KR, AU, CA, US (en + ja); fi covers Finnish regions and falls back to en elsewhere.
+- **`focalLengthEquiv`** (`BETA_FEATURE_FOCAL_LENGTH_EQUIV`) — adds a 35mm-equivalent focal length filter category and a matching Stats Settings category. Uses EXIF `FocalLengthIn35mmFormat` when present; falls back to `react-app/src/lib/crop-factors.json` for known-no-EXIF bodies (X100F, 5D Mark II, 30D, GX7, FinePix F50fd). The MetadataPanel Settings row also appends `(N㎜ eq.)` next to the raw focal length when the values differ.
+
 ## Photo Pipeline
 
 End-to-end flow from a new JPG arriving on the host to it being browsable in the gallery:
@@ -399,7 +407,6 @@ The pipeline is intentionally split: the converter doesn't touch the DB at all, 
 
 Active milestones on the way to 1.0. Each bullet links the GitHub milestone for live status.
 
-- [**0.12 — Geocoded location surfaced**](https://github.com/vlumi/photo-diary/milestone/16): render the auto-populated `geocoded_place` per UI language in the metadata panel (#247), filter chain for geocoded state / city / district with cross-language-stable URLs (#344), Stats Places topic with drill-down by state / city / district (#345). All consumers of the data #246 lays down.
 - [**0.13 — Admin UI bundle**](https://github.com/vlumi/photo-diary/milestone/14): frontend admin view (#10), mutation API (#222), inbox subdirectories auto-link to galleries (#245), ACL user groups (#270), ACL `:all` floor rule (#271), more built-in themes (#279), admin theme selector (#287), converter picks up JSON in inbox (#333), per-language editing for place / title / description (#343).
 - [**0.14 — Composition + scale**](https://github.com/vlumi/photo-diary/milestone/15): hybrid galleries (#22), Postgres driver alongside SQLite (#265), saved filters / sub-galleries (#285), server-side stats with language-agnostic values and a single-key base cache (#286).
 - [**1.0 — Pre-release audits**](https://github.com/vlumi/photo-diary/milestone/4): test-coverage gap analysis (#194), frontend security audit (#217), end-to-end UI test suite (#261), documentation overhaul (#283).
@@ -448,5 +455,6 @@ After the hiatus, a burst of releases that modernized the stack, formalized the 
 - **0.9** (May 2026) — Privacy hardening (collapse 403/404 distinctions to prevent gallery enumeration), JWT expiration (90 days), self-service password change, global 401 → login-modal handling, toast notifications, profile-icon `UserMenu`.
 - **0.10** (May 2026) — UI/UX polish across the calendar and Stats views. Photo view becomes a modal over Month with touch-tracking swipe and controlled zoom. Stats grows an expanded Summary, a Location card with map-in-modal, and modal-based deep dives for each category. Title bar carries a clickable breadcrumb with Up-navigation and a gallery/stats segmented control. The standalone Day view merges into Month, and seven new built-in themes ship. Server-side logout via refresh-token sessions.
 - **0.11** (May 2026) — Reverse-geocoded place hierarchy: converter intake fetches structured Nominatim data per photo (English canonical + optional extra languages), backfill daemon (`bin/photo-geocode.ts`) fills the existing archive, and `bin/photo.ts audit --country-mismatch` surfaces operator-vs-geocoded drift. Converter hardens around filename collisions (stable `<taken>-<uuid>.<ext>` rename at intake) and stub flows (writes a DB row directly, dedups on `(originalFilename, EXIF DateTimeOriginal)`). New `bin/meta.ts` operator script and `audit` subcommands across `bin/{photo,gallery,user,access,meta}.ts`. Stats Location card splits geotagged / not-geotagged with click-to-filter chips.
+- **0.12** (May 2026) — Geocoded location surfaced across the app: per-language city / state / country address line in the MetadataPanel with locale-aware flag positioning, City + State filter categories, Stats Places + State topics with the same drill-down, per-language city overlay JSON layered on top of Nominatim. Converter intake now flows JSONs + recursive subdirs (`inbox/<gallery>/...` auto-link, JPG processing in place, no mid-pipeline rename). MetadataPanel polished into a label-value table with author overlay on the photo Frame. Stats Exposure topic splits into Settings / Image / Light; By-value mode drops the "Other (N+)" aggregation. New beta-gated Focal length 35mm equivalent (`focal_35mm_equiv` column + crop-factor fallback). `bin/photo.ts audit` defaults to a counts-only summary; city subcommands consolidated under `cities <action>`.
 
-See the [Roadmap](#roadmap) for what's in flight after 0.11.
+See the [Roadmap](#roadmap) for what's in flight after 0.12.

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4"
   },
-  "version": "0.11.0"
+  "version": "0.12.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -65,5 +65,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.11.0"
+  "version": "0.12.0"
 }

--- a/react-app/src/components/Gallery/Photo/MetadataPanel.tsx
+++ b/react-app/src/components/Gallery/Photo/MetadataPanel.tsx
@@ -209,6 +209,7 @@ const MetadataPanel = ({
     const camera = photo.formatCamera();
     const lens = photo.formatLens();
     const focalLength = photo.focalLength();
+    const focalLengthEq = photo.focalLength35mmEquiv();
     const aperture = photo.aperture();
     const exposureTime = photo.exposureTime();
     const iso = photo.iso();
@@ -217,8 +218,13 @@ const MetadataPanel = ({
     const aspectRatio = photo.aspectRatio();
     const exposureValue = photo.exposureValue();
     const lightValue = photo.lightValue();
+    const focalStr = focalLength
+      ? focalLengthEq && focalLengthEq !== focalLength
+        ? `${formatExposure.focalLength(focalLength)}㎜ ${t("metadata-focal-eq", { value: formatExposure.focalLength(focalLengthEq) })}`
+        : `${formatExposure.focalLength(focalLength)}㎜`
+      : "";
     const settingParts = [
-      focalLength ? `${formatExposure.focalLength(focalLength)}㎜` : "",
+      focalStr,
       aperture ? formatExposure.aperture(aperture) : "",
       exposureTime ? `${formatExposure.exposureTime(exposureTime)}s` : "",
       iso ? `ISO${formatExposure.iso(iso)}` : "",

--- a/react-app/src/lib/translations/en.json
+++ b/react-app/src/lib/translations/en.json
@@ -86,6 +86,7 @@
     "photo-metadata": "Photo details",
     "photo-author": "Photo author",
     "metadata-camera": "Camera",
+    "metadata-focal-eq": "({{value}}㎜ eq.)",
     "metadata-lens": "Lens",
     "metadata-settings": "Settings",
     "metadata-image": "Image",
@@ -221,6 +222,7 @@
     "stats-col-camera-lens": "Camera + Lens",
 
     "stats-col-focal-length": "Millimeters",
+    "stats-col-focal-length-eq": "Millimeters (35mm eq.)",
     "stats-col-aperture": "Aperture",
     "stats-col-exposure-time": "Seconds",
     "stats-col-iso": "ISO",

--- a/react-app/src/lib/translations/fi.json
+++ b/react-app/src/lib/translations/fi.json
@@ -86,6 +86,7 @@
     "photo-metadata": "Kuvan tiedot",
     "photo-author": "Valokuvaaja",
     "metadata-camera": "Kamera",
+    "metadata-focal-eq": "({{value}}㎜ vast.)",
     "metadata-lens": "Objektiivi",
     "metadata-settings": "Asetukset",
     "metadata-image": "Kuva",
@@ -221,6 +222,7 @@
     "stats-col-camera-lens": "Kamera ja objektiivi",
 
     "stats-col-focal-length": "Millimetriä",
+    "stats-col-focal-length-eq": "Millimetriä (35mm vast.)",
     "stats-col-aperture": "Aukko",
     "stats-col-exposure-time": "Sekuntia",
     "stats-col-iso": "ISO",

--- a/react-app/src/lib/translations/ja.json
+++ b/react-app/src/lib/translations/ja.json
@@ -86,6 +86,7 @@
     "photo-metadata": "写真情報",
     "photo-author": "撮影者",
     "metadata-camera": "カメラ",
+    "metadata-focal-eq": "（{{value}}㎜換算）",
     "metadata-lens": "レンズ",
     "metadata-settings": "設定",
     "metadata-image": "画像",
@@ -221,6 +222,7 @@
     "stats-col-camera-lens": "カメラとレンズ",
 
     "stats-col-focal-length": "ミリ",
+    "stats-col-focal-length-eq": "ミリ（35mm換算）",
     "stats-col-aperture": "絞り",
     "stats-col-exposure-time": "秒",
     "stats-col-iso": "ISO",

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.11.0"
+    "version": "0.12.0"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -55,5 +55,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.11.0"
+  "version": "0.12.0"
 }


### PR DESCRIPTION
## Summary

Release-prep PR for 0.12.0. No new features beyond what already shipped on `main`; just CHANGELOG / README / version-stamp + a couple of small polish items that surfaced during the release-prep pass.

## Changes

- **CHANGELOG**: stamp `[Unreleased]` → `[0.12.0] - 2026-05-31`. Fill in seven bullets for work that shipped without one — MetadataPanel polish, Stats Exposure → Settings/Image/Light split, Stats by-value mode drops the "Other (N+)" aggregation, EpochAge same-day-zero i18n fix, `photo.focal_35mm_equiv` column (migration 010), `BETA_FEATURE_<NAME>` env camelization, clearer FK-violation message in `migrate.ts`.
- **README**: bump version examples (`0.11.0` → `0.12.0` in the `npm install`, `tar`, `code →` symlink, and `bin/instance.ts` snippets); move the 0.12 milestone from "Roadmap (active)" to "Version History (completed)"; point the trailing "what's in flight" arrow at 0.13.
- **Version bump**: `0.11.0` → `0.12.0` across root + 3 workspace `package.json`.
- **MetadataPanel inline 35mm-eq**: Settings row now appends `(75㎜ eq.)` after the raw focal length when the equivalent is known and differs (full-frame bodies stay clean — no parenthetical). New `metadata-focal-eq` i18n key across en / fi / ja, plus the missing `stats-col-focal-length-eq` column header for the Stats table.

## Test plan

- [x] `npm run typecheck` + `lint` clean on all three subtrees.
- [x] `npm test` green (react-app 977, converter 21). Server flakes on the pre-existing supertest "Parse Error" footgun (`gallery-photos`, `users` — both unrelated to this PR); passes on retry.
- [x] `npm run build` (react-app) produces the bundle. Sizes unchanged ±1 KB from main.
- [x] Smoke: photo with X100F shoots → `23㎜ (35㎜ eq.)` in the Settings row. Photo with 5D Mk II shoots → `50㎜` (no parenthesis since full-frame).
- [x] Smoke: Stats Settings → "Focal Length (35mm eq.)" category (beta on) shows localized column header in fi / ja, not `stats-col-focal-length-eq`.

After merge: tag `v0.12.0`, then operator can run the backfill SQLs from `dev/backfill_focal_35mm_equiv_{dailybw,gallery}.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)