### PR TITLE
Fix server test flakiness (closes #390)

### DIFF
--- a/server/bin/user.ts
+++ b/server/bin/user.ts
@@ -32,10 +32,9 @@ import bcrypt from "bcrypt";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
+import { SALT_ROUNDS } from "../lib/bcrypt-rounds.js";
 import CONST from "../lib/constants.js";
 import db from "../db/index.js";
-
-const SALT_ROUNDS = 10;
 
 const confirm = async (prompt: string): Promise<boolean> => {
   const rl = createInterface({ input: process.stdin, output: process.stdout });

--- a/server/lib/bcrypt-rounds.ts
+++ b/server/lib/bcrypt-rounds.ts
@@ -1,0 +1,4 @@
+// bcrypt cost factor. Production-safe default of 10 (~100ms per hash);
+// tests override via `BCRYPT_ROUNDS=4` to keep the API suite from
+// starving the event loop when many login flows run in parallel.
+export const SALT_ROUNDS = Number(process.env.BCRYPT_ROUNDS ?? 10);

--- a/server/models/token.ts
+++ b/server/models/token.ts
@@ -9,10 +9,10 @@ import {
   LoginError,
   TokenExpiredError,
 } from "../lib/errors.js";
+import { SALT_ROUNDS } from "../lib/bcrypt-rounds.js";
 import logger from "../lib/logger.js";
 import db from "../db/index.js";
 
-const SALT_ROUNDS = 10;
 const REFRESH_SECRET_BYTES = 32;
 
 const encodeSecret = (secret: string): Uint8Array =>

--- a/server/models/user.ts
+++ b/server/models/user.ts
@@ -1,11 +1,10 @@
 import { randomBytes, randomUUID } from "node:crypto";
 import bcrypt from "bcrypt";
 
+import { SALT_ROUNDS } from "../lib/bcrypt-rounds.js";
 import { ValidationError } from "../lib/errors.js";
 import logger from "../lib/logger.js";
 import db from "../db/index.js";
-
-const SALT_ROUNDS = 10;
 
 export default () => {
   return {

--- a/server/tests/api/galleries.test.ts
+++ b/server/tests/api/galleries.test.ts
@@ -5,14 +5,13 @@ import { createApi, loginUser } from "./helper.js";
 
 const db = dummyFactory();
 
-const { api, close } = createApi();
+const { api } = createApi();
 
 beforeEach(async () => {
   await db.init();
   await init();
 });
 
-afterAll(close);
 
 const getGalleries = async (token: string | undefined, status = 200) =>
   api
@@ -581,4 +580,3 @@ describe("Mutations as admin", () => {
       .expect(204));
 });
 
-afterAll(() => {});

--- a/server/tests/api/gallery-photos.test.ts
+++ b/server/tests/api/gallery-photos.test.ts
@@ -4,14 +4,13 @@ import { createApi, loginUser } from "./helper.js";
 
 const db = dummyFactory();
 
-const { api, close } = createApi();
+const { api } = createApi();
 
 beforeEach(async () => {
   await db.init();
   await init();
 });
 
-afterAll(close);
 
 const getGalleryPhoto = async (token: string | undefined, galleryId: string, photoId: string, status = 200) =>
   api
@@ -896,4 +895,3 @@ describe("As publicUser", () => {
   });
 });
 
-afterAll(() => {});

--- a/server/tests/api/helper.ts
+++ b/server/tests/api/helper.ts
@@ -1,16 +1,14 @@
 import supertest, { type Agent } from "supertest";
 import { app } from "../../app.js";
 
-// Pass Fastify's underlying http.Server to supertest. supertest binds an
-// ephemeral port on first request and tears it down via `close()`. Routes
-// are registered at module load, so `app.server` already knows the full
-// pipeline — `init()` only needs to finish before the first request fires
-// (handled by each test file's `beforeEach`).
+// Pass Fastify's underlying http.Server to supertest. supertest binds
+// an ephemeral port on first request; the listener lives for the
+// whole test run. Routes are registered at module load, so `app.server`
+// already knows the full pipeline — `init()` only needs to finish
+// before the first request fires (handled by each file's `beforeEach`).
 export const createApi = () => {
-  const server = app.server;
-  const api = supertest(server);
-  const close = () => new Promise<void>((resolve) => server.close(() => resolve()));
-  return { api, close };
+  const api = supertest(app.server);
+  return { api };
 };
 
 export const loginUser = async (api: Agent, id: string): Promise<string> => {

--- a/server/tests/api/host-scope.test.ts
+++ b/server/tests/api/host-scope.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test } from "vitest";
 import type { Agent } from "supertest";
 
 import { init } from "../../app.js";
@@ -7,7 +7,7 @@ import dbFacade from "../../db/index.js";
 import { createApi, loginUser } from "./helper.js";
 
 const db = dummyFactory();
-const { api, close } = createApi();
+const { api } = createApi();
 
 beforeEach(async () => {
   await db.init();
@@ -22,7 +22,6 @@ beforeEach(async () => {
   await init();
 });
 
-afterAll(close);
 
 // Supertest re-uses the underlying http.Server's port; the Host header is
 // what Fastify's `request.hostname` reads, so this is the lever for scope

--- a/server/tests/api/meta.test.ts
+++ b/server/tests/api/meta.test.ts
@@ -4,14 +4,13 @@ import { createApi, loginUser } from "./helper.js";
 
 const db = dummyFactory();
 
-const { api, close } = createApi();
+const { api } = createApi();
 
 beforeEach(async () => {
   await db.init();
   await init();
 });
 
-afterAll(close);
 
 const getMetas = async (status = 200) =>
   api

--- a/server/tests/api/photos.test.ts
+++ b/server/tests/api/photos.test.ts
@@ -5,14 +5,13 @@ import { createApi, loginUser } from "./helper.js";
 
 const db = dummyFactory();
 
-const { api, close } = createApi();
+const { api } = createApi();
 
 beforeEach(async () => {
   await db.init();
   await init();
 });
 
-afterAll(close);
 
 const getPhotos = async (token: string | undefined, status = 200) =>
   api.get("/api/v1/photos").set("Authorization", `Bearer ${token}`).expect(status);
@@ -468,4 +467,3 @@ describe("Mutations as admin", () => {
       .expect(400));
 });
 
-afterAll(() => {});

--- a/server/tests/api/tokens.test.ts
+++ b/server/tests/api/tokens.test.ts
@@ -2,7 +2,7 @@ import { init } from "../../app.js";
 import { _resetLoginRateLimitForTests } from "../../controllers/tokens-v1.js";
 import { createApi, loginUser, loginUserPair } from "./helper.js";
 
-const { api, close } = createApi();
+const { api } = createApi();
 
 beforeEach(async () => {
   await init();
@@ -12,7 +12,6 @@ beforeEach(async () => {
   _resetLoginRateLimitForTests();
 });
 
-afterAll(close);
 
 describe("Login", () => {
   test("Non-existing user", async () => {

--- a/server/tests/api/user-gallery.test.ts
+++ b/server/tests/api/user-gallery.test.ts
@@ -4,14 +4,13 @@ import { createApi, loginUser } from "./helper.js";
 
 const db = dummyFactory();
 
-const { api, close } = createApi();
+const { api } = createApi();
 
 beforeEach(async () => {
   await db.init();
   await init();
 });
 
-afterAll(close);
 
 describe("As guest", () => {
   test("List rejected", () => api.get("/api/v1/user-gallery").expect(403));
@@ -137,4 +136,3 @@ describe("As admin", () => {
       .expect(400));
 });
 
-afterAll(() => {});

--- a/server/tests/api/users.test.ts
+++ b/server/tests/api/users.test.ts
@@ -4,14 +4,13 @@ import { createApi, loginUser } from "./helper.js";
 
 const db = dummyFactory();
 
-const { api, close } = createApi();
+const { api } = createApi();
 
 beforeEach(async () => {
   await db.init();
   await init();
 });
 
-afterAll(close);
 
 const getUsers = async (token: string | undefined, status = 200) =>
   api.get("/api/v1/users").set("Authorization", `Bearer ${token}`).expect(status);
@@ -346,4 +345,3 @@ describe("Mutations as admin", () => {
       .expect(400));
 });
 
-afterAll(() => {});

--- a/server/vitest.config.js
+++ b/server/vitest.config.js
@@ -4,5 +4,12 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
+    // Serialise test files. The API suite mounts the same Fastify
+    // instance through supertest in every file, and concurrent calls
+    // surfaced "Parse Error: Expected HTTP/" + ECONNRESET races.
+    fileParallelism: false,
+    // bcrypt at the production cost (10) starves the event loop when
+    // many login flows run. 4 is the minimum bcrypt accepts.
+    env: { BCRYPT_ROUNDS: "4" },
   },
 });


### PR DESCRIPTION
## Summary

The server API suite was failing ~50% of the time on full runs — "Parse Error: Expected HTTP/", `ECONNRESET`, and `expected 200, got 404` cascades. Two root causes, two commits.

**Closes #390.**

### Cause 1: bcrypt cost factor starves the event loop

The 10-round bcrypt default is ~100ms per hash. The suite does many parallel login flows (per-`describe`'s `beforeEach(loginUser)`), and stacked bcrypt work blocked Fastify from servicing concurrent requests fast enough — `Login rate limit` and `Change password` tests timed out at 5-10s.

Fix: `SALT_ROUNDS` reads from `BCRYPT_ROUNDS` env (default 10). Vitest config sets it to 4 — bcrypt's minimum, ~50× faster, no security cost in tests.

### Cause 2: shared `app.server` across test files

Every API test file calls `supertest(app.server)` and ran `afterAll(close)`. With vitest's default parallelism, multiple files hit the same http.Server concurrently — supertest fed sibling tests' bytes into each other ("Parse Error" symptoms). Switching to serial execution exposed a second issue: `afterAll(close)` from file 1 left the shared server closed before file 2 started (404 cascades).

Fix: `fileParallelism: false` in vitest config + drop the `afterAll(close)` hooks. The supertest listener lives for the whole run; vitest tears down the process at the end. No explicit close needed.

## Reliability

- 20/20 consecutive full runs green.
- Wall-clock: 5s parallel → 13s serial. Acceptable trade for the signal.
- Test count unchanged: 715/715.

## Test plan

- [x] `npm run typecheck` + `npm run lint` clean.
- [x] 20 consecutive `vitest run` invocations all pass.
- [x] CI green on this branch (the same flakes occasionally hit CI; expect a few green runs in a row now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)