### PR TITLE
ACL simplification: is_admin flag, drop pseudo-gallery wildcards, drop NONE (closes #394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,9 @@
 
 ## [Unreleased]
 
-### Tooling
-
-- `bin/gallery.ts` now uses explicit subcommands (`list`, `create`, `update`, `delete`, `audit`) — typing `gallery.ts list` no longer silently creates a gallery called "list."
-
-### Frontend
-
-- User-side theme picker in the UserMenu dropdown — pick from any of the built-in themes or keep "Follow gallery default" (the unset state). The choice is persisted per-browser in localStorage and overrides the gallery's `theme` + the instance default for that user. Resolution priority is user preference → gallery theme → instance default.
-
 ### Server
 
+- ACL simplification — collapses the access model to one global `user.is_admin` flag plus per-(user, gallery) rows where `is_admin` upgrades a row from view to gallery admin. Pseudo-galleries (`:all`, `:public`) lose their cascade role; the `access_level` enum (`none|view|admin`) is replaced by a boolean; explicit-deny rows (NONE) are dropped. Resolution becomes three clauses: global admin bypass → MAX over matching (user / :guest) positive grants → deny. Migration 012 promotes `(user, :all, admin)` rows to `user.is_admin = 1`, fans `:public` grants out to per-gallery rows, drops the pseudo-gallery and NONE rows, and rebuilds `user_gallery` with the new column. `bin/user.ts` gains `make-admin` / `revoke-admin`; `bin/access.ts` switches from `level <user> <gallery> <view|admin|none>` to `grant <user> <gallery> [--admin]` + `revoke <user> <gallery>`. `GET /api/v1/users` exposes `isAdmin` on each row; `/api/v1/user-gallery` body uses `isAdmin: boolean` instead of `accessLevel`. `/api/v1/photos` collapses into admin-only (the old global-view tier had no real meaning under the new model).
 - Virtual-host scope: requests reaching the server with a `Host` header matching a gallery's `hostname` pattern are now narrowed to that gallery (or to the set of galleries when multiple match) for both writes and reads. Cross-gallery admin operations (user CRUD, gallery CRUD, instance meta mutations) 404 from a scoped host. `PUT /galleries/:id`, `PUT/DELETE /photos/:id`, and `user-gallery` mutations are accepted only when the target gallery is in scope. Reads are scoped too: `GET /galleries` returns only in-scope galleries; `GET /galleries/:id` for an off-scope id returns the same empty placeholder as a non-existent gallery (privacy-collapse); `GET /gallery-photos/:gallery/*` 404s off-scope; `GET /photos` filters to photos linked to an in-scope gallery (photos in multiple galleries are visible if any link is in scope). Instance meta (`GET /meta`) stays unscoped — it's SPA boot data. The SPA mirrors the scope client-side: the breadcrumb gallery dropdown filters to the bound galleries, and an off-scope URL redirects in.
 - Retired the `:private` pseudo-gallery. Its sole role (browsable view of orphan photos) moves to the admin UI's orphan filter; the alert theme stays as a generic operator-applied visibility flag. Migration 011 drops any `user_gallery` rows pointing at `:private`.
 - Mutation endpoints (`POST` / `PUT` / `DELETE`) implemented across `/api/v1/{meta,users,galleries,photos}` — every one was throwing `ERROR_NOT_IMPLEMENTED` until now. Body shapes validated via TypeBox on the route, so malformed input returns 400 with field-level detail. Admin-gated; gallery `PUT` / `DELETE` uses gallery-admin scope (existing semantics), the rest require global admin. `POST` returns 201, `PUT` / `DELETE` return 204. The Swagger UI at `/api/v1/docs` now documents the new bodies.
@@ -20,6 +13,14 @@
 - `models/user.ts` absorbs the bcrypt-hash + secret-rotation + cascade logic that `bin/user.ts` had inline, so the CLI and API share the same path. User `DELETE` cascades `user_gallery` rows + active sessions; gallery `DELETE` cascades `gallery_photo` links + `user_gallery` rows (the FKs are RESTRICT and would otherwise refuse); photo `DELETE` cascades `gallery_photo` links.
 - Meta `key` is locked to a schema-seeded enum (`name | description | cdn | image`). `schema_version` and other internals can't be written via the API; operators who need an experimental key reach for `./bin/meta.ts set --force`. `server/lib/meta-keys.ts` is the single source of truth shared by the CLI and the API.
 - New `/api/v1/user-gallery` resource: `GET /` (with optional `userId` / `galleryId` filters), `PUT /:userId/:galleryId` body `{ accessLevel: "none|view|admin", hideMap?: boolean|null }`, `DELETE /:userId/:galleryId`. Admin-only — same plumbing the `bin/access.ts` CLI uses, exposed over HTTP for the admin UI.
+
+### Frontend
+
+- User-side theme picker in the UserMenu dropdown — pick from any of the built-in themes or keep "Follow gallery default" (the unset state). The choice is persisted per-browser in localStorage and overrides the gallery's `theme` + the instance default for that user. Resolution priority is user preference → gallery theme → instance default.
+
+### Tooling
+
+- `bin/gallery.ts` now uses explicit subcommands (`list`, `create`, `update`, `delete`, `audit`) — typing `gallery.ts list` no longer silently creates a gallery called "list."
 
 ## [0.12.1] - 2026-05-31
 

--- a/react-app/src/lib/api-schema.ts
+++ b/react-app/src/lib/api-schema.ts
@@ -348,6 +348,7 @@ export interface paths {
                     content: {
                         "application/json": {
                             id: string;
+                            isAdmin: boolean;
                         }[];
                     };
                 };
@@ -367,6 +368,7 @@ export interface paths {
                     "application/json": {
                         id: string;
                         password: string;
+                        isAdmin?: boolean;
                     };
                 };
             };
@@ -427,7 +429,8 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        password: string;
+                        password?: string;
+                        isAdmin?: boolean;
                     };
                 };
             };
@@ -1026,7 +1029,7 @@ export interface paths {
                         "application/json": {
                             user_id: string;
                             gallery_id: string;
-                            access_level: number;
+                            is_admin: number;
                             hide_map: number | null;
                         }[];
                     };
@@ -1063,8 +1066,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        /** @enum {string} */
-                        accessLevel: "none" | "view" | "admin";
+                        isAdmin: boolean;
                         hideMap?: boolean | null;
                     };
                 };

--- a/server/bin/access.ts
+++ b/server/bin/access.ts
@@ -2,24 +2,20 @@
 /* eslint-disable no-console -- interactive CLI tool; console output is the UI */
 
 /**
- * Manage `user_gallery` rows — access level (level / unset subcommands) and
- * the privacy cascade's `hide_map` toggle (hide-map subcommand). Avoids the
- * previous "edit the DB directly with sqlite3" recipe.
+ * Manage `user_gallery` rows — per-gallery access grants (grant /
+ * revoke) and the privacy cascade's `hide_map` toggle (hide-map).
  *
  * Subcommands:
  *
  *   access.ts list [--user <id>] [--gallery <id>]
- *   access.ts level <user> <gallery> <none|view|admin>
- *   access.ts unset <user> <gallery> [--yes]
+ *   access.ts grant <user> <gallery> [--admin]
+ *   access.ts revoke <user> <gallery> [--yes]
  *   access.ts hide-map <user> <gallery> <hide|show|default>
+ *   access.ts audit [...]
  *
- * `:guest` (the sentinel user) and `:all` (the sentinel gallery) are accepted
- * directly as the positional arguments — the operator doesn't have to quote
- * anything.
- *
- * `level … none` and `unset` differ: `level … none` writes a row with
- * access_level=0 and stops the cascade at that row; `unset` deletes the row
- * entirely and lets the cascade fall through to less-specific rows.
+ * `:guest` is accepted as the user. Pseudo-galleries (`:all`,
+ * `:public`) are rejected — the model has no use for them. Global
+ * admin is set via `bin/user.ts make-admin <user>`.
  */
 
 import { createInterface } from "node:readline/promises";
@@ -31,30 +27,48 @@ import CONST from "../lib/constants.js";
 import db from "../db/index.js";
 import type { UserGalleryRow } from "../db/index.js";
 
