### PR TITLE
User-side theme picker in UserMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Frontend
+
+- User-side theme picker in the UserMenu dropdown — pick from any of the built-in themes or keep "Follow gallery default" (the unset state). The choice is persisted per-browser in localStorage and overrides the gallery's `theme` + the instance default for that user. Resolution priority is user preference → gallery theme → instance default.
+
 ### Server
 
 - Virtual-host scope: requests reaching the server with a `Host` header matching a gallery's `hostname` pattern are now narrowed to that gallery (or to the set of galleries when multiple match) for both writes and reads. Cross-gallery admin operations (user CRUD, gallery CRUD, instance meta mutations) 404 from a scoped host. `PUT /galleries/:id`, `PUT/DELETE /photos/:id`, and `user-gallery` mutations are accepted only when the target gallery is in scope. Reads are scoped too: `GET /galleries` returns only in-scope galleries; `GET /galleries/:id` for an off-scope id returns the same empty placeholder as a non-existent gallery (privacy-collapse); `GET /gallery-photos/:gallery/*` 404s off-scope; `GET /photos` filters to photos linked to an in-scope gallery (photos in multiple galleries are visible if any link is in scope). Instance meta (`GET /meta`) stays unscoped — it's SPA boot data. The SPA mirrors the scope client-side: the breadcrumb gallery dropdown filters to the bound galleries, and an off-scope URL redirects in.

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -39,6 +39,7 @@ import {
   useFiltersStore,
   useScrollStore,
   useBetaStore,
+  useThemePreferenceStore,
 } from "../../stores";
 import type { BetaFeature, BetaMode } from "../../stores/beta";
 import { BETA_FEATURES } from "../../stores/beta";
@@ -82,6 +83,8 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
   const filters = useFiltersStore((s) => s.filters);
   const setFilters = useFiltersStore((s) => s.setFilters);
   const setScroll = useScrollStore((s) => s.set);
+  const themePreference = useThemePreferenceStore((s) => s.preference);
+  const loadThemePreference = useThemePreferenceStore((s) => s.load);
 
   const { t } = useTranslation();
   const location = useLocation();
@@ -248,9 +251,18 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
     return selectedGallery.withPhotos(filteredPhotos);
   }, [selectedGallery, photos, filters]);
 
+  // Load the persisted user preference once, against the current
+  // manifest so a stale localStorage entry can't survive a theme
+  // rename or removal.
+  React.useEffect(() => {
+    loadThemePreference(new Set(theme.manifest.map((entry) => entry.id)));
+  }, [loadThemePreference]);
+
+  // Theme resolution priority: user preference → gallery theme → instance default.
   const selectedThemeName = selectedGallery?.theme();
-  const activeTheme =
-    selectedGallery && selectedGallery.hasTheme() && selectedThemeName
+  const activeTheme = themePreference
+    ? theme.setTheme(themePreference)
+    : selectedGallery && selectedGallery.hasTheme() && selectedThemeName
       ? theme.setTheme(selectedThemeName)
       : theme.setTheme(config.DEFAULT_THEME);
 

--- a/react-app/src/components/UserMenu.tsx
+++ b/react-app/src/components/UserMenu.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { BsPersonFill, BsPerson } from "react-icons/bs";
 
