### PR TITLE
Release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.12.1] - 2026-05-31
+
+### Frontend
+
+- Photo modal URL with an unknown id no longer spins on "Loading" — the router now redirects to the gallery's month view when the id doesn't resolve. As a bonus, if the URL param matches a photo's `originalFilename` anywhere in the gallery, redirects to that photo's canonical URL (pre-rename bookmarks + "shared the camera filename not the URL" links now resolve).
+
 ## [0.12.0] - 2026-05-31
 
 ### Frontend

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  0.12.0/                               #   so different instances can run different versions
+  0.12.1/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/0.12.0      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/0.12.1      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  display/  thumbnail/
@@ -136,7 +136,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.12.0
+V=0.12.1
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -151,7 +151,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.12.0/bin/instance.ts dailybw
+/opt/photo-diary/0.12.1/bin/instance.ts dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The script can be invoked from any working directory; the instance dir is derived from the name (and the `--base <dir>` flag, default `/var/photo-diary`, if you want instances under a different parent). Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -182,7 +182,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.12.0/bin/instance.ts dailybw          # backs up the DB, flips the symlink
+/opt/photo-diary/0.12.1/bin/instance.ts dailybw          # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                    # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                         # migration runner applies any schema bumps

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4"
   },
-  "version": "0.12.0"
+  "version": "0.12.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -65,5 +65,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.12.0"
+  "version": "0.12.1"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.12.0"
+    "version": "0.12.1"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -55,5 +55,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.12.0"
+  "version": "0.12.1"
 }


### PR DESCRIPTION
## Summary

Patch release wrapping the photo-URL fallback fix (#381).

### What's in 0.12.1

- Photo modal URL with an unknown id no longer spins on "Loading" — the router redirects to the gallery's month view. If the URL param matches a photo's `originalFilename` anywhere in the gallery, redirects to that photo's canonical URL instead.

### Release-prep changes

- CHANGELOG entry for `[0.12.1] - 2026-05-31`.
- Version bump to 0.12.1 across root + 3 workspace `package.json`.
- OpenAPI spec regenerated (only the `info.version` field changes).

## Test plan

- [x] `npm run typecheck` + `lint` + `test` clean on all three subtrees.
- [ ] After tag + deploy: visit a stale URL with an unknown photo id → redirected to month view.
- [ ] After tag + deploy: visit a URL with a pre-rename camera filename → redirected to canonical id URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)