### PR TITLE
Photo URL: originalFilename fallback + drop spinning Loading

### DIFF
--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -455,7 +455,19 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
     }
     const photo = gallery.photo(year, month, day, photoId);
     if (!photo) {
-      return <div>{t("loading")}</div>;
+      // The URL points at an id this gallery doesn't have. Try the
+      // param as an `originalFilename` (camera filename) — covers
+      // pre-rename bookmarks and "shared the file name not the URL"
+      // from the operator's archive. If we find a match anywhere in
+      // the gallery, redirect to its canonical URL. Otherwise drop
+      // back to the month view rather than spinning on "Loading".
+      const byOriginal = gallery
+        .photos()
+        .find((p) => p.originalFilename() === photoId);
+      if (byOriginal) {
+        return <Navigate to={byOriginal.path(gallery)} replace />;
+      }
+      return <Navigate to={gallery.path(year, month)} replace />;
     }
     // Photo URLs mount Month + Photo together so the modal overlays
     // a real Month underneath (closing returns there without remount).

--- a/react-app/src/models/PhotoModel.ts
+++ b/react-app/src/models/PhotoModel.ts
@@ -63,6 +63,7 @@ interface Exposure {
 export interface PhotoData {
   id: string;
   index: number;
+  originalFilename?: string;
   title?: string;
   description?: string;
   taken: Taken;
@@ -119,6 +120,7 @@ const PhotoModel = (photoData: unknown) => {
   const self = {
     id: (): string => photo.id,
     index: (): number => photo.index,
+    originalFilename: (): string | undefined => photo.originalFilename,
     title: (): string | undefined => photo.title,
     description: (): string | undefined => photo.description,
     author: (): string | undefined => photo.taken.author,


### PR DESCRIPTION
## Summary

Two related fixes to the photo URL handling.

### The bug

A URL pointing at a photo id the gallery doesn't have (typo, stale bookmark, deleted photo, etc.) used to spin on a "Loading" screen indefinitely. By the time that branch in `Gallery/index.tsx` runs, photos are already loaded — the missing-photo case got the same fallback as the still-loading case.

### The fix

- If the URL param matches a photo's `originalFilename` (camera filename) anywhere in the gallery, redirect to that photo's canonical URL. This is the "pre-rename bookmark" + "shared the camera filename not the URL" use case the operator's archive sometimes produces.
- Otherwise, navigate to the month view (`gallery.path(year, month)`). The user lands somewhere usable instead of staring at a spinner.

Both use react-router's `<Navigate replace>` so the history stack stays clean.

### What changed

- `PhotoModel`: new `originalFilename(): string | undefined` getter + the matching field in `PhotoData`. The server already emits `originalFilename` in the Photo response (`additionalProperties: true` on the typed schema let it flow through unconfigured); the client just wasn't reading it.
- `Gallery/index.tsx` photo-not-found branch: the new fallback chain replacing the spinning `<div>{t("loading")}</div>`.

### Not in scope

- Empty / filtered-out month view: confirmed already handled — line 375 `!gallery.includesPhotos()` → `<Empty>` with the filter bar above, so applying filters that exclude every photo renders the empty surface cleanly. No change.

## Test plan

- [x] `npm run typecheck` + `lint` clean.
- [x] `npm test` green (977 tests).
- [x] Visit `/<gallery>/<year>/<month>/<day>/<bogus-id>.jpg` → redirects to `/<gallery>/<year>/<month>/`.
- [x] Visit `/<gallery>/<year>/<month>/<day>/<oldCameraFilename>.jpg` (a filename that exists in the archive but isn't the current id) → redirects to the canonical URL for that photo.
- [x] Sanity: valid photo URL still renders the photo modal as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)