+import theme from "../lib/theme";
 import token from "../lib/token";
 import tokenService from "../services/tokens";
 import {
@@ -11,6 +12,7 @@ import {
   useLoginModalStore,
   useChangePasswordModalStore,
   useBetaStore,
+  useThemePreferenceStore,
 } from "../stores";
 import { BETA_FEATURES } from "../stores/beta";
 
@@ -92,6 +94,19 @@ const BetaToggle = styled.label`
     color: var(--header-color);
   }
 `;
+const ThemeRow = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  color: var(--primary-color);
+  font: inherit;
+`;
+const ThemeSelect = styled.select`
+  flex: 1;
+  font: inherit;
+  padding: 2px 4px;
+`;
 
 // Profile icon in the top-right of the top menu. Anonymous (outlined) when
 // not logged in — clicking opens the login modal. Filled when logged in —
@@ -110,6 +125,8 @@ const UserMenu = (): React.ReactElement => {
   const userBetaFeatures = BETA_FEATURES.filter(
     (f) => betaModes[f] === "user"
   );
+  const themePreference = useThemePreferenceStore((s) => s.preference);
+  const setThemePreference = useThemePreferenceStore((s) => s.setPreference);
 
   const [isOpen, setIsOpen] = React.useState(false);
   const rootRef = React.useRef<HTMLDivElement>(null);
@@ -193,6 +210,22 @@ const UserMenu = (): React.ReactElement => {
           >
             {t("change-password-title")}
           </MenuItem>
+          <ThemeRow>
+            <span>{t("theme-label")}</span>
+            <ThemeSelect
+              value={themePreference ?? ""}
+              onChange={(e) =>
+                setThemePreference(e.target.value === "" ? null : e.target.value)
+              }
+            >
+              <option value="">{t("theme-follow-default")}</option>
+              {theme.manifest.map((entry) => (
+                <option key={entry.id} value={entry.id}>
+                  {entry.displayName}
+                </option>
+              ))}
+            </ThemeSelect>
+          </ThemeRow>
           {userBetaFeatures.map((f) => (
             <BetaToggle key={f}>
               <input

--- a/react-app/src/components/UserMenu.tsx
+++ b/react-app/src/components/UserMenu.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { BsPersonFill, BsPerson } from "react-icons/bs";
 
-import theme from "../lib/theme";
+import theme, { THEME_CATEGORIES, type ThemeCategory } from "../lib/theme";
 import token from "../lib/token";
 import tokenService from "../services/tokens";
 import {
@@ -219,11 +219,24 @@ const UserMenu = (): React.ReactElement => {
               }
             >
               <option value="">{t("theme-follow-default")}</option>
-              {theme.manifest.map((entry) => (
-                <option key={entry.id} value={entry.id}>
-                  {entry.displayName}
-                </option>
-              ))}
+              {THEME_CATEGORIES.map((category: ThemeCategory) => {
+                const entries = theme.manifest.filter(
+                  (entry) => entry.category === category
+                );
+                if (entries.length === 0) return null;
+                return (
+                  <optgroup
+                    key={category}
+                    label={String(t(`theme-group-${category}`))}
+                  >
+                    {entries.map((entry) => (
+                      <option key={entry.id} value={entry.id}>
+                        {entry.displayName}
+                      </option>
+                    ))}
+                  </optgroup>
+                );
+              })}
             </ThemeSelect>
           </ThemeRow>
           {userBetaFeatures.map((f) => (

--- a/react-app/src/lib/theme.ts
+++ b/react-app/src/lib/theme.ts
@@ -196,24 +196,37 @@ const THEMES: Record<ThemeName, Theme> = {
   },
 };
 
+export type ThemeCategory = "coloured" | "neutral" | "dark" | "statement";
+
+export const THEME_CATEGORIES: ThemeCategory[] = [
+  "coloured",
+  "neutral",
+  "dark",
+  "statement",
+];
+
 interface ThemeManifestEntry {
   id: ThemeName;
   displayName: string;
+  category: ThemeCategory;
 }
 
+// Ordered by category (see THEME_CATEGORIES), then alphabetically by
+// displayName within each category. The picker renders one <optgroup>
+// per category in this order.
 const MANIFEST: ThemeManifestEntry[] = [
-  { id: "blue", displayName: "Blue" },
-  { id: "red", displayName: "Red" },
-  { id: "grayscale", displayName: "Grayscale" },
-  { id: "contrast", displayName: "High Contrast" },
-  { id: "alert", displayName: "Alert" },
-  { id: "dark", displayName: "Dark" },
-  { id: "amoled", displayName: "AMOLED" },
-  { id: "forest", displayName: "Forest" },
-  { id: "silver", displayName: "Silver" },
-  { id: "showcase", displayName: "Showcase" },
-  { id: "teal", displayName: "Teal" },
-  { id: "paper", displayName: "Paper" },
+  { id: "blue", displayName: "Blue", category: "coloured" },
+  { id: "forest", displayName: "Forest", category: "coloured" },
+  { id: "red", displayName: "Red", category: "coloured" },
+  { id: "teal", displayName: "Teal", category: "coloured" },
+  { id: "grayscale", displayName: "Grayscale", category: "neutral" },
+  { id: "contrast", displayName: "High Contrast", category: "neutral" },
+  { id: "paper", displayName: "Paper", category: "neutral" },
+  { id: "silver", displayName: "Silver", category: "neutral" },
+  { id: "amoled", displayName: "AMOLED", category: "dark" },
+  { id: "dark", displayName: "Dark", category: "dark" },
+  { id: "showcase", displayName: "Showcase", category: "dark" },
+  { id: "alert", displayName: "Alert", category: "statement" },
 ];
 
 const isThemeName = (name: string): name is ThemeName => name in THEMES;

--- a/react-app/src/lib/translations/en.json
+++ b/react-app/src/lib/translations/en.json
@@ -25,6 +25,8 @@
     "change-password-success": "Password changed",
     "beta-feature-regions": "Region filter (beta)",
     "beta-feature-focalLengthEquiv": "Focal length 35mm equivalent (beta)",
+    "theme-label": "Theme",
+    "theme-follow-default": "Follow gallery default",
 
     "nav-galleries": "Galleries",
     "nav-gallery-top": "Back to top",

--- a/react-app/src/lib/translations/en.json
+++ b/react-app/src/lib/translations/en.json
@@ -27,6 +27,10 @@
     "beta-feature-focalLengthEquiv": "Focal length 35mm equivalent (beta)",
     "theme-label": "Theme",
     "theme-follow-default": "Follow gallery default",
+    "theme-group-coloured": "Coloured",
+    "theme-group-neutral": "Neutral",
+    "theme-group-dark": "Dark",
+    "theme-group-statement": "Statement",
 
     "nav-galleries": "Galleries",
     "nav-gallery-top": "Back to top",

--- a/react-app/src/lib/translations/fi.json
+++ b/react-app/src/lib/translations/fi.json
@@ -27,6 +27,10 @@
     "beta-feature-focalLengthEquiv": "Polttoväli 35mm-vastaava (beta)",
     "theme-label": "Teema",
     "theme-follow-default": "Käytä gallerian oletusta",
+    "theme-group-coloured": "Värilliset",
+    "theme-group-neutral": "Neutraalit",
+    "theme-group-dark": "Tummat",
+    "theme-group-statement": "Korostavat",
 
     "nav-galleries": "Galleriat",
     "nav-gallery-top": "Palaa alkuun",

--- a/react-app/src/lib/translations/fi.json
+++ b/react-app/src/lib/translations/fi.json
@@ -25,6 +25,8 @@
     "change-password-success": "Salasana vaihdettu",
     "beta-feature-regions": "Aluesuodatin (beta)",
     "beta-feature-focalLengthEquiv": "Polttoväli 35mm-vastaava (beta)",
+    "theme-label": "Teema",
+    "theme-follow-default": "Käytä gallerian oletusta",
 
     "nav-galleries": "Galleriat",
     "nav-gallery-top": "Palaa alkuun",

--- a/react-app/src/lib/translations/ja.json
+++ b/react-app/src/lib/translations/ja.json
@@ -25,6 +25,8 @@
     "change-password-success": "パスワードを変更しました",
     "beta-feature-regions": "地域フィルター（ベータ）",
     "beta-feature-focalLengthEquiv": "焦点距離 35mm換算（ベータ）",
+    "theme-label": "テーマ",
+    "theme-follow-default": "ギャラリーの既定に従う",
 
     "nav-galleries": "ギャラリー",
     "nav-gallery-top": "トップへ",

--- a/react-app/src/lib/translations/ja.json
+++ b/react-app/src/lib/translations/ja.json
@@ -27,6 +27,10 @@
     "beta-feature-focalLengthEquiv": "焦点距離 35mm換算（ベータ）",
     "theme-label": "テーマ",
     "theme-follow-default": "ギャラリーの既定に従う",
+    "theme-group-coloured": "カラー",
+    "theme-group-neutral": "ニュートラル",
+    "theme-group-dark": "ダーク",
+    "theme-group-statement": "強調",
 
     "nav-galleries": "ギャラリー",
     "nav-gallery-top": "トップへ",

--- a/react-app/src/stores/index.ts
+++ b/react-app/src/stores/index.ts
@@ -7,3 +7,4 @@ export { useLoginModalStore } from "./login-modal";
 export { useChangePasswordModalStore } from "./change-password-modal";
 export { useLastGalleryPathStore } from "./last-gallery-path";
 export { useBetaStore } from "./beta";
+export { useThemePreferenceStore } from "./theme-preference";

--- a/react-app/src/stores/theme-preference.test.ts
+++ b/react-app/src/stores/theme-preference.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, expect, test, vi } from "vitest";
+
+import { useThemePreferenceStore } from "./theme-preference";
+
+const VALID = new Set(["blue", "red", "grayscale"]);
+
+const memoryStorage = (): Storage => {
+  let store: Record<string, string> = {};
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear: () => {
+      store = {};
+    },
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+  };
+};
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", memoryStorage());
+  useThemePreferenceStore.setState({ preference: null });
+});
+
+test("setPreference persists and updates state", () => {
+  useThemePreferenceStore.getState().setPreference("blue");
+  expect(useThemePreferenceStore.getState().preference).toBe("blue");
+  expect(localStorage.getItem("theme-preference")).toBe("blue");
+});
+
+test("setPreference(null) clears storage", () => {
+  useThemePreferenceStore.getState().setPreference("blue");
+  useThemePreferenceStore.getState().setPreference(null);
+  expect(useThemePreferenceStore.getState().preference).toBeNull();
+  expect(localStorage.getItem("theme-preference")).toBeNull();
+});
+
+test("load reads from storage when the value is in the valid set", () => {
+  localStorage.setItem("theme-preference", "red");
+  useThemePreferenceStore.getState().load(VALID);
+  expect(useThemePreferenceStore.getState().preference).toBe("red");
+});
+
+test("load discards stale values not in the valid set", () => {
+  localStorage.setItem("theme-preference", "removed-theme");
+  useThemePreferenceStore.getState().load(VALID);
+  expect(useThemePreferenceStore.getState().preference).toBeNull();
+});

--- a/react-app/src/stores/theme-preference.ts
+++ b/react-app/src/stores/theme-preference.ts
@@ -1,0 +1,35 @@
+import { create } from "zustand";
+
+const STORAGE_KEY = "theme-preference";
+
+// `null` = follow gallery / instance default (no override). A string
+// is the chosen theme name; validated against the manifest at read
+// time so a stale localStorage entry can't break rendering after a
+// theme is renamed or removed.
+const read = (validNames: Set<string>): string | null => {
+  if (typeof window === "undefined" || !window.localStorage) return null;
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  return validNames.has(raw) ? raw : null;
+};
+
+const write = (value: string | null) => {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  if (value === null) window.localStorage.removeItem(STORAGE_KEY);
+  else window.localStorage.setItem(STORAGE_KEY, value);
+};
+
+interface State {
+  preference: string | null;
+  setPreference: (next: string | null) => void;
+  load: (validNames: Set<string>) => void;
+}
+
+export const useThemePreferenceStore = create<State>((set) => ({
+  preference: null,
+  setPreference: (preference) => {
+    write(preference);
+    set({ preference });
+  },
+  load: (validNames) => set({ preference: read(validNames) }),
+}));


### PR DESCRIPTION
## Summary

Adds a per-browser theme picker to the UserMenu dropdown — pick any of the built-in themes or keep "Follow gallery default" (the unset state). The choice is persisted to localStorage and overrides both the gallery's `theme` and the instance default for that user. Resolution priority becomes user preference → gallery theme → instance default.

The user-facing half of #287. The admin instance-default setter half still depends on #10's admin shell and will land with it.

## Files

- `react-app/src/stores/theme-preference.ts` — zustand store + localStorage glue, with a stale-value guard against the current manifest at load.
- `react-app/src/components/Gallery/index.tsx` — consults the preference before the existing gallery-or-default resolution.
- `react-app/src/components/UserMenu.tsx` — inline `<select>` listing every theme from `theme.manifest`, plus a "Follow gallery default" entry that clears the override.
- `react-app/src/lib/translations/{en,fi,ja}.json` — `theme-label` + `theme-follow-default` keys in all three locales.
- `react-app/src/stores/theme-preference.test.ts` — 4 unit tests covering persistence, clearing, valid-name reads, and stale-value discard.

## Test plan

- [x] `npm run typecheck` + `npm run lint` clean.
- [x] React-app tests green (976 → 980).
- [x] Smoke: open the UserMenu dropdown, switch through several themes — the page re-themes immediately; selection persists across reload; "Follow gallery default" reverts to whatever the gallery's `theme` (or instance default) is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)