### PR TITLE
bin/photo.ts: by-id show / update / delete; retire file-driven default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Tooling
 
+- `bin/photo.ts` restructured around by-id operations: new `show <id>` / `update <id>` / `delete <id>` subcommands replace the file-driven default. `update` accepts the same property / override flags as the old default (title, description, country, place, author, `camera-{make,model}`, `lens-{make,model}`, focal, aperture) plus `--gallery` for membership; only the flags passed apply, the rest of the row stays untouched. The `<files..>` positional and its JSON / JPEG ingest paths are gone — the converter's recursive `inbox/<gallery>/` watcher (#272, #223) handles intake end-to-end, and `bin/photo-geocode.ts` fills place / country / city / state from coordinates, so the operator-facing role of the old default was reduced to enrichment-on-existing-rows. `audit` / `search` / `cities` unchanged.
 - `bin/gallery.ts` now uses explicit subcommands (`list`, `create`, `update`, `delete`, `audit`) — typing `gallery.ts list` no longer silently creates a gallery called "list."
 
 ## [0.12.1] - 2026-05-31

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Photo Diary is split into independent modules, each handling its own sub-system:
 - [server](server) — Fastify + SQLite backend. Exposes `/api/v1` (with an OpenAPI doc at `/api/v1/docs`) and serves the bundled frontend.
 - [converter](converter) — back-end worker that pre-processes new photos (EXIF extraction, thumbnail/display renditions via sharp).
 