-const LEVEL_VALUES = {
-  none: CONST.ACCESS_NONE,
-  view: CONST.ACCESS_VIEW,
-  admin: CONST.ACCESS_ADMIN,
-} as const;
-type LevelName = keyof typeof LEVEL_VALUES;
-const levelName = (value: number | null): string => {
-  if (value === null) return "—";
-  if (value === CONST.ACCESS_ADMIN) return "admin";
-  if (value === CONST.ACCESS_VIEW) return "view";
-  if (value === CONST.ACCESS_NONE) return "none";
-  return String(value);
+const REJECTED_GALLERIES = new Set([
+  CONST.SPECIAL_GALLERY_ALL,
+  CONST.SPECIAL_GALLERY_PUBLIC,
+]);
+
+const checkGalleryId = (galleryId: string) => {
+  if (REJECTED_GALLERIES.has(galleryId)) {
+    console.error(
+      `✗ ${galleryId} is not a real gallery. ` +
+        "For global admin, use `bin/user.ts make-admin <user>`."
+    );
+    process.exit(1);
+  }
 };
-const hideMapName = (value: number | null): string => {
+
+const accessLabel = (isAdmin: number): string =>
+  isAdmin ? "admin" : "view";
+const hideMapLabel = (value: number | null): string => {
   if (value === null) return "—";
   return value === 1 ? "hide" : "show";
 };
 
-const formatRows = (rows: UserGalleryRow[]): string => {
-  if (rows.length === 0) return "(no rows)";
+const formatRows = (
+  rows: UserGalleryRow[],
+  globalAdmins: Set<string>
+): string => {
+  const annotatedGlobals = [...globalAdmins].sort().map(
+    (id) => `${id}\t(global admin)`
+  );
+  if (rows.length === 0 && annotatedGlobals.length === 0) return "(no rows)";
   const header = ["user", "gallery", "access", "hide_map"];
   const lines: string[][] = [header];
   for (const r of rows) {
-    lines.push([r.user_id, r.gallery_id, levelName(r.access_level), hideMapName(r.hide_map)]);
+    const annotated = globalAdmins.has(r.user_id)
+      ? `${r.user_id} (global admin)`
+      : r.user_id;
+    lines.push([annotated, r.gallery_id, accessLabel(r.is_admin), hideMapLabel(r.hide_map)]);
+  }
+  // Surface global admins with no per-gallery rows on their own line.
+  for (const id of globalAdmins) {
+    if (rows.some((r) => r.user_id === id)) continue;
+    lines.push([`${id} (global admin)`, "—", "—", "—"]);
   }
   const widths = header.map((_, col) => Math.max(...lines.map((l) => l[col].length)));
   return lines
@@ -63,6 +77,16 @@ const formatRows = (rows: UserGalleryRow[]): string => {
       return i === 0 ? `${padded}\n${widths.map((w) => "-".repeat(w)).join("  ")}` : padded;
     })
     .join("\n");
+};
+
+const loadGlobalAdmins = async (filter?: string): Promise<Set<string>> => {
+  const users = (await db.loadUsers()) as Array<{ id: string; is_admin?: number | boolean }>;
+  return new Set(
+    users
+      .filter((u) => !!u.is_admin)
+      .map((u) => u.id)
+      .filter((id) => !filter || id === filter)
+  );
 };
 
 const confirm = async (prompt: string): Promise<boolean> => {
@@ -79,68 +103,70 @@ await yargs(hideBin(process.argv))
   .scriptName("access.ts")
   .locale("en")
   .strict()
-  .demandCommand(1, "Specify a subcommand: list, grant, revoke, or hide-map")
+  .demandCommand(1, "Specify a subcommand: list, grant, revoke, hide-map, or audit")
   .command(
     "list",
-    "Print existing user_gallery rows (optionally filtered)",
+    "Print existing user_gallery rows (optionally filtered) plus global admins",
     (y) =>
       y
         .option("user", { describe: "Filter to one user ID (e.g. :guest)", type: "string" })
-        .option("gallery", { describe: "Filter to one gallery ID (e.g. :all)", type: "string" }),
+        .option("gallery", { describe: "Filter to one gallery ID", type: "string" }),
     async (argv) => {
       const rows = await db.loadUserGalleryRows({
         userId: argv.user,
         galleryId: argv.gallery,
       });
-      console.log(formatRows(rows));
+      // When filtering by gallery alone, the global-admin list isn't
+      // gallery-scoped — only surface it when the gallery filter isn't set.
+      const globals = argv.gallery
+        ? new Set<string>()
+        : await loadGlobalAdmins(argv.user);
+      console.log(formatRows(rows, globals));
     }
   )
   .command(
-    "level <user> <gallery> <level>",
-    "Set the access level on a user × gallery row (use 'none' for explicit deny)",
+    "grant <user> <gallery>",
+    "Grant a user view (or admin with --admin) on a gallery. Idempotent — re-running with a different --admin toggles it.",
     (y) =>
       y
         .positional("user", { describe: "User ID (or :guest)", type: "string", demandOption: true })
-        .positional("gallery", { describe: "Gallery ID (or :all)", type: "string", demandOption: true })
-        .positional("level", {
-          describe:
-            "Access level — 'none' explicitly denies at this row (cascade stops here)",
-          choices: ["none", "view", "admin"] as const,
-          demandOption: true,
-        }),
+        .positional("gallery", { describe: "Gallery ID", type: "string", demandOption: true })
+        .option("admin", { describe: "Grant gallery-admin instead of view", type: "boolean", default: false }),
     async (argv) => {
-      const level = LEVEL_VALUES[argv.level as LevelName];
+      checkGalleryId(argv.gallery);
       await db.upsertUserGallery({
         user_id: argv.user,
         gallery_id: argv.gallery,
-        access_level: level,
+        is_admin: !!argv.admin,
       });
-      console.log(`✓ Set access to ${argv.level}: (${argv.user}, ${argv.gallery})`);
+      const label = argv.admin ? "admin" : "view";
+      console.log(`✓ Granted ${label}: (${argv.user}, ${argv.gallery})`);
     }
   )
   .command(
-    "unset <user> <gallery>",
-    "Delete the row entirely (cascade falls through to less-specific rows)",
+    "revoke <user> <gallery>",
+    "Delete the user_gallery row (revokes all access at this scope)",
     (y) =>
       y
         .positional("user", { describe: "User ID (or :guest)", type: "string", demandOption: true })
-        .positional("gallery", { describe: "Gallery ID (or :all)", type: "string", demandOption: true })
+        .positional("gallery", { describe: "Gallery ID", type: "string", demandOption: true })
         .option("yes", { describe: "Skip the confirmation prompt", type: "boolean", default: false }),
     async (argv) => {
+      checkGalleryId(argv.gallery);
       if (!argv.yes) {
-        const ok = await confirm(`Delete user_gallery row (${argv.user}, ${argv.gallery})?`);
+        const ok = await confirm(`Revoke (${argv.user}, ${argv.gallery})?`);
         if (!ok) {
           console.log("Aborted.");
           return;
         }
       }
       await db.deleteUserGallery(argv.user, argv.gallery);
-      console.log(`✓ Unset: (${argv.user}, ${argv.gallery})`);
+      console.log(`✓ Revoked: (${argv.user}, ${argv.gallery})`);
     }
   )
   .command(
     "audit",
-    "Find user_gallery rows whose referenced user or gallery no longer exists",
+    "Find user_gallery rows whose referenced user or gallery no longer exists; report global-admin count",
     (y) =>
       y
         .option("orphan-users", {
@@ -151,8 +177,7 @@ await yargs(hideBin(process.argv))
         .option("orphan-galleries", {
           type: "boolean",
           default: false,
-          describe:
-            "Restrict to rows referencing a deleted gallery (sentinel ids :all etc. excluded)",
+          describe: "Restrict to rows referencing a deleted gallery",
         })
         .option("format", {
           choices: ["table", "ids"] as const,
@@ -168,7 +193,11 @@ await yargs(hideBin(process.argv))
       };
 
       if (argv.format === "table") {
-        console.log(`Audited ${orphans.length} orphan user_gallery row(s).`);
+        const globalAdmins = await loadGlobalAdmins();
+        console.log(
+          `Audited ${orphans.length} orphan user_gallery row(s). ` +
+            `Global admins: ${globalAdmins.size}${globalAdmins.size > 0 ? " (" + [...globalAdmins].join(", ") + ")" : ""}`
+        );
       }
 
       const print = (
@@ -214,14 +243,15 @@ await yargs(hideBin(process.argv))
     (y) =>
       y
         .positional("user", { describe: "User ID (or :guest)", type: "string", demandOption: true })
-        .positional("gallery", { describe: "Gallery ID (or :all)", type: "string", demandOption: true })
+        .positional("gallery", { describe: "Gallery ID", type: "string", demandOption: true })
         .positional("state", {
           describe:
-            "hide = hide the map; show = show the map; default = clear override (inherit from less-specific row)",
+            "hide = hide the map; show = show the map; default = clear override (inherit)",
           choices: ["hide", "show", "default"] as const,
           demandOption: true,
         }),
     async (argv) => {
+      checkGalleryId(argv.gallery);
       const value = argv.state === "hide" ? 1 : argv.state === "show" ? 0 : null;
       await db.upsertUserGallery({
         user_id: argv.user,

--- a/server/bin/user.ts
+++ b/server/bin/user.ts
@@ -33,7 +33,6 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
 import { SALT_ROUNDS } from "../lib/bcrypt-rounds.js";
-import CONST from "../lib/constants.js";
 import db from "../db/index.js";
 
 const confirm = async (prompt: string): Promise<boolean> => {
@@ -124,24 +123,58 @@ await yargs(hideBin(process.argv))
   .scriptName("user.ts")
   .locale("en")
   .strict()
-  .demandCommand(1, "Specify a subcommand: list, passwd, or delete")
+  .demandCommand(1, "Specify a subcommand: list, passwd, make-admin, revoke-admin, delete, or audit")
   .command(
     "list",
-    "Print every user as a table with their admin flag",
+    "Print every user as a table with their global-admin flag",
     (y) => y,
     async () => {
-      const users = (await db.loadUsers()) as Array<{ id: string }>;
+      const users = (await db.loadUsers()) as Array<{
+        id: string;
+        is_admin?: number | boolean;
+      }>;
       const rows: string[][] = [["user", "admin"]];
       for (const user of users) {
         if (!user.id) continue;
-        const accessRows = await db.loadUserGalleryRows({
-          userId: user.id,
-          galleryId: CONST.SPECIAL_GALLERY_ALL,
-        });
-        const isAdmin = accessRows.some((r) => r.access_level === CONST.ACCESS_ADMIN);
-        rows.push([user.id, isAdmin ? "yes" : "no"]);
+        rows.push([user.id, user.is_admin ? "yes" : "no"]);
       }
       console.log(rows.length === 1 ? "(no users)" : formatTable(rows));
+    }
+  )
+  .command(
+    "make-admin <id>",
+    "Promote a user to global admin (bypasses all access checks)",
+    (y) =>
+      y.positional("id", { describe: "User ID", type: "string", demandOption: true }),
+    async (argv) => {
+      const existing = await db
+        .loadUser(argv.id)
+        .then((u) => u as { id: string })
+        .catch(() => null);
+      if (!existing) {
+        console.error(`✗ User "${argv.id}" doesn't exist.`);
+        process.exit(1);
+      }
+      await db.updateUser(argv.id, { is_admin: 1 });
+      console.log(`✓ "${argv.id}" is now a global admin.`);
+    }
+  )
+  .command(
+    "revoke-admin <id>",
+    "Revoke a user's global-admin flag (does not change per-gallery grants)",
+    (y) =>
+      y.positional("id", { describe: "User ID", type: "string", demandOption: true }),
+    async (argv) => {
+      const existing = await db
+        .loadUser(argv.id)
+        .then((u) => u as { id: string })
+        .catch(() => null);
+      if (!existing) {
+        console.error(`✗ User "${argv.id}" doesn't exist.`);
+        process.exit(1);
+      }
+      await db.updateUser(argv.id, { is_admin: 0 });
+      console.log(`✓ Revoked global-admin from "${argv.id}".`);
     }
   )
   .command(
@@ -186,7 +219,12 @@ await yargs(hideBin(process.argv))
             : `✓ Updated password for "${argv.id}"; existing sessions invalidated (secret rotated).`
         );
       } else {
-        await db.createUser({ id: argv.id, password: hash, secret: randomUUID() });
+        await db.createUser({
+          id: argv.id,
+          password: hash,
+          secret: randomUUID(),
+          is_admin: 0,
+        });
         console.log(`✓ Created user "${argv.id}".`);
       }
     }
@@ -211,7 +249,10 @@ await yargs(hideBin(process.argv))
           default: "table" as const,
         }),
     async (argv) => {
-      const users = (await db.loadUsers()) as Array<{ id: string }>;
+      const users = (await db.loadUsers()) as Array<{
+        id: string;
+        is_admin?: number | boolean;
+      }>;
       const filterFlag = argv["no-access"] || argv["no-admin"];
       const want = (key: string) => !filterFlag || argv[key];
 
@@ -239,27 +280,17 @@ await yargs(hideBin(process.argv))
       }
 
       if (want("no-admin")) {
-        let anyAdmin = false;
-        for (const user of users) {
-          if (!user.id) continue;
-          const accessRows = await db.loadUserGalleryRows({
-            userId: user.id,
-            galleryId: CONST.SPECIAL_GALLERY_ALL,
-          });
-          if (accessRows.some((r) => r.access_level === CONST.ACCESS_ADMIN)) {
-            anyAdmin = true;
-            break;
-          }
-        }
+        const anyAdmin = (users as Array<{ is_admin?: number | boolean }>).some(
+          (u) => !!u.is_admin
+        );
         if (argv.format === "table") {
           console.log(
-            `\nInstance has admin: ${anyAdmin ? "yes" : "NO — no user has ACCESS_ADMIN on :all"}`
+            `\nInstance has global admin: ${anyAdmin ? "yes" : "NO — no user.is_admin = true"}`
           );
         } else if (!anyAdmin) {
           // ids format: emit the warning on stderr so stdout stays empty
-          // when there are no rows of concern (the no-admin case still
-          // demands attention).
-          console.error("WARNING: no user has ACCESS_ADMIN on :all");
+          // when there are no rows of concern.
+          console.error("WARNING: no user has is_admin = true");
         }
       }
     }

--- a/server/controllers/user-gallery-v1.ts
+++ b/server/controllers/user-gallery-v1.ts
@@ -1,10 +1,8 @@
 import { Type } from "typebox";
 import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
-import CONST from "../lib/constants.js";
 import authorizerFactory from "../lib/authorizer.js";
 import { requireScopeMatches } from "../lib/host-scope.js";
-import { StringEnum } from "../lib/schema-utils.js";
 import modelFactory from "../models/user-gallery.js";
 
 const authorizer = authorizerFactory();
@@ -25,33 +23,21 @@ const RowParams = Type.Object({
 const RowResponse = Type.Object({
   user_id: Type.String(),
   gallery_id: Type.String(),
-  access_level: Type.Number(),
+  is_admin: Type.Number(),
   hide_map: Type.Union([Type.Number(), Type.Null()]),
 });
 const RowsResponse = Type.Array(RowResponse);
-// `none|view|admin` maps to the numeric ACCESS_* constants. `hideMap`
+// `isAdmin = true` upgrades a row to gallery admin. `hideMap`
 // is the privacy override on this specific (user, gallery) pair —
-// `null` means "inherit from the next outer level".
-const AccessLevelLiteral = StringEnum(["none", "view", "admin"] as const);
+// `null` means "inherit from the next outer level."
 const UpsertBody = Type.Object(
   {
-    accessLevel: AccessLevelLiteral,
+    isAdmin: Type.Boolean(),
     hideMap: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
   },
   { additionalProperties: false }
 );
 const TAGS = ["user-gallery"];
-
-const accessLevelToNumber = (level: "none" | "view" | "admin"): number => {
-  switch (level) {
-    case "none":
-      return CONST.ACCESS_NONE;
-    case "view":
-      return CONST.ACCESS_VIEW;
-    case "admin":
-      return CONST.ACCESS_ADMIN;
-  }
-};
 
 const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   /**
@@ -77,7 +63,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       })) as Array<{
         user_id: string;
         gallery_id: string;
-        access_level: number;
+        is_admin: number;
         hide_map: number | null;
       }>;
       // On a scoped host, narrow to the scoped galleries. Rows for any
@@ -106,11 +92,11 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
     async (request, reply) => {
       requireScopeMatches(request, request.params.galleryId);
       await authorizer.authorizeAdmin(request.user.id);
-      const { accessLevel, hideMap } = request.body;
+      const { isAdmin, hideMap } = request.body;
       await model.upsertUserGallery({
         user_id: request.params.userId,
         gallery_id: request.params.galleryId,
-        access_level: accessLevelToNumber(accessLevel),
+        is_admin: isAdmin,
         hide_map:
           hideMap === undefined ? undefined : hideMap === null ? null : hideMap ? 1 : 0,
       });

--- a/server/controllers/users-v1.ts
+++ b/server/controllers/users-v1.ts
@@ -17,14 +17,19 @@ const init = async () => {
 };
 
 const UserIdParam = Type.Object({ userId: Type.String() });
-const UserSummary = Type.Object({ id: Type.String() });
+const UserSummary = Type.Object({
+  id: Type.String(),
+  isAdmin: Type.Boolean(),
+});
 const UsersListResponse = Type.Array(UserSummary);
 const UserCreateBody = Type.Object({
   id: Type.String({ minLength: 1 }),
   password: Type.String({ minLength: 1 }),
+  isAdmin: Type.Optional(Type.Boolean()),
 });
 const UserUpdateBody = Type.Object({
-  password: Type.String({ minLength: 1 }),
+  password: Type.Optional(Type.String({ minLength: 1 })),
+  isAdmin: Type.Optional(Type.Boolean()),
 });
 const ChangePasswordBody = Type.Object({
   currentPassword: Type.String({ minLength: 1 }),
@@ -57,9 +62,11 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
     async (request) => {
       requireUnscoped(request);
       await authorizer.authorizeAdmin(request.user.id);
-      const cleanUser = (user: { id: string }) => ({ id: user.id });
-      const users = (await model.getUsers()) as Array<{ id: string }>;
-      return users.map(cleanUser);
+      const users = (await model.getUsers()) as Array<{
+        id: string;
+        is_admin?: number | boolean;
+      }>;
+      return users.map((user) => ({ id: user.id, isAdmin: !!user.is_admin }));
     }
   );
 

--- a/server/db/dummy.ts
+++ b/server/db/dummy.ts
@@ -170,32 +170,35 @@ const deleteUser = async (id: string) => {
   delete db.users[id];
 };
 
+type AclEntry = { is_admin: boolean; hide_map?: number | null };
+type AclMap = Record<string, Record<string, AclEntry>>;
+
 const loadUserGalleryRows = async (
   filter: { userId?: string; galleryId?: string } = {}
 ) => {
-  const acl = (db.accessControl as Record<string, Record<string, number>>) ?? {};
+  const acl = (db.accessControl as AclMap) ?? {};
   const out: Array<{
     user_id: string;
     gallery_id: string;
-    access_level: number;
+    is_admin: number;
     hide_map: number | null;
   }> = [];
   for (const [userId, perGallery] of Object.entries(acl)) {
     if (filter.userId && filter.userId !== userId) continue;
-    for (const [galleryId, level] of Object.entries(perGallery)) {
+    for (const [galleryId, entry] of Object.entries(perGallery)) {
       if (filter.galleryId && filter.galleryId !== galleryId) continue;
       out.push({
         user_id: userId,
         gallery_id: galleryId,
-        access_level: level,
-        hide_map: null,
+        is_admin: entry.is_admin ? 1 : 0,
+        hide_map: entry.hide_map ?? null,
       });
     }
   }
   return out;
 };
 const deleteUserGallery = async (userId: string, galleryId: string) => {
-  const acl = db.accessControl as Record<string, Record<string, number>>;
+  const acl = db.accessControl as AclMap;
   if (acl?.[userId]) {
     delete acl[userId][galleryId];
     if (Object.keys(acl[userId]).length === 0) delete acl[userId];
@@ -204,39 +207,45 @@ const deleteUserGallery = async (userId: string, galleryId: string) => {
 const upsertUserGallery = async (row: {
   user_id: string;
   gallery_id: string;
-  access_level?: number | null;
+  is_admin?: boolean;
   hide_map?: number | null;
 }) => {
-  const acl = (db.accessControl ??= {}) as Record<
-    string,
-    Record<string, number>
-  >;
+  const acl = (db.accessControl ??= {}) as AclMap;
   acl[row.user_id] ??= {};
-  if (row.access_level !== undefined && row.access_level !== null) {
-    acl[row.user_id][row.gallery_id] = row.access_level;
-  }
-  // Dummy doesn't track `hide_map` separately; the access cascade
-  // queries it via `resolveHideMap`, which in the dummy just returns
-  // `false`. Real schema persists the column.
+  const existing = acl[row.user_id][row.gallery_id] ?? { is_admin: false };
+  if ("is_admin" in row) existing.is_admin = !!row.is_admin;
+  if ("hide_map" in row) existing.hide_map = row.hide_map;
+  acl[row.user_id][row.gallery_id] = existing;
 };
 
 const resolveAccessLevel = async (
   userId: string,
   galleryId: string
-): Promise<number | undefined> => {
-  const isSpecial = galleryId.startsWith(":");
-  const galleries = isSpecial ? [galleryId, ":all"] : [galleryId, ":public", ":all"];
-  const userRows = (db.accessControl[userId] ?? {}) as Record<string, number>;
-  for (const g of galleries) if (g in userRows) return userRows[g];
-  const guestRows = (db.accessControl[":guest"] ?? {}) as Record<string, number>;
-  for (const g of galleries) if (g in guestRows) return guestRows[g];
-  return undefined;
+): Promise<{ hasAccess: boolean; isAdmin: boolean }> => {
+  const user = db.users[userId] as { is_admin?: boolean } | undefined;
+  if (user?.is_admin) return { hasAccess: true, isAdmin: true };
+  const acl = db.accessControl as AclMap;
+  const userRow = acl[userId]?.[galleryId];
+  const guestRow = acl[":guest"]?.[galleryId];
+  if (!userRow && !guestRow) return { hasAccess: false, isAdmin: false };
+  const isAdmin = !!(userRow?.is_admin || guestRow?.is_admin);
+  return { hasAccess: true, isAdmin };
 };
 const resolveHideMap = async (
-  _userId: string,
-  _galleryId: string
+  userId: string,
+  galleryId: string
 ): Promise<number | undefined> => {
-  // Dummy ACL data carries only access levels, no privacy overrides.
+  const user = db.users[userId] as { is_admin?: boolean } | undefined;
+  if (user?.is_admin) return 0;
+  const acl = db.accessControl as AclMap;
+  const userRow = acl[userId]?.[galleryId];
+  if (userRow?.hide_map !== null && userRow?.hide_map !== undefined) {
+    return userRow.hide_map;
+  }
+  const guestRow = acl[":guest"]?.[galleryId];
+  if (guestRow?.hide_map !== null && guestRow?.hide_map !== undefined) {
+    return guestRow.hide_map;
+  }
   return undefined;
 };
 
@@ -585,79 +594,92 @@ const dbDump = JSON.stringify({
       id: "admin",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
       secret: randomUUID(),
+      is_admin: true,
     },
     gallery1Admin: {
       id: "gallery1Admin",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
       secret: randomUUID(),
+      is_admin: false,
     },
     gallery2Admin: {
       id: "gallery2Admin",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
       secret: randomUUID(),
+      is_admin: false,
     },
     gallery1User: {
       id: "gallery1User",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
       secret: randomUUID(),
+      is_admin: false,
     },
     gallery12User: {
       id: "gallery12User",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
       secret: randomUUID(),
+      is_admin: false,
     },
     plainUser: {
       id: "plainUser",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
       secret: randomUUID(),
+      is_admin: false,
     },
     publicUser: {
       id: "publicUser",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
       secret: randomUUID(),
+      is_admin: false,
     },
     simpleUser: {
       id: "simpleUser",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
       secret: randomUUID(),
+      is_admin: false,
     },
     blockedUser: {
       id: "blockedUser",
       password: "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG",
       secret: randomUUID(),
+      is_admin: false,
     },
   },
+  // Per-(user, gallery) positive grants. Row presence = VIEW; is_admin
+  // upgrades to gallery admin. The new model has no NONE rows — revoke
+  // is "delete the row." `admin` user is global admin (is_admin flag on
+  // the user table), so no rows here.
   accessControl: {
-    admin: {
-      [CONST.SPECIAL_GALLERY_ALL]: CONST.ACCESS_ADMIN,
-    },
     gallery1Admin: {
-      [CONST.SPECIAL_GALLERY_ALL]: CONST.ACCESS_VIEW,
-      gallery1: CONST.ACCESS_ADMIN,
+      gallery1: { is_admin: true },
     },
     gallery2Admin: {
-      gallery2: CONST.ACCESS_ADMIN,
+      gallery2: { is_admin: true },
     },
     gallery1User: {
-      gallery1: CONST.ACCESS_VIEW,
+      gallery1: { is_admin: false },
     },
     gallery12User: {
-      gallery1: CONST.ACCESS_VIEW,
-      gallery2: CONST.ACCESS_VIEW,
-      gallery3: CONST.ACCESS_NONE,
+      gallery1: { is_admin: false },
+      gallery2: { is_admin: false },
     },
+    // plainUser and publicUser previously used the `:all` / `:public`
+    // wildcard rows. The post-#394 equivalent is explicit per-gallery
+    // grants on every real gallery in the fixture.
     plainUser: {
-      [CONST.SPECIAL_GALLERY_ALL]: CONST.ACCESS_VIEW,
+      gallery1: { is_admin: false },
+      gallery2: { is_admin: false },
+      gallery3: { is_admin: false },
     },
     publicUser: {
-      [CONST.SPECIAL_GALLERY_PUBLIC]: CONST.ACCESS_VIEW,
+      gallery1: { is_admin: false },
+      gallery2: { is_admin: false },
+      gallery3: { is_admin: false },
     },
     simpleUser: {},
-    blockedUser: {
-      [CONST.SPECIAL_GALLERY_ALL]: CONST.ACCESS_NONE,
-    },
+    blockedUser: {},
     ":guest": {
-      gallery3: CONST.ACCESS_VIEW,
+      gallery3: { is_admin: false },
     },
   },
   galleries: {

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -87,12 +87,15 @@ export default {
     await db.deleteUserSessions(userId);
   },
 
-  // Resolve the effective access_level for (userId, galleryId) under the
-  // user-first cascade. Returns undefined when no row applies.
+  // Resolve effective access for (userId, galleryId):
+  //   user.is_admin → global admin (bypass).
+  //   matching user_gallery row (user or :guest, this gallery) → access;
+  //     is_admin flag on the winning row distinguishes gallery admin from view.
+  //   no match → deny.
   resolveAccessLevel: async (
     userId: string,
     galleryId: string
-  ): Promise<number | undefined> => {
+  ): Promise<{ hasAccess: boolean; isAdmin: boolean }> => {
     return await db.resolveAccessLevel(userId, galleryId);
   },
   loadUserGalleryRows: async (
@@ -103,7 +106,7 @@ export default {
   upsertUserGallery: async (row: {
     user_id: string;
     gallery_id: string;
-    access_level?: number | null;
+    is_admin?: boolean;
     hide_map?: number | null;
   }): Promise<void> => {
     await db.upsertUserGallery(row);
@@ -111,11 +114,11 @@ export default {
   deleteUserGallery: async (userId: string, galleryId: string): Promise<void> => {
     await db.deleteUserGallery(userId, galleryId);
   },
-  // Resolve the privacy cascade for (userId, galleryId): gallery-first
-  // walk matching the access cascade — `requested → :public → :all` for
-  // non-special galleries (skipping :public for :public/:all requests),
-  // with user-beats-guest at each gallery level. Returns the
-  // first non-null `hide_map` encountered; undefined when nothing matches.
+  // Resolve privacy for (userId, galleryId):
+  //   user.is_admin → 0 (show, bypass).
+  //   first non-null hide_map from (user, gallery), (:guest, gallery)
+  //     with the user row winning the tie.
+  //   undefined when nothing matches (treated as show downstream).
   resolveHideMap: async (
     userId: string,
     galleryId: string

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -167,39 +167,34 @@ const deleteUserSessions = async (userId: string): Promise<void> => {
   db.prepare("DELETE FROM session WHERE user_id = ?").run(userId);
 };
 
-// Resolve the access level for (userId, galleryId) under the user-first
-// cascade: user's rows are consulted in gallery-specificity order first, then
-// :guest's rows. For a non-special gallery request the gallery steps are
-// `gallery → :public → :all`; for `:public`/`:all` requests the
-// :public step is dropped. NULL `access_level` rows are filtered out so
-// privacy-only rows (`hide_map` set without an access grant) don't poison
-// the resolution and force a deny.
+// Resolve access for (userId, galleryId) under the post-#394 model:
+//   1. user.is_admin = true                       → global admin (bypass).
+//   2. row exists in user_gallery for user-or-:guest on this gallery:
+//        is_admin = 1                             → gallery admin.
+//        otherwise (row present)                  → view.
+//   3. else                                       → deny.
+// Group rows (#270) will slot in at step 2 as an additional row source.
 const resolveAccessLevel = async (
   userId: string,
   galleryId: string
-): Promise<number | undefined> => {
-  const isSpecial = galleryId.startsWith(":");
-  const galleryWhere = isSpecial
-    ? "gallery_id IN (?, ':all')"
-    : "gallery_id IN (?, ':public', ':all')";
-  const galleryOrder = isSpecial
-    ? "CASE WHEN gallery_id = ? THEN 0 ELSE 1 END"
-    : "CASE WHEN gallery_id = ? THEN 0 WHEN gallery_id = ':public' THEN 1 ELSE 2 END";
-  const row = db
+): Promise<{ hasAccess: boolean; isAdmin: boolean }> => {
+  const userRow = db
+    .prepare("SELECT is_admin FROM user WHERE id = ?")
+    .get(userId) as { is_admin: number } | undefined;
+  if (userRow && userRow.is_admin) {
+    return { hasAccess: true, isAdmin: true };
+  }
+  const grantRow = db
     .prepare(
-      `SELECT access_level FROM user_gallery
-       WHERE (user_id = ? OR user_id = ':guest')
-         AND ${galleryWhere}
-         AND access_level IS NOT NULL
-       ORDER BY
-         CASE WHEN user_id = ? THEN 0 ELSE 1 END,
-         ${galleryOrder}
-       LIMIT 1`
+      `SELECT MAX(is_admin) AS is_admin
+       FROM user_gallery
+       WHERE user_id IN (?, ':guest') AND gallery_id = ?`
     )
-    .get(userId, galleryId, userId, galleryId) as
-    | { access_level: number }
-    | undefined;
-  return row?.access_level;
+    .get(userId, galleryId) as { is_admin: number | null } | undefined;
+  if (grantRow?.is_admin === null || grantRow?.is_admin === undefined) {
+    return { hasAccess: false, isAdmin: false };
+  }
+  return { hasAccess: true, isAdmin: !!grantRow.is_admin };
 };
 
 const loadUserGalleryRows = async (
@@ -224,7 +219,7 @@ const upsertUserGallery = async (
   row: {
     user_id: string;
     gallery_id: string;
-    access_level?: number | null;
+    is_admin?: boolean;
     hide_map?: number | null;
   }
 ): Promise<void> => {
@@ -232,16 +227,16 @@ const upsertUserGallery = async (
   // conflict). Done with SQLite's INSERT ON CONFLICT DO UPDATE so a single
   // statement handles both the create and the partial-update path.
   const sets: string[] = [];
-  if ("access_level" in row) sets.push("access_level = excluded.access_level");
+  if ("is_admin" in row) sets.push("is_admin = excluded.is_admin");
   if ("hide_map" in row) sets.push("hide_map = excluded.hide_map");
   const query =
-    "INSERT INTO user_gallery (user_id, gallery_id, access_level, hide_map) " +
+    "INSERT INTO user_gallery (user_id, gallery_id, is_admin, hide_map) " +
     "VALUES (?, ?, ?, ?) " +
     `ON CONFLICT(user_id, gallery_id) DO UPDATE SET ${sets.join(", ")}`;
   db.prepare(query).run(
     row.user_id,
     row.gallery_id,
-    row.access_level ?? null,
+    row.is_admin ? 1 : 0,
     row.hide_map ?? null
   );
 };
@@ -255,44 +250,29 @@ const deleteUserGallery = async (
     galleryId,
   ]);
 };
-// Resolve the privacy cascade for (userId, galleryId). Same user-first
-// ordering as the access cascade: user's rows first in gallery-specificity
-// order, then :guest's. For a non-special gallery the gallery steps are
-// `gallery → :public → :all`; for `:public`/`:all` the :public
-// step is dropped (those aren't subsets of :public).
-//
-// Priority for a non-special gallery request:
-//   (user, gallery) > (user, :public) > (user, :all)
-//                   > (:guest, gallery) > (:guest, :public) > (:guest, :all)
-//
-// Rows with null `hide_map` are skipped so a less-specific row's non-null
-// value can win. Returns undefined when no row at any level has a non-null
-// `hide_map`.
+// Resolve the privacy cascade for (userId, galleryId).
+//   1. user.is_admin = true                       → 0 (show, bypass).
+//   2. first non-null hide_map from (user, gallery), (:guest, gallery)
+//      with the user's row beating :guest          → that value.
+//   3. else                                       → undefined (default show).
 const resolveHideMap = async (
   userId: string,
   galleryId: string
 ): Promise<number | undefined> => {
-  const isSpecial = galleryId.startsWith(":");
-  const galleryWhere = isSpecial
-    ? "gallery_id IN (?, ':all')"
-    : "gallery_id IN (?, ':public', ':all')";
-  const galleryOrder = isSpecial
-    ? "CASE WHEN gallery_id = ? THEN 0 ELSE 1 END"
-    : "CASE WHEN gallery_id = ? THEN 0 WHEN gallery_id = ':public' THEN 1 ELSE 2 END";
+  const userRow = db
+    .prepare("SELECT is_admin FROM user WHERE id = ?")
+    .get(userId) as { is_admin: number } | undefined;
+  if (userRow && userRow.is_admin) return 0;
   const row = db
     .prepare(
       `SELECT hide_map FROM user_gallery
-       WHERE (user_id = ? OR user_id = ':guest')
-         AND ${galleryWhere}
+       WHERE user_id IN (?, ':guest')
+         AND gallery_id = ?
          AND hide_map IS NOT NULL
-       ORDER BY
-         CASE WHEN user_id = ? THEN 0 ELSE 1 END,
-         ${galleryOrder}
+       ORDER BY CASE WHEN user_id = ? THEN 0 ELSE 1 END
        LIMIT 1`
     )
-    .get(userId, galleryId, userId, galleryId) as
-    | { hide_map: number }
-    | undefined;
+    .get(userId, galleryId, userId) as { hide_map: number } | undefined;
   return row?.hide_map;
 };
 

--- a/server/db/sqlite3/migrations/012_acl_simplification.sql
+++ b/server/db/sqlite3/migrations/012_acl_simplification.sql
@@ -1,0 +1,54 @@
+-- ACL simplification: drop pseudo-gallery wildcards from the cascade,
+-- collapse the access_level enum to a boolean `is_admin` on the link
+-- row, and promote `(user, :all, admin)` rows to a `user.is_admin`
+-- flag. The new model resolves access in three clauses: global admin
+-- bypass, then any matching positive grant (user / group / :guest),
+-- else deny. No NONE rows.
+
+-- 1. is_admin flag on the user table.
+ALTER TABLE user ADD COLUMN is_admin INTEGER NOT NULL DEFAULT 0;
+
+-- 2. Promote any user with `(user, :all, admin=2)` to a global admin.
+UPDATE user
+SET is_admin = 1
+WHERE id IN (
+  SELECT user_id FROM user_gallery
+  WHERE gallery_id = ':all' AND access_level = 2
+);
+
+-- 3. Fan out `:public` grants to every real gallery before the drop
+--    step, so non-admin users with a `:public` grant keep their
+--    effective per-gallery access. `INSERT OR IGNORE` keeps any
+--    specific-gallery row that already overrides.
+INSERT OR IGNORE INTO user_gallery (user_id, gallery_id, access_level, hide_map)
+SELECT ug.user_id, g.id, ug.access_level, ug.hide_map
+FROM user_gallery ug
+CROSS JOIN gallery g
+WHERE ug.gallery_id = ':public'
+  AND ug.user_id NOT IN (SELECT id FROM user WHERE is_admin = 1);
+
+-- 4. Drop pseudo-gallery rows.
+DELETE FROM user_gallery WHERE gallery_id IN (':all', ':public');
+
+-- 5. Drop NONE rows (access_level = 0). Historically rare; no longer
+--    expressible under the new model (revoking is deleting the row).
+DELETE FROM user_gallery WHERE access_level = 0;
+
+-- 6. Rebuild user_gallery: swap access_level INTEGER for is_admin INTEGER.
+--    sqlite-friendly rename-and-rebuild dance.
+CREATE TABLE user_gallery_new (
+  user_id    TEXT    NOT NULL,
+  gallery_id TEXT    NOT NULL,
+  is_admin   INTEGER NOT NULL DEFAULT 0,
+  hide_map   INTEGER,
+  PRIMARY KEY (user_id, gallery_id)
+);
+
+INSERT INTO user_gallery_new (user_id, gallery_id, is_admin, hide_map)
+SELECT user_id, gallery_id, CASE WHEN access_level = 2 THEN 1 ELSE 0 END, hide_map
+FROM user_gallery;
+
+DROP TABLE user_gallery;
+ALTER TABLE user_gallery_new RENAME TO user_gallery;
+
+UPDATE meta SET value='12' WHERE key='schema_version';

--- a/server/db/sqlite3/schema.ts
+++ b/server/db/sqlite3/schema.ts
@@ -10,6 +10,7 @@ export interface UserRow {
   id: string;
   password: string;
   secret: string;
+  is_admin: number;
 }
 export interface SessionRow {
   id: string;
@@ -21,7 +22,8 @@ export interface SessionRow {
 export interface UserGalleryRow {
   user_id: string;
   gallery_id: string;
-  access_level: number;
+  // Row presence alone grants VIEW; is_admin=1 upgrades that row to gallery admin.
+  is_admin: number;
   // Privacy toggle: 1 = hide map/coordinates, 0 = show; NULL inherits the
   // next outer level (gallery override → instance default).
   hide_map: number | null;
@@ -91,7 +93,9 @@ export interface PhotoLocalizedRow {
 // App-side shapes (what mapRow returns / mapInsert and mapToRow take).
 export type Meta = Record<string, string>;
 export type User = UserRow;
-export type UserGalleryAccess = [galleryId: string, accessLevel: number];
+// `(galleryId, isAdmin)` — row presence in the underlying table already
+// implies VIEW; isAdmin upgrades to gallery admin.
+export type UserGalleryAccess = [galleryId: string, isAdmin: number];
 export interface Gallery {
   id: string;
   title: string;
@@ -210,11 +214,13 @@ export default () => {
         id: toString(row.id),
         password: toString(row.password),
         secret: toString(row.secret),
+        is_admin: Number(row.is_admin ?? 0),
       }),
       mapInsert: (user: User): unknown[] => [
         user.id,
         user.password,
         user.secret,
+        user.is_admin ? 1 : 0,
       ],
 
       buildCreateQuery: () => buildCreateQuery(SCHEMA.user),
@@ -258,7 +264,7 @@ export default () => {
     userGallery: {
       mapRow: (row: UserGalleryRow): UserGalleryAccess => [
         row.gallery_id,
-        row.access_level,
+        row.is_admin,
       ],
       mapInsert: (): unknown[] => {
         throw new NotImplementedError();
@@ -505,6 +511,7 @@ const userMapToRow = (user: Partial<User>): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
   if ("password" in user) result.password = user.password;
   if ("secret" in user) result.secret = user.secret;
+  if ("is_admin" in user) result.is_admin = user.is_admin ? 1 : 0;
   return result;
 };
 const sessionMapToRow = (
@@ -519,7 +526,8 @@ const userGalleryMapToRow = (
   userGallery: Partial<UserGalleryRow>
 ): Record<string, unknown> => {
   const result: Record<string, unknown> = {};
-  if ("access_level" in userGallery) result.access_level = userGallery.access_level;
+  if ("is_admin" in userGallery) result.is_admin = userGallery.is_admin ? 1 : 0;
+  if ("hide_map" in userGallery) result.hide_map = userGallery.hide_map;
   return result;
 };
 const galleryMapToRow = (
@@ -629,7 +637,7 @@ const SCHEMA = {
   },
   user: {
     table: "user",
-    columns: ["id", "password", "secret"],
+    columns: ["id", "password", "secret", "is_admin"],
     primaryKey: ["id"],
     order: ["id ASC"],
     mapToRow: userMapToRow as (data: Record<string, unknown>) => Record<string, unknown>,
@@ -649,7 +657,7 @@ const SCHEMA = {
   },
   userGallery: {
     table: "user_gallery",
-    columns: ["user_id", "gallery_id", "access_level", "hide_map"],
+    columns: ["user_id", "gallery_id", "is_admin", "hide_map"],
     primaryKey: ["user_id", "gallery_id"],
     order: ["user_id ASC", "gallery_id ASC"],
     mapToRow: userGalleryMapToRow as (data: Record<string, unknown>) => Record<string, unknown>,

--- a/server/lib/authorizer.ts
+++ b/server/lib/authorizer.ts
@@ -1,4 +1,3 @@
-import CONST from "./constants.js";
 import { AccessError } from "./errors.js";
 import db from "../db/index.js";
 
@@ -11,34 +10,51 @@ export default () => {
   };
 };
 
-// Catch-all so driver-specific failures surface as a uniform AccessError.
-const requireLevel = async (
+// Driver-agnostic resolution. Any underlying failure surfaces as a
+// uniform AccessError so the controllers don't have to distinguish
+// "user not found" from "permission denied."
+const resolve = async (
   userId: string,
-  galleryId: string,
-  required: number
-): Promise<void> => {
+  galleryId: string
+): Promise<{ hasAccess: boolean; isAdmin: boolean }> => {
   try {
-    const level = await db.resolveAccessLevel(userId, galleryId);
-    if (level === undefined || level < required) {
-      throw new AccessError(undefined, { userId, galleryId, required });
-    }
-  } catch (e) {
-    if (e instanceof AccessError) throw e;
-    throw new AccessError(undefined, { userId, galleryId, required });
+    return await db.resolveAccessLevel(userId, galleryId);
+  } catch {
+    return { hasAccess: false, isAdmin: false };
   }
 };
 
-const authorizeView = (userId: string): Promise<void> =>
-  requireLevel(userId, CONST.SPECIAL_GALLERY_ALL, CONST.ACCESS_VIEW);
+const isGlobalAdmin = async (userId: string): Promise<boolean> => {
+  try {
+    const user = (await db.loadUser(userId)) as { is_admin?: number | boolean };
+    return !!user.is_admin;
+  } catch {
+    return false;
+  }
+};
 
-const authorizeAdmin = (userId: string): Promise<void> =>
-  requireLevel(userId, CONST.SPECIAL_GALLERY_ALL, CONST.ACCESS_ADMIN);
+// Global-admin-only operations (user CRUD, gallery CRUD, instance meta).
+const authorizeAdmin = async (userId: string): Promise<void> => {
+  if (!(await isGlobalAdmin(userId))) {
+    throw new AccessError(undefined, { userId, required: "global admin" });
+  }
+};
+
+// Equivalent to "is global admin" under the new model — there's no
+// "global view" tier. Kept as a separate verb because the existing
+// cross-gallery endpoints (`GET /photos`, `GET /photos/:id`) used it
+// to mean "user has visibility across the catalogue," and that role
+// is now strictly admin.
+const authorizeView = authorizeAdmin;
 
 const authorizeGalleryView = async (
   userId: string,
   galleryId: string
 ): Promise<string> => {
-  await requireLevel(userId, galleryId, CONST.ACCESS_VIEW);
+  const { hasAccess } = await resolve(userId, galleryId);
+  if (!hasAccess) {
+    throw new AccessError(undefined, { userId, galleryId, required: "view" });
+  }
   return galleryId;
 };
 
@@ -46,6 +62,9 @@ const authorizeGalleryAdmin = async (
   userId: string,
   galleryId: string
 ): Promise<string> => {
-  await requireLevel(userId, galleryId, CONST.ACCESS_ADMIN);
+  const { isAdmin } = await resolve(userId, galleryId);
+  if (!isAdmin) {
+    throw new AccessError(undefined, { userId, galleryId, required: "admin" });
+  }
   return galleryId;
 };

--- a/server/lib/constants.ts
+++ b/server/lib/constants.ts
@@ -43,10 +43,6 @@ const SPECIAL_GALLERIES = {
 const isSpecialGallery = (galleryId: string): boolean =>
   galleryId in SPECIAL_GALLERIES;
 
-const ACCESS_ADMIN = 2;
-const ACCESS_VIEW = 1;
-const ACCESS_NONE = 0;
-
 export default {
   DEFAULT_ENV,
   DEFAULT_DEBUG,
@@ -65,8 +61,4 @@ export default {
   SPECIAL_GALLERY_PUBLIC,
   SPECIAL_GALLERIES,
   isSpecialGallery,
-
-  ACCESS_ADMIN,
-  ACCESS_VIEW,
-  ACCESS_NONE,
 };

--- a/server/models/user-gallery.ts
+++ b/server/models/user-gallery.ts
@@ -22,7 +22,7 @@ const getUserGalleryRows = async (filter: {
 const upsertUserGallery = async (row: {
   user_id: string;
   gallery_id: string;
-  access_level?: number | null;
+  is_admin?: boolean;
   hide_map?: number | null;
 }) => {
   logger.debug("Upserting user_gallery", row);

--- a/server/models/user.ts
+++ b/server/models/user.ts
@@ -26,21 +26,40 @@ const getUsers = async () => {
 const getUser = async (id: string) => {
   return await db.loadUser(id);
 };
-const createUser = async (user: { id: string; password: string }) => {
-  logger.debug("Creating user", { id: user.id });
+const createUser = async (user: {
+  id: string;
+  password: string;
+  isAdmin?: boolean;
+}) => {
+  logger.debug("Creating user", { id: user.id, isAdmin: !!user.isAdmin });
   const password = await bcrypt.hash(user.password, SALT_ROUNDS);
-  await db.createUser({ id: user.id, password, secret: randomUUID() });
+  await db.createUser({
+    id: user.id,
+    password,
+    secret: randomUUID(),
+    is_admin: user.isAdmin ? 1 : 0,
+  });
 };
-// Admin-driven password reset for another user. Rotates `secret` so
-// any existing JWTs (and the user's own active sessions) are
-// invalidated — same semantics as `bin/user.ts passwd` without
-// `--keep-secret`.
-const updateUser = async (userId: string, patch: { password: string }) => {
-  logger.debug("Updating user", { id: userId });
-  const password = await bcrypt.hash(patch.password, SALT_ROUNDS);
-  const secret = randomBytes(32).toString("hex");
-  await db.updateUser(userId, { password, secret });
-  await db.deleteUserSessions(userId);
+// Admin-driven user update. Password rotation invalidates `secret`
+// (and active sessions) — same semantics as `bin/user.ts passwd`.
+// Toggling `isAdmin` is a separate concern that doesn't rotate the
+// secret; only password change does.
+const updateUser = async (
+  userId: string,
+  patch: { password?: string; isAdmin?: boolean }
+) => {
+  logger.debug("Updating user", { id: userId, hasPassword: !!patch.password });
+  const update: Record<string, unknown> = {};
+  if (patch.password) {
+    update.password = await bcrypt.hash(patch.password, SALT_ROUNDS);
+    update.secret = randomBytes(32).toString("hex");
+  }
+  if (patch.isAdmin !== undefined) {
+    update.is_admin = patch.isAdmin ? 1 : 0;
+  }
+  if (Object.keys(update).length === 0) return;
+  await db.updateUser(userId, update);
+  if (update.password) await db.deleteUserSessions(userId);
 };
 // Cascades to user_gallery rows so we don't orphan ACL entries.
 // Matches the `bin/user.ts delete` cleanup.

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -393,11 +393,15 @@
                   "items": {
                     "type": "object",
                     "required": [
-                      "id"
+                      "id",
+                      "isAdmin"
                     ],
                     "properties": {
                       "id": {
                         "type": "string"
+                      },
+                      "isAdmin": {
+                        "type": "boolean"
                       }
                     }
                   }
@@ -430,6 +434,9 @@
                   "password": {
                     "type": "string",
                     "minLength": 1
+                  },
+                  "isAdmin": {
+                    "type": "boolean"
                   }
                 }
               }
@@ -486,13 +493,13 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "password"
-                ],
                 "properties": {
                   "password": {
                     "type": "string",
                     "minLength": 1
+                  },
+                  "isAdmin": {
+                    "type": "boolean"
                   }
                 }
               }
@@ -1347,7 +1354,7 @@
                     "required": [
                       "user_id",
                       "gallery_id",
-                      "access_level",
+                      "is_admin",
                       "hide_map"
                     ],
                     "properties": {
@@ -1357,7 +1364,7 @@
                       "gallery_id": {
                         "type": "string"
                       },
-                      "access_level": {
+                      "is_admin": {
                         "type": "number"
                       },
                       "hide_map": {
@@ -1392,16 +1399,11 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "accessLevel"
+                  "isAdmin"
                 ],
                 "properties": {
-                  "accessLevel": {
-                    "type": "string",
-                    "enum": [
-                      "none",
-                      "view",
-                      "admin"
-                    ]
+                  "isAdmin": {
+                    "type": "boolean"
                   },
                   "hideMap": {
                     "anyOf": [

--- a/server/tests/api/galleries.test.ts
+++ b/server/tests/api/galleries.test.ts
@@ -127,11 +127,10 @@ describe("As blocked user", () => {
   });
 
   test("List galleries", async () => {
-    // blockedUser has `:all=NONE`, which under the user-first cascade shadows
-    // every :guest grant (including `:guest, gallery3, VIEW`). Logged in as
-    // blockedUser, the visible list is empty.
+    // blockedUser has no user_gallery rows. Falls through to :guest's
+    // grants under the post-#394 model — :guest sees gallery3.
     const result = await getGalleries(token);
-    expect(result.body.length).toBe(0);
+    expect(result.body.length).toBe(1);
   });
   test("Get gallery1", async () => {
     await expectGalleryUnavailable(token, "gallery1");
@@ -139,9 +138,9 @@ describe("As blocked user", () => {
   test("Get gallery2", async () => {
     await expectGalleryUnavailable(token, "gallery2");
   });
-  test("Get gallery3 (anonymous, not as blockedUser)", async () => {
-    // Anonymous request — :guest has gallery3=VIEW, so this still works.
-    const result = await api.get("/api/v1/galleries/gallery3").expect(200);
+  test("Get gallery3", async () => {
+    // blockedUser inherits :guest's gallery3 view under the new model.
+    const result = await getGallery(token, "gallery3");
     expectGallery3(result);
   });
   test("Get :all", async () => {
@@ -193,8 +192,9 @@ describe("As publicUser", () => {
   });
 
   test("List galleries", async () => {
+    // Fanned-out grants on gallery1/2/3; no pseudo-galleries.
     const result = await getGalleries(token);
-    expect(result.body.length).toBe(4);
+    expect(result.body.length).toBe(3);
   });
   test("Get gallery1", async () => {
     const result = await getGallery(token, "gallery1");
@@ -212,8 +212,8 @@ describe("As publicUser", () => {
     await expectGalleryUnavailable(token, ":all");
   });
   test("Get :public", async () => {
-    const result = await getGallery(token, ":public");
-    expectGalleryPublic(result);
+    // :public is no longer ACL-accessible for non-admins under #394.
+    await expectGalleryUnavailable(token, ":public");
   });
   test("Get invalid", async () => {
     await expectGalleryUnavailable(token, "invalid");
@@ -262,28 +262,26 @@ describe("As gallery1Admin", () => {
   });
 
   test("List galleries", async () => {
+    // Own gallery1 grant + gallery3 via :guest fall-through.
     const result = await getGalleries(token);
-    expect(result.body.length).toBe(5);
+    expect(result.body.length).toBe(2);
   });
   test("Get gallery1", async () => {
     const result = await getGallery(token, "gallery1");
     expectGallery1(result);
   });
   test("Get gallery2", async () => {
-    const result = await getGallery(token, "gallery2");
-    expectGallery2(result);
+    await expectGalleryUnavailable(token, "gallery2");
   });
   test("Get gallery3", async () => {
     const result = await getGallery(token, "gallery3");
     expectGallery3(result);
   });
   test("Get :all", async () => {
-    const result = await getGallery(token, ":all");
-    expectGalleryAll(result);
+    await expectGalleryUnavailable(token, ":all");
   });
   test("Get :public", async () => {
-    const result = await getGallery(token, ":public");
-    expectGalleryPublic(result);
+    await expectGalleryUnavailable(token, ":public");
   });
   test("Get invalid", async () => {
     await expectGalleryUnavailable(token, "invalid");
@@ -329,8 +327,9 @@ describe("As plainUser", () => {
   });
 
   test("List galleries", async () => {
+    // Fanned-out grants on gallery1/2/3; no pseudo-galleries.
     const result = await getGalleries(token);
-    expect(result.body.length).toBe(5);
+    expect(result.body.length).toBe(3);
   });
   test("Get gallery1", async () => {
     const result = await getGallery(token, "gallery1");
@@ -345,12 +344,10 @@ describe("As plainUser", () => {
     expectGallery3(result);
   });
   test("Get :all", async () => {
-    const result = await getGallery(token, ":all");
-    expectGalleryAll(result);
+    await expectGalleryUnavailable(token, ":all");
   });
   test("Get :public", async () => {
-    const result = await getGallery(token, ":public");
-    expectGalleryPublic(result);
+    await expectGalleryUnavailable(token, ":public");
   });
   test("Get invalid", async () => {
     await expectGalleryUnavailable(token, "invalid");
@@ -396,8 +393,9 @@ describe("As gallery12User", () => {
   });
 
   test("List galleries", async () => {
+    // gallery1, gallery2 (own grants) + gallery3 (via :guest fallthrough).
     const result = await getGalleries(token);
-    expect(result.body.length).toBe(2);
+    expect(result.body.length).toBe(3);
   });
   test("Get gallery1", async () => {
     const result = await getGallery(token, "gallery1");
@@ -408,7 +406,9 @@ describe("As gallery12User", () => {
     expectGallery2(result);
   });
   test("Get gallery3", async () => {
-    await expectGalleryUnavailable(token, "gallery3");
+    // Inherits gallery3 view from :guest.
+    const result = await getGallery(token, "gallery3");
+    expectGallery3(result);
   });
   test("Get :all", async () => {
     await expectGalleryUnavailable(token, ":all");

--- a/server/tests/api/gallery-photos.test.ts
+++ b/server/tests/api/gallery-photos.test.ts
@@ -272,87 +272,31 @@ describe("As gallery1Admin", () => {
       await getGalleryPhoto(token, "gallery1", "invalid.jpg", 404);
     });
   });
-  describe("Gallery 2", () => {
+  describe("Gallery 2 (no access)", () => {
     test("Get gallery1photo.jpg", async () => {
       await getGalleryPhoto(token, "gallery2", "gallery1photo.jpg", 404);
     });
     test("Get gallery12photo.jpg", async () => {
-      const result = await getGalleryPhoto(
-        token,
-        "gallery2",
-        "gallery12photo.jpg"
-      );
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery12photo.jpg");
+      await getGalleryPhoto(token, "gallery2", "gallery12photo.jpg", 404);
     });
     test("Get gallery2photo.jpg", async () => {
-      const result = await getGalleryPhoto(
-        token,
-        "gallery2",
-        "gallery2photo.jpg"
-      );
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery2photo.jpg");
+      await getGalleryPhoto(token, "gallery2", "gallery2photo.jpg", 404);
     });
     test("Get orphanphoto.jpg", async () => {
       await getGalleryPhoto(token, "gallery2", "orphanphoto.jpg", 404);
     });
   });
-  describe("Gallery :all", () => {
+  describe("Gallery :all (admin-only post-#394)", () => {
     test("Get gallery1photo.jpg", async () => {
-      const result = await getGalleryPhoto(token, ":all", "gallery1photo.jpg");
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery1photo.jpg");
-    });
-    test("Get gallery12photo.jpg", async () => {
-      const result = await getGalleryPhoto(token, ":all", "gallery12photo.jpg");
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery12photo.jpg");
-    });
-    test("Get gallery2photo.jpg", async () => {
-      const result = await getGalleryPhoto(token, ":all", "gallery2photo.jpg");
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery2photo.jpg");
-    });
-    test("Get orphanphoto.jpg", async () => {
-      const result = await getGalleryPhoto(token, ":all", "orphanphoto.jpg");
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("orphanphoto.jpg");
+      await getGalleryPhoto(token, ":all", "gallery1photo.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
       await getGalleryPhoto(token, ":all", "invalid.jpg", 404);
     });
   });
-  describe("Gallery :public", () => {
+  describe("Gallery :public (admin-only post-#394)", () => {
     test("Get gallery1photo.jpg", async () => {
-      const result = await getGalleryPhoto(
-        token,
-        ":public",
-        "gallery1photo.jpg"
-      );
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery1photo.jpg");
-    });
-    test("Get gallery12photo.jpg", async () => {
-      const result = await getGalleryPhoto(
-        token,
-        ":public",
-        "gallery12photo.jpg"
-      );
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery12photo.jpg");
-    });
-    test("Get gallery2photo.jpg", async () => {
-      const result = await getGalleryPhoto(
-        token,
-        ":public",
-        "gallery2photo.jpg"
-      );
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery2photo.jpg");
-    });
-    test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "orphanphoto.jpg", 404);
+      await getGalleryPhoto(token, ":public", "gallery1photo.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
       await getGalleryPhoto(token, ":public", "invalid.jpg", 404);
@@ -500,7 +444,6 @@ describe("As plainUser", () => {
         "gallery2",
         "gallery12photo.jpg"
       );
-      expect(result.body.id).toBeDefined();
       expect(result.body.id).toBe("gallery12photo.jpg");
     });
     test("Get gallery2photo.jpg", async () => {
@@ -509,68 +452,23 @@ describe("As plainUser", () => {
         "gallery2",
         "gallery2photo.jpg"
       );
-      expect(result.body.id).toBeDefined();
       expect(result.body.id).toBe("gallery2photo.jpg");
     });
     test("Get orphanphoto.jpg", async () => {
       await getGalleryPhoto(token, "gallery2", "orphanphoto.jpg", 404);
     });
   });
-  describe("Gallery :all", () => {
+  describe("Gallery :all (admin-only post-#394)", () => {
     test("Get gallery1photo.jpg", async () => {
-      const result = await getGalleryPhoto(token, ":all", "gallery1photo.jpg");
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery1photo.jpg");
-    });
-    test("Get gallery12photo.jpg", async () => {
-      const result = await getGalleryPhoto(token, ":all", "gallery12photo.jpg");
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery12photo.jpg");
-    });
-    test("Get gallery2photo.jpg", async () => {
-      const result = await getGalleryPhoto(token, ":all", "gallery2photo.jpg");
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery2photo.jpg");
-    });
-    test("Get orphanphoto.jpg", async () => {
-      const result = await getGalleryPhoto(token, ":all", "orphanphoto.jpg");
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("orphanphoto.jpg");
+      await getGalleryPhoto(token, ":all", "gallery1photo.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
       await getGalleryPhoto(token, ":all", "invalid.jpg", 404);
     });
   });
-  describe("Gallery :public", () => {
+  describe("Gallery :public (admin-only post-#394)", () => {
     test("Get gallery1photo.jpg", async () => {
-      const result = await getGalleryPhoto(
-        token,
-        ":public",
-        "gallery1photo.jpg"
-      );
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery1photo.jpg");
-    });
-    test("Get gallery12photo.jpg", async () => {
-      const result = await getGalleryPhoto(
-        token,
-        ":public",
-        "gallery12photo.jpg"
-      );
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery12photo.jpg");
-    });
-    test("Get gallery2photo.jpg", async () => {
-      const result = await getGalleryPhoto(
-        token,
-        ":public",
-        "gallery2photo.jpg"
-      );
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery2photo.jpg");
-    });
-    test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "orphanphoto.jpg", 404);
+      await getGalleryPhoto(token, ":public", "gallery1photo.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
       await getGalleryPhoto(token, ":public", "invalid.jpg", 404);
@@ -853,36 +751,9 @@ describe("As publicUser", () => {
       await getGalleryPhoto(token, ":all", "invalid.jpg", 404);
     });
   });
-  describe("Gallery :public", () => {
+  describe("Gallery :public (admin-only post-#394)", () => {
     test("Get gallery1photo.jpg", async () => {
-      const result = await getGalleryPhoto(
-        token,
-        ":public",
-        "gallery1photo.jpg"
-      );
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery1photo.jpg");
-    });
-    test("Get gallery12photo.jpg", async () => {
-      const result = await getGalleryPhoto(
-        token,
-        ":public",
-        "gallery12photo.jpg"
-      );
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery12photo.jpg");
-    });
-    test("Get gallery2photo.jpg", async () => {
-      const result = await getGalleryPhoto(
-        token,
-        ":public",
-        "gallery2photo.jpg"
-      );
-      expect(result.body.id).toBeDefined();
-      expect(result.body.id).toBe("gallery2photo.jpg");
-    });
-    test("Get orphanphoto.jpg", async () => {
-      await getGalleryPhoto(token, ":public", "orphanphoto.jpg", 404);
+      await getGalleryPhoto(token, ":public", "gallery1photo.jpg", 404);
     });
     test("Get invalid.jpg", async () => {
       await getGalleryPhoto(token, ":public", "invalid.jpg", 404);

--- a/server/tests/api/host-scope.test.ts
+++ b/server/tests/api/host-scope.test.ts
@@ -211,7 +211,7 @@ describe("scoped host (single match: gallery1.example.com → gallery1)", () => 
       "gallery1.example.com"
     )
       .set("Authorization", auth)
-      .send({ accessLevel: "view" })
+      .send({ isAdmin: false })
       .expect(204);
   });
 
@@ -222,7 +222,7 @@ describe("scoped host (single match: gallery1.example.com → gallery1)", () => 
       "gallery1.example.com"
     )
       .set("Authorization", auth)
-      .send({ accessLevel: "view" })
+      .send({ isAdmin: false })
       .expect(404);
   });
 

--- a/server/tests/api/photos.test.ts
+++ b/server/tests/api/photos.test.ts
@@ -160,42 +160,29 @@ describe("As gallery1Admin", () => {
     token = await loginUser(api, "gallery1Admin");
   });
 
+  // /photos and /photos/:id are admin-only post-#394 (the old "global
+  // view" tier collapsed into is_admin). gallery1Admin has only a
+  // per-gallery grant → 403 across the board.
   test("List photos", async () => {
-    const result = await getPhotos(token);
-    expect(Object.keys(result.body).length).toBe(5);
-    expectPhoto(result, "gallery1photo.jpg");
-    expectPhoto(result, "gallery12photo.jpg");
-    expectPhoto(result, "gallery2photo.jpg");
-    expectPhoto(result, "gallery3photo.jpg");
-    expectPhoto(result, "orphanphoto.jpg");
+    await getPhotos(token, 403);
   });
   test("Get gallery1photo.jpg", async () => {
-    const result = await getPhoto(token, "gallery1photo.jpg");
-    expect(result.body.id).toBeDefined();
-    expect(result.body.id).toBe("gallery1photo.jpg");
+    await getPhoto(token, "gallery1photo.jpg", 403);
   });
   test("Get gallery12photo.jpg", async () => {
-    const result = await getPhoto(token, "gallery12photo.jpg");
-    expect(result.body.id).toBeDefined();
-    expect(result.body.id).toBe("gallery12photo.jpg");
+    await getPhoto(token, "gallery12photo.jpg", 403);
   });
   test("Get gallery2photo.jpg", async () => {
-    const result = await getPhoto(token, "gallery2photo.jpg");
-    expect(result.body.id).toBeDefined();
-    expect(result.body.id).toBe("gallery2photo.jpg");
+    await getPhoto(token, "gallery2photo.jpg", 403);
   });
   test("Get gallery3photo.jpg", async () => {
-    const result = await getPhoto(token, "gallery3photo.jpg");
-    expect(result.body.id).toBeDefined();
-    expect(result.body.id).toBe("gallery3photo.jpg");
+    await getPhoto(token, "gallery3photo.jpg", 403);
   });
   test("Get orphanphoto.jpg", async () => {
-    const result = await getPhoto(token, "orphanphoto.jpg");
-    expect(result.body.id).toBeDefined();
-    expect(result.body.id).toBe("orphanphoto.jpg");
+    await getPhoto(token, "orphanphoto.jpg", 403);
   });
   test("Get invalid", async () => {
-    await getPhoto(token, "invalid.jpg", 404);
+    await getPhoto(token, "invalid.jpg", 403);
   });
 });
 
@@ -234,42 +221,29 @@ describe("As plainUser", () => {
     token = await loginUser(api, "plainUser");
   });
 
+  // plainUser previously had `:all VIEW`, granting access to the
+  // cross-gallery `/photos` endpoints. Under #394 these are admin-only;
+  // plainUser's per-gallery grants don't reach them.
   test("List photos", async () => {
-    const result = await getPhotos(token);
-    expect(Object.keys(result.body).length).toBe(5);
-    expectPhoto(result, "gallery1photo.jpg");
-    expectPhoto(result, "gallery12photo.jpg");
-    expectPhoto(result, "gallery2photo.jpg");
-    expectPhoto(result, "gallery3photo.jpg");
-    expectPhoto(result, "orphanphoto.jpg");
+    await getPhotos(token, 403);
   });
   test("Get gallery1photo.jpg", async () => {
-    const result = await getPhoto(token, "gallery1photo.jpg");
-    expect(result.body.id).toBeDefined();
-    expect(result.body.id).toBe("gallery1photo.jpg");
+    await getPhoto(token, "gallery1photo.jpg", 403);
   });
   test("Get gallery12photo.jpg", async () => {
-    const result = await getPhoto(token, "gallery12photo.jpg");
-    expect(result.body.id).toBeDefined();
-    expect(result.body.id).toBe("gallery12photo.jpg");
+    await getPhoto(token, "gallery12photo.jpg", 403);
   });
   test("Get gallery2photo.jpg", async () => {
-    const result = await getPhoto(token, "gallery2photo.jpg");
-    expect(result.body.id).toBeDefined();
-    expect(result.body.id).toBe("gallery2photo.jpg");
+    await getPhoto(token, "gallery2photo.jpg", 403);
   });
   test("Get gallery3photo.jpg", async () => {
-    const result = await getPhoto(token, "gallery3photo.jpg");
-    expect(result.body.id).toBeDefined();
-    expect(result.body.id).toBe("gallery3photo.jpg");
+    await getPhoto(token, "gallery3photo.jpg", 403);
   });
   test("Get orphanphoto.jpg", async () => {
-    const result = await getPhoto(token, "orphanphoto.jpg");
-    expect(result.body.id).toBeDefined();
-    expect(result.body.id).toBe("orphanphoto.jpg");
+    await getPhoto(token, "orphanphoto.jpg", 403);
   });
   test("Get invalid", async () => {
-    await getPhoto(token, "invalid.jpg", 404);
+    await getPhoto(token, "invalid.jpg", 403);
   });
 });
 

--- a/server/tests/api/user-gallery.test.ts
+++ b/server/tests/api/user-gallery.test.ts
@@ -17,7 +17,7 @@ describe("As guest", () => {
   test("Upsert rejected", () =>
     api
       .put("/api/v1/user-gallery/plainUser/gallery1")
-      .send({ accessLevel: "view" })
+      .send({ isAdmin: false })
       .expect(403));
   test("Delete rejected", () =>
     api.delete("/api/v1/user-gallery/plainUser/gallery1").expect(403));
@@ -37,7 +37,7 @@ describe("As gallery1Admin (non-global)", () => {
     api
       .put("/api/v1/user-gallery/plainUser/gallery1")
       .set("Authorization", `Bearer ${token}`)
-      .send({ accessLevel: "view" })
+      .send({ isAdmin: false })
       .expect(403));
   test("Delete rejected", () =>
     api
@@ -83,11 +83,11 @@ describe("As admin", () => {
       )
     ).toBe(true);
   });
-  test("Upsert (grants access)", async () => {
+  test("Upsert grants view (is_admin=false)", async () => {
     await api
       .put("/api/v1/user-gallery/plainUser/gallery1")
       .set("Authorization", `Bearer ${token}`)
-      .send({ accessLevel: "view" })
+      .send({ isAdmin: false })
       .expect(204);
     const result = await api
       .get("/api/v1/user-gallery")
@@ -95,22 +95,22 @@ describe("As admin", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200);
     expect(result.body.length).toBe(1);
-    expect(result.body[0].access_level).toBe(1);
+    expect(result.body[0].is_admin).toBe(0);
   });
-  test("Upsert (revokes via 'none')", async () => {
+  test("Upsert promotes to gallery admin (is_admin=true)", async () => {
     await api
       .put("/api/v1/user-gallery/gallery1Admin/gallery1")
       .set("Authorization", `Bearer ${token}`)
-      .send({ accessLevel: "none" })
+      .send({ isAdmin: true })
       .expect(204);
     const result = await api
       .get("/api/v1/user-gallery")
       .query({ userId: "gallery1Admin", galleryId: "gallery1" })
       .set("Authorization", `Bearer ${token}`)
       .expect(200);
-    expect(result.body[0].access_level).toBe(0);
+    expect(result.body[0].is_admin).toBe(1);
   });
-  test("Delete", async () => {
+  test("Delete (revokes the row entirely)", async () => {
     await api
       .delete("/api/v1/user-gallery/gallery1Admin/gallery1")
       .set("Authorization", `Bearer ${token}`)
@@ -122,17 +122,17 @@ describe("As admin", () => {
       .expect(200);
     expect(result.body.length).toBe(0);
   });
-  test("Upsert with invalid accessLevel → 400", () =>
+  test("Upsert with invalid isAdmin → 400", () =>
     api
       .put("/api/v1/user-gallery/plainUser/gallery1")
       .set("Authorization", `Bearer ${token}`)
-      .send({ accessLevel: "owner" })
+      .send({ isAdmin: "yes" })
       .expect(400));
   test("Upsert with extra field → 400", () =>
     api
       .put("/api/v1/user-gallery/plainUser/gallery1")
       .set("Authorization", `Bearer ${token}`)
-      .send({ accessLevel: "view", bogus: true })
+      .send({ isAdmin: false, bogus: true })
       .expect(400));
 });
 

--- a/server/tests/api/users.test.ts
+++ b/server/tests/api/users.test.ts
@@ -45,10 +45,12 @@ describe("As admin", () => {
     expect(admin).toBeDefined();
     expect(admin.id).toBe("admin");
     expect(admin.password).not.toBeDefined();
-    users.forEach((user: { id: string; password?: string }) => {
+    users.forEach((user: { id: string; isAdmin?: boolean; password?: string }) => {
       expect(user).toBeDefined();
-      expect(Object.keys(user).length).toBe(1);
+      // Two visible fields now: id + isAdmin. Password not exposed.
+      expect(Object.keys(user).length).toBe(2);
       expect(user.id).toBeDefined();
+      expect(typeof user.isAdmin).toBe("boolean");
       expect(user.password).not.toBeDefined();
     });
   });
@@ -341,7 +343,7 @@ describe("Mutations as admin", () => {
     api
       .put("/api/v1/users/admin")
       .set("Authorization", `Bearer ${token}`)
-      .send({})
+      .send({ password: null })
       .expect(400));
 });
 

--- a/server/tests/db/sqlite3/migrate.test.ts
+++ b/server/tests/db/sqlite3/migrate.test.ts
@@ -33,7 +33,7 @@ describe("migrate", () => {
   test("fresh DB runs every migration and lands at the highest version", () => {
     const db = open();
     migrate(db);
-    expect(schemaVersion(db)).toBe(11);
+    expect(schemaVersion(db)).toBe(12);
     expect(tableNames(db)).toEqual(
       expect.arrayContaining([
         "gallery",
@@ -52,7 +52,9 @@ describe("migrate", () => {
       db.pragma("table_info(user_gallery)") as { name: string }[]
     ).map((r) => r.name);
     expect(userGalleryCols).toContain("hide_map");
-    expect(userGalleryCols).toContain("access_level");
+    // Migration 012 swapped access_level INTEGER for is_admin INTEGER.
+    expect(userGalleryCols).toContain("is_admin");
+    expect(userGalleryCols).not.toContain("access_level");
     expect(userGalleryCols).not.toContain("level");
   });
 
@@ -77,6 +79,7 @@ describe("migrate", () => {
       CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);
       INSERT INTO meta VALUES ('schema_version', '1');
       CREATE TABLE gallery (id TEXT PRIMARY KEY);
+      CREATE TABLE user (id TEXT PRIMARY KEY, password TEXT, secret TEXT);
       CREATE TABLE acl (
         user_id TEXT,
         gallery_id TEXT,
@@ -100,7 +103,7 @@ describe("migrate", () => {
 
     migrate(db);
 
-    expect(schemaVersion(db)).toBe(11);
+    expect(schemaVersion(db)).toBe(12);
     expect(gallerPhotoFkRefs(db).sort()).toEqual(["gallery", "photo"]);
     const rows = db.prepare("SELECT * FROM gallery_photo").all();
     expect(rows).toEqual([{ gallery_id: "g1", photo_id: "p1" }]);

--- a/server/tests/db/sqlite3/schema.test.ts
+++ b/server/tests/db/sqlite3/schema.test.ts
@@ -3,14 +3,14 @@ import schemaFactory from "../../../db/sqlite3/schema.js";
 const schema = schemaFactory();
 
 describe("User", () => {
-  const cols = ["id", "password", "secret"].join(",");
+  const cols = ["id", "password", "secret", "is_admin"].join(",");
   test("Build create query", () =>
     expect(schema.user.buildCreateQuery()).toBe(
-      `INSERT INTO user (${cols}) VALUES (?,?,?)`
+      `INSERT INTO user (${cols}) VALUES (?,?,?,?)`
     ));
   test("Build select by id query", () =>
     expect(schema.user.buildSelectByIdQuery()).toBe(
-      "SELECT id,password,secret FROM user WHERE id = ? ORDER BY id ASC"
+      `SELECT ${cols} FROM user WHERE id = ? ORDER BY id ASC`
     ));
   test("Build update by id query: nothing", () =>
     expect(schema.user.buildUpdateByIdQuery({})).toStrictEqual({
@@ -56,11 +56,11 @@ describe("User", () => {
     ));
   test("Build select all query", () =>
     expect(schema.user.buildSelectQuery()).toBe(
-      "SELECT id,password,secret FROM user ORDER BY id ASC"
+      `SELECT ${cols} FROM user ORDER BY id ASC`
     ));
   test("Build select by condition query", () =>
     expect(schema.user.buildSelectQuery(["id = ?"])).toBe(
-      "SELECT id,password,secret FROM user WHERE id = ? ORDER BY id ASC"
+      `SELECT ${cols} FROM user WHERE id = ? ORDER BY id ASC`
     ));
   test("Build delete all query", () =>
     expect(schema.user.buildDeleteQuery()).toBe("DELETE FROM user"));
@@ -71,7 +71,7 @@ describe("User", () => {
 });
 
 describe("UserGallery", () => {
-  const cols = ["user_id", "gallery_id", "access_level", "hide_map"].join(",");
+  const cols = ["user_id", "gallery_id", "is_admin", "hide_map"].join(",");
   test("Build create query", () =>
     expect(schema.userGallery.buildCreateQuery()).toBe(
       `INSERT INTO user_gallery (${cols}) VALUES (?,?,?,?)`
@@ -106,25 +106,25 @@ describe("UserGallery", () => {
         gallery_id: "bar",
       })
     ).toStrictEqual({ query: undefined, values: undefined }));
-  test("Build update by id query: access_level", () =>
+  test("Build update by id query: is_admin", () =>
     expect(
-      schema.userGallery.buildUpdateByIdQuery({ access_level: 2 })
+      schema.userGallery.buildUpdateByIdQuery({ is_admin: 1 })
     ).toStrictEqual({
       query:
-        "UPDATE user_gallery SET access_level=? WHERE user_id = ? AND gallery_id = ?",
-      values: [2],
+        "UPDATE user_gallery SET is_admin=? WHERE user_id = ? AND gallery_id = ?",
+      values: [1],
     }));
   test("Build update by id query: all", () =>
     expect(
       schema.userGallery.buildUpdateByIdQuery({
         user_id: "foo",
         gallery_id: "bar",
-        access_level: 2,
+        is_admin: 1,
       })
     ).toStrictEqual({
       query:
-        "UPDATE user_gallery SET access_level=? WHERE user_id = ? AND gallery_id = ?",
-      values: [2],
+        "UPDATE user_gallery SET is_admin=? WHERE user_id = ? AND gallery_id = ?",
+      values: [1],
     }));
   test("Build delete by id query", () =>
     expect(schema.userGallery.buildDeleteByIdQuery()).toBe(

--- a/server/tests/lib/authorizer.test.ts
+++ b/server/tests/lib/authorizer.test.ts
@@ -1,11 +1,11 @@
-import CONST from "../../lib/constants.js";
 import authorizerFactory from "../../lib/authorizer.js";
-import { AccessError } from "../../lib/errors.js";
+import { AccessError, NotFoundError } from "../../lib/errors.js";
 import dbOriginal from "../../db/index.js";
 
 vi.mock("../../db/index.js", () => ({
   default: {
     resolveAccessLevel: vi.fn(),
+    loadUser: vi.fn(),
   },
 }));
 
@@ -27,308 +27,115 @@ const fail = (authorize: Authorize, user: string, gallery?: string) => {
   );
 };
 
-// Mock helper: takes a per-user-per-gallery-id ACL config and simulates the
-// user-first cascade with :public fall-through. Tests describe what's in the
-// DB; the helper resolves the effective level the same way the SQL does.
-const setAcl = (
-  rows: Record<string, Record<string, number>>
+// New model: the authorizer reads two things —
+//   - user.is_admin (via db.loadUser) for the global-admin bypass
+//   - resolveAccessLevel(userId, galleryId) → { hasAccess, isAdmin } for
+//     gallery-scoped checks
+// The mock keeps a per-test ACL and answers both queries from it.
+const setup = (
+  globalAdmins: string[],
+  perGallery: Record<string, Record<string, { isAdmin: boolean }>>
 ): void => {
+  db.loadUser.mockImplementation(async (userId) => {
+    if (userId === ":guest") return { id: ":guest", is_admin: 0 };
+    return { id: userId, is_admin: globalAdmins.includes(userId) ? 1 : 0 };
+  });
   db.resolveAccessLevel.mockImplementation(async (userId, galleryId) => {
-    const isSpecial = galleryId.startsWith(":");
-    const galleries = isSpecial
-      ? [galleryId, ":all"]
-      : [galleryId, ":public", ":all"];
-    const userRows = rows[userId] ?? {};
-    for (const g of galleries) if (g in userRows) return userRows[g];
-    const guestRows = rows[":guest"] ?? {};
-    for (const g of galleries) if (g in guestRows) return guestRows[g];
-    return undefined;
+    if (globalAdmins.includes(userId)) {
+      return { hasAccess: true, isAdmin: true };
+    }
+    const userRow = perGallery[userId]?.[galleryId];
+    const guestRow = perGallery[":guest"]?.[galleryId];
+    if (!userRow && !guestRow) return { hasAccess: false, isAdmin: false };
+    const isAdmin = !!(userRow?.isAdmin || guestRow?.isAdmin);
+    return { hasAccess: true, isAdmin };
   });
 };
 
-describe("No ACL defined", () => {
-  beforeAll(() => setAcl({}));
+describe("No grants", () => {
+  beforeAll(() => setup([], {}));
   describe("As :guest", () => {
-    test("View", () => fail(authorizeView, ":guest"));
+    test("View (admin-only)", () => fail(authorizeView, ":guest"));
     test("Admin", () => fail(authorizeAdmin, ":guest"));
     test("Gallery view", () => fail(authorizeGalleryView, ":guest", "gallery"));
-    test("Gallery admin", () =>
-      fail(authorizeGalleryAdmin, ":guest", "gallery"));
+    test("Gallery admin", () => fail(authorizeGalleryAdmin, ":guest", "gallery"));
   });
   describe("As user", () => {
-    test("View", () => fail(authorizeView, "user"));
+    test("View (admin-only)", () => fail(authorizeView, "user"));
     test("Admin", () => fail(authorizeAdmin, "user"));
     test("Gallery view", () => fail(authorizeGalleryView, "user", "gallery"));
     test("Gallery admin", () => fail(authorizeGalleryAdmin, "user", "gallery"));
   });
 });
 
-describe("ACL :guest,:all,VIEW", () => {
-  beforeAll(() => setAcl({ ":guest": { ":all": CONST.ACCESS_VIEW } }));
-  describe("As :guest", () => {
-    test("View", () => authorizeView(":guest"));
-    test("Admin", () => fail(authorizeAdmin, ":guest"));
-    test("Gallery view", () => authorizeGalleryView(":guest", "gallery"));
-    test("Gallery admin", () =>
-      fail(authorizeGalleryAdmin, ":guest", "gallery"));
+describe("user.is_admin bypass", () => {
+  beforeAll(() => setup(["admin"], {}));
+  describe("As admin (global)", () => {
+    test("View", () => authorizeView("admin"));
+    test("Admin", () => authorizeAdmin("admin"));
+    test("Gallery view (any)", () =>
+      authorizeGalleryView("admin", "any-gallery"));
+    test("Gallery admin (any)", () =>
+      authorizeGalleryAdmin("admin", "any-gallery"));
   });
-  describe("As user", () => {
-    test("View", () => authorizeView("user"));
-    test("Admin", () => fail(authorizeAdmin, "user"));
-    test("Gallery view", () => authorizeGalleryView("user", "gallery"));
-    test("Gallery admin", () => fail(authorizeGalleryAdmin, "user", "gallery"));
-  });
-});
-
-describe("ACL :guest,:public,VIEW", () => {
-  beforeAll(() => setAcl({ ":guest": { ":public": CONST.ACCESS_VIEW } }));
-  describe("As :guest", () => {
-    // No :all grant → global view fails. But specific galleries fall through
-    // via :public to the view grant.
-    test("View", () => fail(authorizeView, ":guest"));
-    test("Admin", () => fail(authorizeAdmin, ":guest"));
-    test("Gallery view", () => authorizeGalleryView(":guest", "gallery"));
-    test("Gallery admin", () =>
-      fail(authorizeGalleryAdmin, ":guest", "gallery"));
-  });
-  describe("As user", () => {
-    test("View", () => fail(authorizeView, "user"));
-    test("Admin", () => fail(authorizeAdmin, "user"));
-    test("Gallery view", () => authorizeGalleryView("user", "gallery"));
-    test("Gallery admin", () => fail(authorizeGalleryAdmin, "user", "gallery"));
+  describe("As non-admin", () => {
+    test("View denied", () => fail(authorizeView, "other"));
+    test("Admin denied", () => fail(authorizeAdmin, "other"));
+    test("Gallery view denied", () =>
+      fail(authorizeGalleryView, "other", "any"));
   });
 });
 
-describe("ACL :guest,:all,ADMIN", () => {
-  beforeAll(() => setAcl({ ":guest": { ":all": CONST.ACCESS_ADMIN } }));
-  describe("As :guest", () => {
-    test("View", () => authorizeView(":guest"));
-    test("Admin", () => authorizeAdmin(":guest"));
-    test("Gallery view", () => authorizeGalleryView(":guest", "gallery"));
-    test("Gallery admin", () => authorizeGalleryAdmin(":guest", "gallery"));
-  });
+describe("Per-gallery view grant", () => {
+  beforeAll(() => setup([], { user: { gallery1: { isAdmin: false } } }));
   describe("As user", () => {
-    test("View", () => authorizeView("user"));
-    test("Admin", () => authorizeAdmin("user"));
-    test("Gallery view", () => authorizeGalleryView("user", "gallery"));
-    test("Gallery admin", () => authorizeGalleryAdmin("user", "gallery"));
+    test("View (no global)", () => fail(authorizeView, "user"));
+    test("Admin (no global)", () => fail(authorizeAdmin, "user"));
+    test("Gallery1 view", () => authorizeGalleryView("user", "gallery1"));
+    test("Gallery1 admin denied", () =>
+      fail(authorizeGalleryAdmin, "user", "gallery1"));
+    test("Gallery2 view denied", () =>
+      fail(authorizeGalleryView, "user", "gallery2"));
   });
 });
 
-describe("ACL user,:all,VIEW", () => {
-  beforeAll(() => setAcl({ user: { ":all": CONST.ACCESS_VIEW } }));
-  describe("As :guest", () => {
-    test("View", () => fail(authorizeView, ":guest"));
-    test("Admin", () => fail(authorizeAdmin, ":guest"));
-    test("Gallery view", () => fail(authorizeGalleryView, ":guest", "gallery"));
-    test("Gallery admin", () =>
-      fail(authorizeGalleryAdmin, ":guest", "gallery"));
-  });
+describe("Per-gallery admin grant", () => {
+  beforeAll(() => setup([], { user: { gallery1: { isAdmin: true } } }));
   describe("As user", () => {
-    test("View", () => authorizeView("user"));
-    test("Admin", () => fail(authorizeAdmin, "user"));
-    test("Gallery view", () => authorizeGalleryView("user", "gallery"));
-    test("Gallery admin", () => fail(authorizeGalleryAdmin, "user", "gallery"));
+    test("Global view denied", () => fail(authorizeView, "user"));
+    test("Gallery1 view", () => authorizeGalleryView("user", "gallery1"));
+    test("Gallery1 admin", () => authorizeGalleryAdmin("user", "gallery1"));
+    test("Gallery2 view denied", () =>
+      fail(authorizeGalleryView, "user", "gallery2"));
   });
 });
 
-describe("ACL user,:all,ADMIN", () => {
-  beforeAll(() => setAcl({ user: { ":all": CONST.ACCESS_ADMIN } }));
-  describe("As :guest", () => {
-    test("View", () => fail(authorizeView, ":guest"));
-    test("Admin", () => fail(authorizeAdmin, ":guest"));
-    test("Gallery view", () => fail(authorizeGalleryView, ":guest", "gallery"));
-    test("Gallery admin", () =>
-      fail(authorizeGalleryAdmin, ":guest", "gallery"));
-  });
-  describe("As user", () => {
-    test("View", () => authorizeView("user"));
-    test("Admin", () => authorizeAdmin("user"));
-    test("Gallery view", () => authorizeGalleryView("user", "gallery"));
-    test("Gallery admin", () => authorizeGalleryAdmin("user", "gallery"));
-  });
-});
-
-describe("ACL :guest,:all,VIEW + user,:all,ADMIN", () => {
+describe(":guest grant falls through to logged-in users without a row", () => {
   beforeAll(() =>
-    setAcl({
-      ":guest": { ":all": CONST.ACCESS_VIEW },
-      user: { ":all": CONST.ACCESS_ADMIN },
-    })
+    setup([], { ":guest": { gallery3: { isAdmin: false } } })
   );
   describe("As :guest", () => {
-    test("View", () => authorizeView(":guest"));
-    test("Admin", () => fail(authorizeAdmin, ":guest"));
-    test("Gallery view", () => authorizeGalleryView(":guest", "gallery"));
-    test("Gallery admin", () =>
-      fail(authorizeGalleryAdmin, ":guest", "gallery"));
-  });
-  describe("As user", () => {
-    test("View", () => authorizeView("user"));
-    test("Admin", () => authorizeAdmin("user"));
-    test("Gallery view", () => authorizeGalleryView("user", "gallery"));
-    test("Gallery admin", () => authorizeGalleryAdmin("user", "gallery"));
-  });
-});
-
-describe("ACL :guest,:all,ADMIN + user1,:all,VIEW", () => {
-  beforeAll(() =>
-    setAcl({
-      ":guest": { ":all": CONST.ACCESS_ADMIN },
-      user1: { ":all": CONST.ACCESS_VIEW },
-    })
-  );
-  describe("As :guest", () => {
-    test("View", () => authorizeView(":guest"));
-    test("Admin", () => authorizeAdmin(":guest"));
-    test("Gallery view", () => authorizeGalleryView(":guest", "gallery"));
-    test("Gallery admin", () => authorizeGalleryAdmin(":guest", "gallery"));
-  });
-  describe("As user1 (explicit row beats guest)", () => {
-    test("View", () => authorizeView("user1"));
-    test("Admin", () => fail(authorizeAdmin, "user1"));
-    test("Gallery view", () => authorizeGalleryView("user1", "gallery"));
-    test("Gallery admin", () =>
-      fail(authorizeGalleryAdmin, "user1", "gallery"));
-  });
-  describe("As user2 (no row, inherits guest)", () => {
-    test("View", () => authorizeView("user2"));
-    test("Admin", () => authorizeAdmin("user2"));
-    test("Gallery view", () => authorizeGalleryView("user2", "gallery"));
-    test("Gallery admin", () => authorizeGalleryAdmin("user2", "gallery"));
-  });
-});
-
-describe("ACL :guest,:all,ADMIN + user1,:all,NONE (explicit deny)", () => {
-  beforeAll(() =>
-    setAcl({
-      ":guest": { ":all": CONST.ACCESS_ADMIN },
-      user1: { ":all": CONST.ACCESS_NONE },
-    })
-  );
-  describe("As :guest", () => {
-    test("View", () => authorizeView(":guest"));
-    test("Admin", () => authorizeAdmin(":guest"));
-    test("Gallery view", () => authorizeGalleryView(":guest", "gallery"));
-    test("Gallery admin", () => authorizeGalleryAdmin(":guest", "gallery"));
-  });
-  describe("As user1 (denied even though :guest is admin)", () => {
-    test("View", () => fail(authorizeView, "user1"));
-    test("Admin", () => fail(authorizeAdmin, "user1"));
-    test("Gallery view", () => fail(authorizeGalleryView, "user1", "gallery"));
-    test("Gallery admin", () =>
-      fail(authorizeGalleryAdmin, "user1", "gallery"));
-  });
-  describe("As user2 (no row, inherits guest)", () => {
-    test("View", () => authorizeView("user2"));
-    test("Admin", () => authorizeAdmin("user2"));
-    test("Gallery view", () => authorizeGalleryView("user2", "gallery"));
-    test("Gallery admin", () => authorizeGalleryAdmin("user2", "gallery"));
-  });
-});
-
-describe("ACL :guest,:all,VIEW + user1,gallery1,ADMIN", () => {
-  beforeAll(() =>
-    setAcl({
-      ":guest": { ":all": CONST.ACCESS_VIEW },
-      user1: { gallery1: CONST.ACCESS_ADMIN },
-    })
-  );
-  describe("As :guest", () => {
-    test("View", () => authorizeView(":guest"));
-    test("Admin", () => fail(authorizeAdmin, ":guest"));
-    test("Gallery1 view", () => authorizeGalleryView(":guest", "gallery1"));
-    test("Gallery1 admin", () =>
-      fail(authorizeGalleryAdmin, ":guest", "gallery1"));
-    test("Gallery2 view", () => authorizeGalleryView(":guest", "gallery2"));
-    test("Gallery2 admin", () =>
-      fail(authorizeGalleryAdmin, ":guest", "gallery2"));
-  });
-  describe("As user1", () => {
-    // user1 has gallery1=ADMIN, no :all row. Global view falls back to
-    // (:guest, :all)=VIEW. Other galleries fall back to guest's :all too.
-    test("View", () => authorizeView("user1"));
-    test("Admin", () => fail(authorizeAdmin, "user1"));
-    test("Gallery1 view", () => authorizeGalleryView("user1", "gallery1"));
-    test("Gallery1 admin", () => authorizeGalleryAdmin("user1", "gallery1"));
-    test("Gallery2 view", () => authorizeGalleryView("user1", "gallery2"));
-    test("Gallery2 admin", () =>
-      fail(authorizeGalleryAdmin, "user1", "gallery2"));
-  });
-  describe("As user2 (no row, inherits guest)", () => {
-    test("View", () => authorizeView("user2"));
-    test("Admin", () => fail(authorizeAdmin, "user2"));
-    test("Gallery1 view", () => authorizeGalleryView("user2", "gallery1"));
-    test("Gallery1 admin", () =>
-      fail(authorizeGalleryAdmin, "user2", "gallery1"));
-    test("Gallery2 view", () => authorizeGalleryView("user2", "gallery2"));
-    test("Gallery2 admin", () =>
-      fail(authorizeGalleryAdmin, "user2", "gallery2"));
-  });
-});
-
-describe("ACL :guest,:all,NONE + :guest,gallery2,VIEW + user1,gallery1,ADMIN", () => {
-  beforeAll(() =>
-    setAcl({
-      ":guest": { ":all": CONST.ACCESS_NONE, gallery2: CONST.ACCESS_VIEW },
-      user1: { gallery1: CONST.ACCESS_ADMIN },
-    })
-  );
-  describe("As :guest", () => {
-    test("View", () => fail(authorizeView, ":guest"));
-    test("Admin", () => fail(authorizeAdmin, ":guest"));
-    test("Gallery1 view", () =>
+    test("Gallery3 view", () => authorizeGalleryView(":guest", "gallery3"));
+    test("Gallery1 view denied", () =>
       fail(authorizeGalleryView, ":guest", "gallery1"));
-    test("Gallery1 admin", () =>
-      fail(authorizeGalleryAdmin, ":guest", "gallery1"));
-    test("Gallery2 view", () => authorizeGalleryView(":guest", "gallery2"));
-    test("Gallery2 admin", () =>
-      fail(authorizeGalleryAdmin, ":guest", "gallery2"));
   });
-  describe("As user1", () => {
-    test("View", () => fail(authorizeView, "user1"));
-    test("Admin", () => fail(authorizeAdmin, "user1"));
-    test("Gallery1 view", () => authorizeGalleryView("user1", "gallery1"));
-    test("Gallery1 admin", () => authorizeGalleryAdmin("user1", "gallery1"));
-    test("Gallery2 view", () => authorizeGalleryView("user1", "gallery2"));
-    test("Gallery2 admin", () =>
-      fail(authorizeGalleryAdmin, "user1", "gallery2"));
-  });
-  describe("As user2 (no row, inherits guest's deny)", () => {
-    test("View", () => fail(authorizeView, "user2"));
-    test("Admin", () => fail(authorizeAdmin, "user2"));
-    test("Gallery1 view", () =>
-      fail(authorizeGalleryView, "user2", "gallery1"));
-    test("Gallery1 admin", () =>
-      fail(authorizeGalleryAdmin, "user2", "gallery1"));
-    test("Gallery2 view", () => authorizeGalleryView("user2", "gallery2"));
-    test("Gallery2 admin", () =>
-      fail(authorizeGalleryAdmin, "user2", "gallery2"));
+  describe("As user (no own row, inherits :guest)", () => {
+    test("Gallery3 view", () => authorizeGalleryView("user", "gallery3"));
+    test("Gallery1 view denied", () =>
+      fail(authorizeGalleryView, "user", "gallery1"));
   });
 });
 
-describe("User-first cascade: user,:all,ADMIN beats :guest,:public,VIEW", () => {
-  // The motivating case for switching to user-first: an admin with a global
-  // grant should keep admin level on specific galleries, even when :guest has
-  // a more-gallery-specific :public row that would have won under gallery-first.
-  beforeAll(() =>
-    setAcl({
-      ":guest": { ":public": CONST.ACCESS_VIEW },
-      admin: { ":all": CONST.ACCESS_ADMIN },
-    })
-  );
-  describe("As admin", () => {
-    test("View (global)", () => authorizeView("admin"));
-    test("Admin (global)", () => authorizeAdmin("admin"));
-    test("Gallery view", () => authorizeGalleryView("admin", "dailybw"));
-    // Critical: admin's :all=ADMIN wins over :guest's :public=VIEW for specific galleries.
-    test("Gallery admin", () => authorizeGalleryAdmin("admin", "dailybw"));
+describe("Global admin missing user is denied (not 500)", () => {
+  beforeAll(() => {
+    db.loadUser.mockImplementation(async () => {
+      throw new NotFoundError();
+    });
+    db.resolveAccessLevel.mockResolvedValue({
+      hasAccess: false,
+      isAdmin: false,
+    });
   });
-  describe("As :guest", () => {
-    test("View (global)", () => fail(authorizeView, ":guest"));
-    test("Gallery view via :public fall-through", () =>
-      authorizeGalleryView(":guest", "dailybw"));
-    test("Gallery admin denied", () =>
-      fail(authorizeGalleryAdmin, ":guest", "dailybw"));
-  });
+  test("authorizeAdmin throws AccessError on missing user", () =>
+    fail(authorizeAdmin, "ghost"));
 });

--- a/server/tests/lib/privacy.test.ts
+++ b/server/tests/lib/privacy.test.ts
@@ -1,36 +1,54 @@
 import Database from "better-sqlite3";
 
-// Tests the hide_map cascade resolution against a fresh in-memory SQLite,
-// bypassing the dummy driver (which doesn't model user_gallery rows). Mirrors
-// the access cascade's user-first ordering (see resolveAccessLevel).
+// Tests the post-#394 hide_map cascade resolution against a fresh
+// in-memory SQLite, bypassing the dummy driver. The new model is:
 //
-// Cascade priority for a non-special gallery request:
-//   1. (user_id,   gallery_id)
-//   2. (user_id,   ':public')
-//   3. (user_id,   ':all')
-//   4. (':guest',  gallery_id)
-//   5. (':guest',  ':public')
-//   6. (':guest',  ':all')
+//   1. user.is_admin = true → 0 (show, bypass)
+//   2. first non-null hide_map from (user, gallery), (:guest, gallery),
+//      with the user row beating :guest on a tie
+//   3. else → undefined (defaults to show downstream)
 //
-// For a :public or :all request, the :public fall-through is skipped
-// — those aren't subsets of :public.
+// No pseudo-gallery wildcards (`:all` / `:public`) — those lost their
+// cascade role in #394.
 
-const setupDb = (rows: Array<[string, string, number | null]>) => {
+interface SeedRow {
+  user_id: string;
+  gallery_id: string;
+  hide_map: number | null;
+}
+
+const setupDb = (
+  rows: SeedRow[],
+  globalAdmins: string[] = []
+) => {
   const db = new Database(":memory:");
   db.exec(`
+    CREATE TABLE user (
+      id TEXT PRIMARY KEY,
+      is_admin INTEGER NOT NULL DEFAULT 0
+    );
     CREATE TABLE user_gallery (
       user_id TEXT,
       gallery_id TEXT,
-      access_level INTEGER,
+      is_admin INTEGER NOT NULL DEFAULT 0,
       hide_map INTEGER,
       PRIMARY KEY(user_id, gallery_id)
     );
   `);
-  const insert = db.prepare(
-    "INSERT INTO user_gallery (user_id, gallery_id, access_level, hide_map) VALUES (?, ?, 1, ?)"
+  const insertUser = db.prepare(
+    "INSERT OR IGNORE INTO user (id, is_admin) VALUES (?, ?)"
   );
-  for (const [user_id, gallery_id, hide_map] of rows) {
-    insert.run(user_id, gallery_id, hide_map);
+  for (const id of globalAdmins) insertUser.run(id, 1);
+  // Make sure every (user_id) appearing in seed rows has a user row,
+  // because resolveHideMap looks the user up to check is_admin.
+  for (const r of rows) {
+    if (r.user_id !== ":guest") insertUser.run(r.user_id, 0);
+  }
+  const insertGrant = db.prepare(
+    "INSERT INTO user_gallery (user_id, gallery_id, is_admin, hide_map) VALUES (?, ?, 0, ?)"
+  );
+  for (const r of rows) {
+    insertGrant.run(r.user_id, r.gallery_id, r.hide_map);
   }
   return db;
 };
@@ -40,156 +58,74 @@ const resolve = (
   userId: string,
   galleryId: string
 ): number | undefined => {
-  const isSpecial = galleryId.startsWith(":");
-  const galleryWhere = isSpecial
-    ? "gallery_id IN (?, ':all')"
-    : "gallery_id IN (?, ':public', ':all')";
-  const galleryOrder = isSpecial
-    ? "CASE WHEN gallery_id = ? THEN 0 ELSE 1 END"
-    : "CASE WHEN gallery_id = ? THEN 0 WHEN gallery_id = ':public' THEN 1 ELSE 2 END";
+  const userRow = db
+    .prepare("SELECT is_admin FROM user WHERE id = ?")
+    .get(userId) as { is_admin: number } | undefined;
+  if (userRow && userRow.is_admin) return 0;
   const row = db
     .prepare(
       `SELECT hide_map FROM user_gallery
-       WHERE (user_id = ? OR user_id = ':guest')
-         AND ${galleryWhere}
+       WHERE user_id IN (?, ':guest')
+         AND gallery_id = ?
          AND hide_map IS NOT NULL
-       ORDER BY
-         CASE WHEN user_id = ? THEN 0 ELSE 1 END,
-         ${galleryOrder}
+       ORDER BY CASE WHEN user_id = ? THEN 0 ELSE 1 END
        LIMIT 1`
     )
-    .get(userId, galleryId, userId, galleryId) as
-    | { hide_map: number }
-    | undefined;
+    .get(userId, galleryId, userId) as { hide_map: number } | undefined;
   return row?.hide_map;
 };
 
-describe("hide_map ACL cascade", () => {
+describe("hide_map cascade (post-#394)", () => {
   test("no rows → undefined (defaults to show)", () => {
     const db = setupDb([]);
     expect(resolve(db, "alice", "dailybw")).toBeUndefined();
   });
 
-  test("(:guest, :all) = 1 → global hide applies to logged-in users too", () => {
-    const db = setupDb([[":guest", ":all", 1]]);
-    expect(resolve(db, "alice", "dailybw")).toBe(1);
+  test("global admin → 0 (show, bypass) regardless of :guest hide", () => {
+    const db = setupDb(
+      [{ user_id: ":guest", gallery_id: "dailybw", hide_map: 1 }],
+      ["alice"]
+    );
+    expect(resolve(db, "alice", "dailybw")).toBe(0);
     expect(resolve(db, ":guest", "dailybw")).toBe(1);
   });
 
-  test("(:guest, gallery) > (:guest, :all) — more specific gallery wins", () => {
+  test("(:guest, gallery) hides for non-admin user without own row", () => {
     const db = setupDb([
-      [":guest", ":all", 1],
-      [":guest", "dailybw", 0],
+      { user_id: ":guest", gallery_id: "dailybw", hide_map: 1 },
     ]);
-    expect(resolve(db, "alice", "dailybw")).toBe(0);
-    expect(resolve(db, "alice", "travel")).toBe(1);
-  });
-
-  test("(user, :all) > (:guest, gallery) — user-first: any user row beats any :guest row", () => {
-    const db = setupDb([
-      [":guest", "dailybw", 1],
-      ["alice", ":all", 0],
-    ]);
-    // User-first: (alice, :all) wins for alice on any gallery, even when
-    // (:guest, dailybw) is more gallery-specific. A user's explicit preference
-    // shouldn't be overridden by a :guest default at a more-specific gallery.
-    expect(resolve(db, "alice", "dailybw")).toBe(0);
-    // bob has no rows, falls back to (:guest, dailybw)
-    expect(resolve(db, "bob", "dailybw")).toBe(1);
-    // alice's :all also applies to travel (no gallery-specific row anywhere)
-    expect(resolve(db, "alice", "travel")).toBe(0);
-  });
-
-  test("(user, gallery) > (user, :all) — within user, gallery-specific wins", () => {
-    const db = setupDb([
-      ["alice", ":all", 0],
-      ["alice", "dailybw", 1],
-    ]);
-    // alice has a per-gallery hide and a global show; the per-gallery one wins
-    expect(resolve(db, "alice", "dailybw")).toBe(1);
-    expect(resolve(db, "alice", "travel")).toBe(0);
-  });
-
-  test("(user, gallery) > (user, :all) — most specific dominates", () => {
-    const db = setupDb([
-      ["alice", ":all", 1],
-      ["alice", "dailybw", 0],
-    ]);
-    expect(resolve(db, "alice", "dailybw")).toBe(0);
-    expect(resolve(db, "alice", "travel")).toBe(1);
-  });
-
-  test("null hide_map at a level → falls through to the next level", () => {
-    const db = setupDb([
-      ["alice", "dailybw", null],
-      [":guest", "dailybw", 1],
-    ]);
-    // alice's own row says "no opinion"; falls through to gallery-level
     expect(resolve(db, "alice", "dailybw")).toBe(1);
   });
 
-  test("logged-in user without any rows uses :guest's defaults", () => {
-    const db = setupDb([[":guest", ":all", 1]]);
-    expect(resolve(db, "newuser", "anygallery")).toBe(1);
-  });
-
-  test(":guest user uses :guest's rows (no special handling)", () => {
+  test("(user, gallery) overrides (:guest, gallery)", () => {
     const db = setupDb([
-      [":guest", ":all", 1],
-      [":guest", "dailybw", 0],
-    ]);
-    expect(resolve(db, ":guest", "dailybw")).toBe(0);
-    expect(resolve(db, ":guest", "other")).toBe(1);
-  });
-
-  test(":public is in the fall-through for non-special gallery requests", () => {
-    const db = setupDb([[":guest", ":public", 1]]);
-    // Specific gallery → falls through :public → hide
-    expect(resolve(db, ":guest", "dailybw")).toBe(1);
-    expect(resolve(db, "alice", "dailybw")).toBe(1);
-    // :public request → matches directly
-    expect(resolve(db, ":guest", ":public")).toBe(1);
-  });
-
-  test("specific (:guest, gallery) beats (:guest, :public)", () => {
-    const db = setupDb([
-      [":guest", ":public", 1],
-      [":guest", "dailybw", 0],
-    ]);
-    expect(resolve(db, ":guest", "dailybw")).toBe(0);
-    // Other galleries still get the :public-level hide
-    expect(resolve(db, ":guest", "travel")).toBe(1);
-  });
-
-  test("(:guest, :public) beats (:guest, :all)", () => {
-    const db = setupDb([
-      [":guest", ":all", 0],
-      [":guest", ":public", 1],
-    ]);
-    expect(resolve(db, ":guest", "dailybw")).toBe(1);
-    // :all wins when the request is :all itself
-    expect(resolve(db, ":guest", ":all")).toBe(0);
-  });
-
-  test("(user, :public) beats (:guest, :public) at the same gallery level", () => {
-    const db = setupDb([
-      [":guest", ":public", 1],
-      ["alice", ":public", 0],
+      { user_id: ":guest", gallery_id: "dailybw", hide_map: 1 },
+      { user_id: "alice", gallery_id: "dailybw", hide_map: 0 },
     ]);
     expect(resolve(db, "alice", "dailybw")).toBe(0);
     expect(resolve(db, "bob", "dailybw")).toBe(1);
   });
 
-  test("(user, :all) beats (:guest, :public) — the motivating user-first case", () => {
-    // The scenario that motivated the user-first switch: an admin with a
-    // global show preference shouldn't see hidden maps just because :guest
-    // has hide set at a more-gallery-specific :public level.
+  test("null user.hide_map falls through to :guest's value", () => {
     const db = setupDb([
-      [":guest", ":public", 1],
-      ["admin", ":all", 0],
+      { user_id: "alice", gallery_id: "dailybw", hide_map: null },
+      { user_id: ":guest", gallery_id: "dailybw", hide_map: 1 },
     ]);
-    expect(resolve(db, "admin", "dailybw")).toBe(0);
-    expect(resolve(db, "admin", "travel")).toBe(0);
-    expect(resolve(db, ":guest", "dailybw")).toBe(1);
+    expect(resolve(db, "alice", "dailybw")).toBe(1);
+  });
+
+  test("no row at all → undefined (defaults to show)", () => {
+    const db = setupDb([
+      { user_id: ":guest", gallery_id: "other-gallery", hide_map: 1 },
+    ]);
+    expect(resolve(db, "alice", "dailybw")).toBeUndefined();
+  });
+
+  test(":guest user uses :guest's own rows", () => {
+    const db = setupDb([
+      { user_id: ":guest", gallery_id: "dailybw", hide_map: 0 },
+    ]);
+    expect(resolve(db, ":guest", "dailybw")).toBe(0);
+    expect(resolve(db, ":guest", "other")).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Collapses the access-control model to three clauses (global admin bypass → MAX of matching positive grants → deny) by replacing the per-row `access_level` enum with a boolean `is_admin` and removing the `:all` / `:public` cascade wildcards. Closes #394.

The cascade today walks a 6-step matrix (user vs `:guest` × `gallery` / `:public` / `:all`), with NONE rows acting as explicit denies. The new model lets you read the rules as one paragraph: "either you're a global admin, or someone (you, a group later, `:guest`) granted you a row; presence of a row means VIEW, `is_admin=1` upgrades it to gallery admin." Revoking is `DELETE`, not "write a NONE row." Groups (#270) drop in cleanly later as one more row source in the MAX.

Split into five commits:

- **Migration 012** — single SQL: adds `user.is_admin`, promotes `(user, :all, admin)` rows to the flag, fans `:public` grants out to per-gallery rows (so non-admins with `:public` view keep equivalent access), drops the pseudo-gallery and NONE rows, rebuilds `user_gallery` swapping `access_level INTEGER` for `is_admin INTEGER`.
- **Server core** — cascade resolution rewrite in both sqlite and dummy drivers; new `resolveAccessLevel` returns `{ hasAccess, isAdmin }`; `resolveHideMap` adds the admin bypass and drops the pseudo-gallery walk. Authorizer drops `ACCESS_*` constants and collapses `authorizeView` into `authorizeAdmin` (the old "global view" tier has no real meaning here). Dummy fixture rewritten: `admin` user is `is_admin=true` with no per-gallery rows; `plainUser` / `publicUser` get per-gallery fan-outs equivalent to their old `:all` / `:public` grants.
- **API** — `GET /api/v1/users` returns `{ id, isAdmin }` per row. POST / PUT bodies accept optional `isAdmin: boolean`. `PUT /api/v1/user-gallery/:user/:gallery` body switches from `accessLevel: "none|view|admin"` to `isAdmin: boolean`. Revoking is `DELETE` on the row.
- **CLI** — `bin/user.ts` gains `make-admin <id>` / `revoke-admin <id>`. `bin/access.ts` swaps `level <user> <gallery> <view|admin|none>` + `unset` for `grant <user> <gallery> [--admin]` (idempotent upsert; flag toggles promote/demote) + `revoke <user> <gallery>`. `list` annotates global admins; `audit` reports the global-admin count and flags edge cases. Pseudo-gallery ids rejected — for global admin, go through `bin/user.ts`.
- **Tests + CHANGELOG + OpenAPI regen** — `privacy.test.ts` and `authorizer.test.ts` rewritten against the new model. API test expectations updated where the cascade behavior shifted (cross-gallery photo lists become admin-only; non-admins lose `:all` / `:public` photo access; gallery-list counts drop pseudo-galleries; `accessLevel` → `isAdmin` body). Migration test expects `is_admin` column at schema 12. CHANGELOG bullet under Server. OpenAPI spec + typed client regenerated.

## Knock-on (already noted in #394 / #10)

- **#10 admin UI** URL anchor moves from `/g/:all/admin/...` to `/m/...` (or similar non-`/admin` prefix). The `:all` gallery is gone from the cascade; it survives in `SPECIAL_GALLERIES` as a synthetic browse rollup only, returned by `model.getGalleries()` and visible to global admins via the existing controller logic.
- **#270 groups** drops in as one more row source in the MAX (no further cascade changes needed).
- **#271** (`:all` user as a floor rule) is fully superseded.

## Test plan

- [x] `npm run typecheck` + `npm run lint` clean (server + react-app).
- [x] Server tests green on dummy driver — 715 → 599 (~120 cascade / pseudo-gallery cases removed; net loss is the removed-feature tests, not regressions).
- [x] React-app tests + typecheck + lint clean. OpenAPI typed client regenerated.
- [ ] Smoke-test the migration against an export from each of three prod instances. The fan-out is already done on prod manually (see local memory); migration 012 should be a near no-op on `:public` (no rows to fan) and only do the `is_admin` promotion + schema rewrite.
- [ ] Smoke `bin/user.ts make-admin <existing-user>`, `bin/access.ts grant <user> <gallery> --admin`, `bin/access.ts revoke <user> <gallery>` round-trips against a real sqlite instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)