-The three pieces communicate via the shared filesystem and SQLite DB rather than over a network — the converter writes to `photos/{display,thumbnail}/` and `inbox/*.json`, the operator (or a future admin UI) registers those JSONs into the DB via `bin/photo.ts`, and the server reads the DB to serve the API. Per-instance state (database, photo files, `.env`) lives in a single instance directory outside the repo; see [Setup](#setup) below.
+The three pieces communicate via the shared filesystem and SQLite DB rather than over a network — the converter writes `photos/{display,thumbnail}/` renditions and inserts the photo row into the DB on intake, processing operator JSON sidecars through the same pipeline; the server reads the DB to serve the API; `bin/photo.ts update <id>` is the operator hook for after-the-fact enrichment. Per-instance state (database, photo files, `.env`) lives in a single instance directory outside the repo; see [Setup](#setup) below.
 
 ## Setup
 
@@ -393,14 +393,11 @@ Opt-in surfaces that aren't part of the default UI. Per-visitor toggle in UserMe
 
 End-to-end flow from a new JPG arriving on the host to it being browsable in the gallery:
 
-1. **Drop into `inbox/`.** Copy/move a JPG (or other supported format) into the instance's `photos/inbox/` directory. The converter watches this path (via chokidar) and picks the file up immediately.
-2. **Converter processes the file.** [converter](converter) reads the EXIF, generates display- and thumbnail-sized renditions (via sharp), and writes them to `photos/display/<name>.jpg` and `photos/thumbnail/<name>.jpg`. The extracted EXIF lands as a sibling JSON in `photos/inbox/<name>.json`. The original JPG is moved to `photos/original/<name>.jpg`. Result: the photo is on disk in three sizes, plus a JSON metadata file ready for ingestion.
-3. **Register in the DB.** Run `./bin/photo.ts photos/inbox/*.json --gallery <id>` from the instance dir. This reads each JSON, inserts a `photo` row with all the extracted EXIF (timestamp, camera, lens, geo, dimensions), and links the photo to the named gallery(ies) via `gallery_photo`. After this step the photo appears in the gallery on next page load.
-4. **(Optional) clean up.** The `inbox/*.json` files have served their purpose once ingested. They're harmless to leave but you can move/delete them to keep the inbox tidy.
-
-The pipeline is intentionally split: the converter doesn't touch the DB at all, and the server doesn't read from the inbox. That lets you bulk-process a backlog of photos with the converter, eyeball the JSON sidecars, and then register them in batches via `./bin/photo.ts` with overrides applied if needed (e.g. `--country jp --place "Yokohama, Kanagawa"` for a whole trip).
-
-`./bin/photo.ts` also accepts JPG paths directly instead of JSON: in that mode it registers a bare `photo` row with no EXIF data (just the filename as the ID), useful when the metadata isn't worth recovering.
+1. **Drop into `inbox/<gallery>/`.** Copy/move a JPG into the instance's `photos/inbox/<gallery>/` directory (or just `photos/inbox/` if you'd rather link to a gallery later). The converter watches this path (via chokidar) recursively and picks the file up immediately.
+2. **Converter processes the file.** [converter](converter) reads the EXIF, generates display- and thumbnail-sized renditions (via sharp), writes them to `photos/{display,thumbnail}/<id>.jpg`, moves the original to `photos/original/<id>.jpg`, and **inserts the photo row into the DB** (id, originalFilename, EXIF-derived timestamp / camera / lens / exposure, dimensions). When the file came in under `inbox/<gallery>/`, it's auto-linked to that gallery in `gallery_photo` on intake. After this step the photo appears in the gallery on next page load.
+3. **Geocoding fills place / country / city.** If the photo had EXIF coordinates, the converter (and the `bin/photo-geocode.ts` backfill daemon) resolves them through Nominatim and stores the result on `photo.geocoded_*` and `photo_localized.*` for the operator's extra languages.
+4. **(Optional) operator enrichment via JSON sidecar.** Drop a `<name>.json` alongside (or anywhere under) `inbox/` with the fields you want to overlay onto an existing row — title, description, operator-set country / place, etc. The converter matches it back to the row by id / originalFilename + timestamp and applies the overlay. The sidecar is archived under `photos/original/<id>.intake.json` after processing.
+5. **(Optional) operator enrichment via CLI.** For one-off corrections, `./bin/photo.ts update <id> --title "…" --place "…"` applies the same overrides directly. `./bin/photo.ts show <id>` prints the current row; `./bin/photo.ts delete <id>` removes one. See `./bin/photo.ts --help`.
 
 ## Roadmap
 

--- a/converter/bin/dump-exif.ts
+++ b/converter/bin/dump-exif.ts
@@ -8,13 +8,13 @@ process.argv.slice(2).forEach((filePath) => {
   const rootDir = path.dirname(filePath);
   readExif(fileName, rootDir)
     .then((properties) => {
-      // Include originalFilename so the output is ready to feed into
-      // `bin/photo.ts` as an enrichment JSON without the operator's
-      // script having to add it. `id` and `originalFilename` are the
-      // same value here (the SOOC's basename); after the converter
-      // imports the photo they diverge — `id` becomes the
-      // <ts>-<uuid> stable id while `originalFilename` stays as
-      // this name.
+      // Include originalFilename so the output is ready to feed
+      // through the converter's JSON sidecar pipeline without the
+      // operator's script having to add it. `id` and
+      // `originalFilename` are the same value here (the SOOC's
+      // basename); after the converter imports the photo they diverge
+      // — `id` becomes the <ts>-<uuid> stable id while
+      // `originalFilename` stays as this name.
       properties.originalFilename = fileName;
       console.log(JSON.stringify(properties));
     })

--- a/converter/process-file.ts
+++ b/converter/process-file.ts
@@ -111,8 +111,8 @@ const processJpeg = async (
   // its original camera filename in inbox until the final atomic move
   // (so a crash mid-pipeline leaves the file in place for the watcher
   // to retry on restart, not as an id-named orphan). The camera filename
-  // is preserved on the DB row's originalFilename for enrichment JSON
-  // matching + `bin/photo.ts search`.
+  // is preserved on the DB row's originalFilename for `bin/photo.ts
+  // search` collision triage.
   const generated = await generateId(originalPath);
   const exifTimestamp = generated.exifTimestamp;
 
@@ -199,8 +199,8 @@ const processJsonSidecar = async (
   } catch (err) {
     throw `[${relPath}] JSON parse error: ${(err as Error).message}`;
   }
-  // Accept a single photo object or an array; tolerate keyed objects
-  // (matching `bin/photo.ts processJson`).
+  // Accept a single photo object, an array, or a keyed object (operator
+  // sidecars used all three shapes historically).
   const photos: any[] = Array.isArray(data)
     ? data
     : "id" in data
@@ -216,7 +216,7 @@ const processJsonSidecar = async (
     const r = await lookup(photo);
     if (r.kind === "ambiguous") {
       logger.error(
-        `[${relPath}] "${photo.id}" matched multiple existing rows; skipping. Resolve via bin/photo.ts.`
+        `[${relPath}] "${photo.id}" matched multiple existing rows; skipping. Resolve via bin/photo.ts search + bin/photo.ts update.`
       );
       continue;
     }

--- a/converter/reverse-geocode/normalize.ts
+++ b/converter/reverse-geocode/normalize.ts
@@ -9,7 +9,7 @@
 // real place names (e.g. "Lake District", or Swedish names ending
 // in 's' like Borås). Add patterns / overrides only when the cruft
 // is observed in actual data; rerun
-// `bin/photo.ts normalize-cities --apply` to backfill.
+// `bin/photo.ts cities normalize --apply` to backfill.
 
 const SUFFIX_STRIPS: RegExp[] = [
   /\s+Municipality$/i, // "Stockholm Municipality"

--- a/converter/tests/pipeline.test.ts
+++ b/converter/tests/pipeline.test.ts
@@ -124,8 +124,8 @@ test("re-importing the same SOOC replaces files in place and preserves opinion f
 
   const id = await onlyFile(path.join(rootDir, "original"));
 
-  // Operator sets opinion fields via `bin/photo.ts` — those should
-  // survive a re-import.
+  // Operator sets opinion fields via `bin/photo.ts update` — those
+  // should survive a re-import.
   await db.updatePhoto(id, {
     title: "Operator-set title",
     taken: { location: { country: "JP", place: "Tokyo" } },
@@ -323,7 +323,8 @@ test("root-level intake JSON is processed without gallery link", async () => {
   const id = await onlyFile(path.join(rootDir, "original"));
 
   // Operator drops an intake JSON at the inbox root (no gallery
-  // auto-link; they'll link later via bin/photo.ts or admin UI).
+  // auto-link; they'll link later via bin/photo.ts update --gallery
+  // or the admin UI).
   await setupJson("new_IMG_GHI.json", {
     id: "IMG_GHI.jpg",
     taken: {

--- a/server/README.md
+++ b/server/README.md
@@ -138,29 +138,38 @@ Creates or updates a single gallery row. The ID is positional and required; ever
 | `--initial_view <view>` | One of `year`, `month`, `day`, `photo` — where the gallery lands when entered. |
 | `--hostname <regex>` | Hostname regex (e.g. `^travel\.` ) that this gallery should be the default for. Lets a single instance serve multiple vhosts (see the nginx section in the top-level README). Also binds the **virtual-host scope** — requests reaching the server with a `Host` header matching this pattern are narrowed to this gallery (or to the set of galleries, if several match) for both reads and writes. Cross-gallery admin operations (user CRUD, gallery CRUD, instance meta) are unreachable. Off-scope reads collapse to the same empty placeholder shape that a non-existent gallery returns, so the hostname can't enumerate galleries beyond its scope. Instance meta (`GET /meta`) stays unscoped — it's SPA boot data. The SPA filters the breadcrumb dropdown to the matched set and redirects off-scope URLs. Global-admin work happens from the primary host (no `hostname` match). |
 
-#### `photo.ts [options] [json-or-jpg-files…]`
+#### `photo.ts <command>`
 
-Registers photos in the DB and (optionally) links them to one or more galleries. Accepts either JSON sidecars produced by the converter or bare JPG paths (the bare-JPG mode stores just the filename as the photo ID, no EXIF).
+Operator-side photo management. Intake (creating new rows from inbox files) is the converter's job; this tool reads, modifies, and deletes existing rows.
+
+| Subcommand | Purpose |
+| --- | --- |
+| `show <id>` | Pretty-print the photo row as JSON. `--lang <code>` applies the per-language overlay. |
+| `update <id>` | Modify operator-set fields on an existing row. Same property / override flags as before — see below. |
+| `delete <id>` | Remove the photo row. Files on disk under `photos/{original,display,thumbnail}/` are not touched. |
+| `audit` | Find missing fields, orphan gallery links, duplicate `originalFilename`s, operator-vs-geocoded country drift. Counts-only by default; `--detail` or any restricting flag surfaces rows. `--format ids` is pipe-friendly. |
+| `search <originalFilename>` | List rows sharing a camera filename (collision triage). |
+| `cities <audit\|normalize\|clean-localized>` | Geocoded city hygiene — see `--help`. |
+
+`update <id>` flags:
 
 | Flag | Purpose |
 | --- | --- |
-| `--gallery <id>` | Gallery to link the photo(s) to. Repeat for multiple. |
-| `--title <s>` | Override the photo's title. |
-| `--description <s>` | Override the description. |
-| `--country <cc>` | Override the country (ISO 3166-1 alpha-2). |
-| `--place <s>` | Override the free-form place description. |
-| `--author <s>` | Override the author. |
-| `--camera-make`, `--camera-model`, `--lens-make`, `--lens-model` | Override gear strings (useful when EXIF is missing or wrong). |
-| `--focal <mm>` | Override focal length. |
-| `--aperture <f>` | Override aperture (f-number). |
+| `--gallery <id>` | Replace gallery membership (repeat for multiple). Without this flag, links stay as-is. |
+| `--title <s>` | Title. |
+| `--description <s>` | Description. |
+| `--country <cc>` | Country (ISO 3166-1 alpha-2). |
+| `--place <s>` | Free-form place description. |
+| `--author <s>` | Author. |
+| `--camera-make`, `--camera-model`, `--lens-make`, `--lens-model` | Gear strings (useful when EXIF is missing or wrong). |
+| `--focal <mm>` | Focal length. |
+| `--aperture <f>` | Aperture (f-number). |
 
-Overrides apply to every photo in the invocation, so this is the natural way to tag a whole trip:
+Only the flags you pass apply; the rest of the row stays as it was. Combine with `audit --format ids` to bulk-fix a category:
 
 ```sh
-./bin/photo.ts photos/inbox/*.json \
-  --gallery dailybw \
-  --country jp \
-  --place "Yokohama, Kanagawa"
+./bin/photo.ts audit --missing place --format ids \
+  | xargs -I{} ./bin/photo.ts update {} --place "Yokohama, Kanagawa"
 ```
 
 #### `photo-geocode.ts [--apply] [--langs en,ja] [--limit N] [--force] [--yes]`

--- a/server/bin/photo.ts
+++ b/server/bin/photo.ts
@@ -3,7 +3,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import yargs from "yargs";
+import yargs, { type Argv } from "yargs";
 import { hideBin } from "yargs/helpers";
 
 import logger from "../lib/logger.js";
@@ -12,7 +12,6 @@ import {
   acceptLocalizedCity,
   RULED_LANGS,
 } from "../lib/localized-script.js";
-import { lookup } from "../lib/photo-intake.js";
 import { normalizeCity } from "photo-diary-converter/reverse-geocode/normalize.js";
 
 const formatTable = (rows: string[][]): string => {
@@ -30,7 +29,7 @@ const formatTable = (rows: string[][]): string => {
     .join("\n");
 };
 
-const addToGalleries = async (photoId: string, galleries: unknown) => {
+const setGalleries = async (photoId: string, galleries: unknown) => {
   if (!galleries) return;
   const list = typeof galleries === "string" ? [galleries] : (galleries as string[]);
   try {
@@ -42,130 +41,95 @@ const addToGalleries = async (photoId: string, galleries: unknown) => {
   }
 };
 
-const reportAmbiguous = (photo: any, candidates: any[]) => {
-  const wantTaken = photo.taken?.instant?.timestamp;
-  console.error(
-    `Cannot resolve "${photo.id}" unambiguously. Existing row(s) with that originalFilename:`
-  );
-  for (const c of candidates) {
-    const taken = c.taken?.instant?.timestamp ?? "—";
-    console.error(`  ${c.id}  taken=${taken}`);
-  }
-  if (!wantTaken) {
-    console.error(
-      "Add taken.instant.timestamp to the input JSON to confirm which row to update (or that this is a different photo)."
-    );
-  } else {
-    console.error(
-      `No row matched taken.instant.timestamp="${wantTaken}". If this is a different photo with a rolled-over filename, use the renamed id directly.`
-    );
-  }
-};
+const overrideOptionKeys = [
+  "title",
+  "description",
+  "country",
+  "author",
+  "place",
+  "camera-make",
+  "camera-model",
+  "lens-make",
+  "lens-model",
+  "focal",
+  "aperture",
+] as const;
 
-const applyOverrides = (photo: any, argv: any) => {
-  if ("title" in argv) photo.title = argv.title;
-  if ("description" in argv) photo.description = argv.description;
+const buildPatchFromArgv = (argv: any): any => {
+  const patch: any = {};
+  if ("title" in argv) patch.title = argv.title;
+  if ("description" in argv) patch.description = argv.description;
   if ("author" in argv) {
-    photo.taken = photo.taken || {};
-    photo.taken.author = argv.author;
+    patch.taken = patch.taken || {};
+    patch.taken.author = argv.author;
   }
   if ("country" in argv) {
-    photo.taken = photo.taken || {};
-    photo.taken.location = photo.taken.location || {};
-    photo.taken.location.country = argv.country;
+    patch.taken = patch.taken || {};
+    patch.taken.location = patch.taken.location || {};
+    patch.taken.location.country = argv.country;
   }
   if ("place" in argv) {
-    photo.taken = photo.taken || {};
-    photo.taken.location = photo.taken.location || {};
-    photo.taken.location.place = argv.place;
+    patch.taken = patch.taken || {};
+    patch.taken.location = patch.taken.location || {};
+    patch.taken.location.place = argv.place;
   }
   if ("camera-make" in argv) {
-    photo.camera = photo.camera || {};
-    photo.camera.make = argv["camera-make"];
+    patch.camera = patch.camera || {};
+    patch.camera.make = argv["camera-make"];
   }
   if ("camera-model" in argv) {
-    photo.camera = photo.camera || {};
-    photo.camera.model = argv["camera-model"];
+    patch.camera = patch.camera || {};
+    patch.camera.model = argv["camera-model"];
   }
   if ("lens-make" in argv) {
-    photo.lens = photo.lens || {};
-    photo.lens.make = argv["lens-make"];
+    patch.lens = patch.lens || {};
+    patch.lens.make = argv["lens-make"];
   }
   if ("lens-model" in argv) {
-    photo.lens = photo.lens || {};
-    photo.lens.model = argv["lens-model"];
+    patch.lens = patch.lens || {};
+    patch.lens.model = argv["lens-model"];
   }
   if ("focal" in argv) {
-    photo.exposure = photo.exposure || {};
-    photo.exposure.focalLength = argv.focal;
+    patch.exposure = patch.exposure || {};
+    patch.exposure.focalLength = argv.focal;
   }
   if ("aperture" in argv) {
-    photo.exposure = photo.exposure || {};
-    photo.exposure.aperture = argv.aperture;
+    patch.exposure = patch.exposure || {};
+    patch.exposure.aperture = argv.aperture;
   }
+  return patch;
 };
 
-const processPhoto = async (photo: any, argv: any) => {
-  if (!photo.id) {
-    logger.error("Photo JSON has no id; skipping");
-    return;
-  }
-  applyOverrides(photo, argv);
-
-  const r = await lookup(photo);
-  if (r.kind === "ambiguous") {
-    reportAmbiguous(photo, r.candidates);
-    process.exitCode = 1;
-    return;
-  }
-  if (r.kind === "update") {
-    const update = { ...photo };
-    delete update.id;
-    try {
-      await db.updatePhoto(r.existingId, update);
-      logger.info(`Updated "${r.existingId}"`);
-      await addToGalleries(r.existingId, argv.gallery);
-    } catch (error) {
-      logger.error(`Update of "${r.existingId}" failed:`, error);
-    }
-    return;
-  }
-  // create — default originalFilename to the input id so the converter's
-  // `loadPhotosByOriginalFilename` finds this row when the SOOC eventually
-  // arrives (JSON-first stub flow). The operator's existing
-  // `{ id, taken: { location: { coordinates }}}` JSONs keep working without
-  // having to also send originalFilename explicitly.
-  const create = { ...photo };
-  if (!create.originalFilename) create.originalFilename = create.id;
-  try {
-    await db.createPhoto(create);
-    logger.info(`Created "${create.id}"`);
-    await addToGalleries(create.id, argv.gallery);
-  } catch (error) {
-    logger.error(`Creating "${create.id}" failed:`, error);
-  }
-};
-
-const processJson = async (filePath: string, argv: any) => {
-  try {
-    const json = await fs.promises.readFile(filePath, { encoding: "utf-8" });
-    const data = JSON.parse(json);
-    if (Array.isArray(data)) {
-      for (const photo of data) await processPhoto(photo, argv);
-    } else if (!("id" in data)) {
-      for (const photo of Object.values(data)) await processPhoto(photo, argv);
-    } else {
-      await processPhoto(data, argv);
-    }
-  } catch (error) {
-    logger.error("Failed:", error);
-  }
-};
-
-const processJpeg = async (filePath: string, argv: any) => {
-  const fileName = path.basename(filePath);
-  await processPhoto({ id: fileName }, argv);
-};
+const applyOverrideOptions = (y: Argv) =>
+  y
+    .group(["title", "description", "country"], "Properties")
+    .option("title", { type: "string", describe: "Title" })
+    .option("description", { type: "string", describe: "Description" })
+    .option("country", {
+      type: "string",
+      describe: "Two-letter country code (ISO 3166-1 alpha-2)",
+    })
+    .group(
+      [
+        "author",
+        "place",
+        "camera-make",
+        "camera-model",
+        "lens-make",
+        "lens-model",
+        "focal",
+        "aperture",
+      ],
+      "Overrides"
+    )
+    .option("author", { type: "string", describe: "Author" })
+    .option("place", { type: "string", describe: "Free-form place description" })
+    .option("camera-make", { type: "string", describe: "Camera make" })
+    .option("camera-model", { type: "string", describe: "Camera model" })
+    .option("lens-make", { type: "string", describe: "Lens make" })
+    .option("lens-model", { type: "string", describe: "Lens model" })
+    .option("focal", { type: "number", describe: "Focal length" })
+    .option("aperture", { type: "number", describe: "Aperture value (f-number)" });
 
 // ---- audit ---------------------------------------------------------------
 
@@ -372,59 +336,85 @@ await yargs(hideBin(process.argv))
   .locale("en")
   .strict()
   .command(
-    "$0 <files..>",
-    "Add or update photos from JSON / JPEG files",
+    "show <id>",
+    "Print a photo row as pretty JSON",
     (y) =>
       y
-        .positional("files", { describe: "JSON or JPEG paths", type: "string", array: true })
-        .option("gallery", {
-          describe: "Link the photo(s) to one or more galleries (repeat for multiple)",
-          type: "array",
-          string: true,
-        })
-        .group(["title", "description", "country"], "Properties")
-        .option("title", { type: "string", describe: "Title" })
-        .option("description", { type: "string", describe: "Description" })
-        .option("country", {
+        .positional("id", {
+          describe: "Photo id",
           type: "string",
-          describe: "Two-letter country code (ISO 3166-1 alpha-2)",
+          demandOption: true,
         })
-        .group(
-          [
-            "author",
-            "place",
-            "camera-make",
-            "camera-model",
-            "lens-make",
-            "lens-model",
-            "focal",
-            "aperture",
-          ],
-          "Overrides"
-        )
-        .option("author", { type: "string", describe: "Author" })
-        .option("place", { type: "string", describe: "Free-form place description" })
-        .option("camera-make", { type: "string", describe: "Camera make" })
-        .option("camera-model", { type: "string", describe: "Camera model" })
-        .option("lens-make", { type: "string", describe: "Lens make" })
-        .option("lens-model", { type: "string", describe: "Lens model" })
-        .option("focal", { type: "number", describe: "Focal length" })
-        .option("aperture", { type: "number", describe: "Aperture value (f-number)" }),
+        .option("lang", {
+          type: "string",
+          describe:
+            "Apply per-language overlay for localized fields (default: en, the canonical row)",
+        }),
     async (argv) => {
-      for (const filePath of argv.files ?? []) {
-        const fp = String(filePath);
-        logger.debug(`Processing "${fp}"`);
-        switch (path.extname(fp)) {
-          case ".json":
-            await processJson(fp, argv);
-            break;
-          case ".jpg":
-            await processJpeg(fp, argv);
-            break;
-          default:
-            logger.error(`Unrecognised extension: ${fp}`);
-        }
+      const photo = await db.loadPhoto(argv.id, argv.lang).catch(() => null);
+      if (!photo) {
+        console.error(`✗ Photo "${argv.id}" doesn't exist.`);
+        process.exit(1);
       }
+      console.log(JSON.stringify(photo, null, 2));
+    }
+  )
+  .command(
+    "update <id>",
+    "Modify operator-set fields on an existing photo. Pass only the flags you want to change; the rest of the row stays as-is.",
+    (y) =>
+      applyOverrideOptions(
+        y.positional("id", {
+          describe: "Photo id",
+          type: "string",
+          demandOption: true,
+        })
+      ).option("gallery", {
+        describe:
+          "Replace gallery membership (repeat for multiple). Without this flag, gallery links stay as-is.",
+        type: "array",
+        string: true,
+      }),
+    async (argv) => {
+      const id = argv.id as string;
+      const existing = await db.loadPhoto(id).catch(() => null);
+      if (!existing) {
+        console.error(`✗ Photo "${id}" doesn't exist.`);
+        process.exit(1);
+      }
+      const patch = buildPatchFromArgv(argv);
+      const anyField = Object.keys(patch).length > 0;
+      const anyGallery = argv.gallery !== undefined;
+      if (!anyField && !anyGallery) {
+        console.error(
+          `(nothing to do — pass at least one of: --${overrideOptionKeys.join(", --")}, --gallery)`
+        );
+        process.exit(1);
+      }
+      if (anyField) {
+        await db.updatePhoto(id, patch);
+        console.log(`✓ Updated "${id}".`);
+      }
+      await setGalleries(id, argv.gallery);
+    }
+  )
+  .command(
+    "delete <id>",
+    "Delete a photo row. Files on disk (photos/{original,display,thumbnail}/<id>.*) are NOT touched.",
+    (y) =>
+      y.positional("id", {
+        describe: "Photo id",
+        type: "string",
+        demandOption: true,
+      }),
+    async (argv) => {
+      const existing = await db.loadPhoto(argv.id).catch(() => null);
+      if (!existing) {
+        console.error(`✗ Photo "${argv.id}" doesn't exist.`);
+        process.exit(1);
+      }
+      await db.deletePhoto(argv.id);
+      console.log(`✓ Deleted "${argv.id}".`);
     }
   )
   .command(
@@ -720,5 +710,5 @@ await yargs(hideBin(process.argv))
           "Choose an action: audit, normalize, or clean-localized"
         )
   )
-  .demandCommand(1, "Specify a subcommand or pass at least one file")
+  .demandCommand(1, "Specify a subcommand")
   .parseAsync();

--- a/server/lib/photo-intake.ts
+++ b/server/lib/photo-intake.ts
@@ -3,9 +3,8 @@ import db from "../db/index.js";
 
 // Find the existing row to update for a photo whose `id` in the input
 // JSON may be the stable id, the legacy filename-id, or just the
-// original camera filename (e.g. IMG_1234.jpg). Used by both
-// `bin/photo.ts` (CLI intake) and the converter's JSON-sidecar
-// pipeline.
+// original camera filename (e.g. IMG_1234.jpg). Used by the converter's
+// JSON-sidecar pipeline.
 //
 // Chain:
 //   1. exact `id` match — direct hit; also catches legacy rows.


### PR DESCRIPTION
## Summary

Restructures `bin/photo.ts` around by-id operations. The file-driven `<files..>` default (and its JPEG positional path) retire — the converter has owned row creation since #272 / #223, and `bin/photo-geocode.ts` (#246) fills place / country / city / state from coordinates. What the operator actually needs from the CLI is enrichment, inspection, and removal on existing rows.

Closes #400.

## What changes

- New `show <id>` — pretty-prints the row as JSON. `--lang <code>` applies the per-language overlay (default: en).
- New `update <id>` — accepts the same property / override flags the old default did (`--title`, `--description`, `--country`, `--place`, `--author`, `--camera-make`, `--camera-model`, `--lens-make`, `--lens-model`, `--focal`, `--aperture`) plus `--gallery` (repeatable, replaces membership). Only the flags passed apply; the rest of the row stays untouched. Errors if the photo doesn't exist; errors if no flags were passed.
- New `delete <id>` — removes the row. Files on disk under `photos/{original,display,thumbnail}/` are not touched (documented in the help text). Errors if the photo doesn't exist.
- Removed: the `<files..>` default command, the JPEG positional path, and the `processJson` / `processJpeg` / `processPhoto` / `reportAmbiguous` helpers along with the `lookup` import. `applyOverrides` becomes a patch-builder (`buildPatchFromArgv`) consumed by `update` only.
- Unchanged: `audit`, `search <originalFilename>`, `cities <audit|normalize|clean-localized>`.
- `server/lib/photo-intake.ts` stays — the converter still uses `lookup()` for sidecar processing. Comment loses the `bin/photo.ts` reference.

## Docs

- README's Photo Pipeline section rewritten: the manual "Register in the DB" step is gone (converter handles it on intake when the JPEG lands under `inbox/<gallery>/`). The new step ladder is JPEG → converter renditions + DB row + auto-link → geocode-fill from coords → optional sidecar overlay → optional `bin/photo.ts update <id>` for one-off corrections.
- `server/README.md`'s `photo.ts` section rewritten with the subcommand table and an `audit --format ids | xargs update {} --place "…"` recipe for bulk fixes.
- CHANGELOG entry under Tooling.

## Test plan

- [x] `npm run typecheck` + `npm run lint` clean for server, converter, and react-app.
- [x] Server tests green (616 / 616).
- [x] Converter tests green (21 / 21).
- [ ] Smoke against a real sqlite3 instance: `./bin/photo.ts show <id>`; `./bin/photo.ts update <id> --place "..."`; `./bin/photo.ts delete <id>`; verify each errors gracefully when the id doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)