### PR TITLE
GET /api/v1/photos: filtered + paginated list (#10 PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Server
 
+- `GET /api/v1/photos` accepts filter query params (`gallery`, `orphan`, `dateFrom`, `dateTo`, `missing`, `duplicates`, `countryMismatch`, `q`) and returns a paginated `{ photos, page, pageSize, total }` shape sorted newest-first; predicates lifted into `server/lib/photo-filter.ts` so `bin/photo.ts audit` and the admin endpoint share one definition. (part of #10)
 - ACL user groups — `group` / `user_group` / `group_gallery` (migration 013) compose into the access cascade as another positive-grant source, exposed via `/api/v1/groups` + `/api/v1/group-gallery` and routed through `bin/{user,group,gallery}.ts` as `bin/access.ts` retires. (closes #270)
 - ACL simplification — access collapses to a global `user.is_admin` flag plus per-(user, gallery) `is_admin` boolean rows; pseudo-galleries (`:all`, `:public`) and NONE deny rows drop out; migration 012 promotes the legacy data. (closes #394)
 - Virtual-host scope — requests on a `Host` matching a gallery's `hostname` regex narrow both reads and writes to that gallery; cross-gallery admin ops 404; the SPA mirrors the scope client-side. (closes #386)

--- a/react-app/src/lib/api-schema.ts
+++ b/react-app/src/lib/api-schema.ts
@@ -699,10 +699,21 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List all photos */
+        /** List photos with optional filters; returns a paginated page of the matching set sorted newest-first by capture timestamp */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    gallery?: string | string[];
+                    orphan?: boolean;
+                    dateFrom?: string;
+                    dateTo?: string;
+                    missing?: ("taken" | "coords" | "place" | "country" | "author" | "title" | "description" | "state-code") | ("taken" | "coords" | "place" | "country" | "author" | "title" | "description" | "state-code")[];
+                    duplicates?: boolean;
+                    countryMismatch?: boolean;
+                    q?: string;
+                    page?: number;
+                    pageSize?: number;
+                };
                 header?: never;
                 path?: never;
                 cookie?: never;

--- a/server/bin/photo.ts
+++ b/server/bin/photo.ts
@@ -133,31 +133,9 @@ const applyOverrideOptions = (y: Argv) =>
 
 // ---- audit ---------------------------------------------------------------
 
-// Empty-data sentinel: NULL → "" through mapRow; "Invalid date" is the
-// explicit placeholder readExif emits for EXIF-less imports.
-const isMissing = (v: unknown): boolean =>
-  v === null || v === undefined || v === "" || v === "unknown" || v === "Invalid date";
-
-type MissingField =
-  | "taken"
-  | "coords"
-  | "place"
-  | "country"
-  | "author"
-  | "title"
-  | "description";
-
-const MISSING_PROBES: Record<MissingField, (p: any) => boolean> = {
-  taken: (p) => isMissing(p.taken?.instant?.timestamp),
-  coords: (p) =>
-    isMissing(p.taken?.location?.coordinates?.latitude) ||
-    isMissing(p.taken?.location?.coordinates?.longitude),
-  place: (p) => isMissing(p.taken?.location?.place),
-  country: (p) => isMissing(p.taken?.location?.country),
-  author: (p) => isMissing(p.taken?.author),
-  title: (p) => isMissing(p.title),
-  description: (p) => isMissing(p.description),
-};
+// Predicates live in server/lib/photo-filter.ts so the CLI and the
+// admin photos endpoint share the same definitions.
+import { MISSING_PREDICATES, type MissingField } from "../lib/photo-filter.js";
 
 interface AuditCheck {
   key: string;
@@ -167,14 +145,24 @@ interface AuditCheck {
   footer?: () => string | undefined;
 }
 
+const FIELDS_FOR_CLI: MissingField[] = [
+  "taken",
+  "coords",
+  "place",
+  "country",
+  "author",
+  "title",
+  "description",
+];
+
 const buildChecks = (
   photos: any[],
   orphanIds: Set<string>
 ): AuditCheck[] => {
   const checks: AuditCheck[] = [];
 
-  for (const field of Object.keys(MISSING_PROBES) as MissingField[]) {
-    const probe = MISSING_PROBES[field];
+  for (const field of FIELDS_FOR_CLI) {
+    const probe = MISSING_PREDICATES[field];
     checks.push({
       key: `missing-${field}`,
       title: `Photos with missing ${field}`,
@@ -277,14 +265,10 @@ const buildChecks = (
       "Photos with coords + city but no geocoded_state_code (ISO 3166-2)",
     whyLabel: "country / state / city",
     rows: () => {
+      const probe = MISSING_PREDICATES["state-code"];
       const out: Array<{ id: string; row: any; why?: string }> = [];
       for (const p of photos) {
-        const lat = p.taken?.location?.coordinates?.latitude;
-        const lon = p.taken?.location?.coordinates?.longitude;
-        if (lat === null || lat === undefined) continue;
-        if (lon === null || lon === undefined) continue;
-        if (!p.geocoded?.city) continue;
-        if (p.geocoded?.stateCode) continue;
+        if (!probe(p)) continue;
         const country = p.geocoded?.countryCode ?? "?";
         const state = p.geocoded?.state ?? "";
         out.push({

--- a/server/controllers/photos-v1.ts
+++ b/server/controllers/photos-v1.ts
@@ -8,6 +8,10 @@ import {
   requireUnscoped,
 } from "../lib/host-scope.js";
 import modelFactory from "../models/photo.js";
+import type {
+  MissingField,
+  PhotoFilter,
+} from "../lib/photo-filter.js";
 
 const authorizer = authorizerFactory();
 const model = modelFactory();
@@ -85,6 +89,48 @@ const PhotoCreateBody = Type.Object(
 const PhotoUpdateBody = Type.Object(PhotoOverridesFields, {
   additionalProperties: false,
 });
+
+const MISSING_VALUES = [
+  "taken",
+  "coords",
+  "place",
+  "country",
+  "author",
+  "title",
+  "description",
+  "state-code",
+] as const satisfies readonly MissingField[];
+const stringOrArray = (s: typeof Type.String) =>
+  Type.Union([s(), Type.Array(s())]);
+
+// Filters mirror the `bin/photo.ts audit` predicate set + gallery
+// membership + date range + free-text search. All fields are optional;
+// repeated query params (`?gallery=g1&gallery=g2`) accumulate into
+// arrays (Fastify default). Pagination defaults to page 1 / 100.
+const PhotosQuery = Type.Object(
+  {
+    gallery: Type.Optional(stringOrArray(Type.String)),
+    orphan: Type.Optional(Type.Boolean()),
+    dateFrom: Type.Optional(Type.String()),
+    dateTo: Type.Optional(Type.String()),
+    missing: Type.Optional(
+      Type.Union([
+        Type.Union(MISSING_VALUES.map((v) => Type.Literal(v))),
+        Type.Array(Type.Union(MISSING_VALUES.map((v) => Type.Literal(v)))),
+      ])
+    ),
+    duplicates: Type.Optional(Type.Boolean()),
+    countryMismatch: Type.Optional(Type.Boolean()),
+    q: Type.Optional(Type.String()),
+    page: Type.Optional(Type.Integer({ minimum: 1 })),
+    pageSize: Type.Optional(Type.Integer({ minimum: 1, maximum: 500 })),
+  },
+  { additionalProperties: false }
+);
+
+const toArray = <T>(v: T | T[] | undefined): T[] | undefined =>
+  v === undefined ? undefined : Array.isArray(v) ? v : [v];
+
 const TAGS = ["photos"];
 
 const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
@@ -93,30 +139,38 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
    */
   fastify.get(
     "/",
-    { schema: { tags: TAGS, summary: "List all photos" } },
+    {
+      schema: {
+        tags: TAGS,
+        summary:
+          "List photos with optional filters; returns a paginated page of the matching set sorted newest-first by capture timestamp",
+        querystring: PhotosQuery,
+        security: [{ bearer: [] }],
+      },
+    },
     async (request) => {
       await authorizer.authorizeView(request.user.id);
-      const photos = await model.getPhotos();
-      // hide_map is a per-(user, gallery) preference. The cross-gallery
-      // list has no gallery scope to resolve against, so coordinates
-      // pass through; per-gallery views still apply the cascade. The
-      // admin photo grid (#10) will reshape this endpoint with proper
-      // filtering and per-link masking.
+      const q = request.query;
+      const filter: PhotoFilter = {
+        galleryIds: toArray(q.gallery),
+        orphan: q.orphan,
+        dateFrom: q.dateFrom,
+        dateTo: q.dateTo,
+        missing: toArray(q.missing) as MissingField[] | undefined,
+        duplicates: q.duplicates,
+        countryMismatch: q.countryMismatch,
+        q: q.q,
+      };
       // On a scoped host, narrow to photos linked to an in-scope
-      // gallery. Photos in multiple galleries pass if at least one
-      // link is in scope.
-      const inScopeIds = await collectScopePhotoIds(request);
-      if (!inScopeIds) return photos;
-      if (Array.isArray(photos)) {
-        return (photos as Array<{ id: string }>).filter((p) =>
-          inScopeIds.has(p.id)
-        );
-      }
-      return Object.fromEntries(
-        Object.entries(photos as Record<string, unknown>).filter(([id]) =>
-          inScopeIds.has(id)
-        )
-      );
+      // gallery. The set passes into the model so pagination still
+      // yields the right window size.
+      const restrictToIds = await collectScopePhotoIds(request);
+      return await model.listPhotos({
+        filter,
+        page: q.page,
+        pageSize: q.pageSize,
+        restrictToIds: restrictToIds ?? undefined,
+      });
     }
   );
 

--- a/server/db/dummy.ts
+++ b/server/db/dummy.ts
@@ -61,6 +61,7 @@ export default () => {
     unlinkGalleryPhoto,
     unlinkAllPhotos,
     unlinkAllGalleries,
+    loadAllGalleryPhotoLinks,
 
     loadPhotos,
     createPhoto,
@@ -478,6 +479,16 @@ const unlinkAllGalleries = async (photoId: string) => {
       (id) => id !== photoId
     );
   }
+};
+const loadAllGalleryPhotoLinks = async (): Promise<
+  Array<{ galleryId: string; photoId: string }>
+> => {
+  const out: Array<{ galleryId: string; photoId: string }> = [];
+  const galleryPhotos = (db.galleryPhotos ?? {}) as Record<string, string[]>;
+  for (const [galleryId, photoIds] of Object.entries(galleryPhotos)) {
+    for (const photoId of photoIds) out.push({ galleryId, photoId });
+  }
+  return out;
 };
 
 const loadPhotos = async () => {

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -214,6 +214,9 @@ export default {
   unlinkAllGalleries: async (photoId: string) => {
     return await db.unlinkAllGalleries(photoId);
   },
+  loadAllGalleryPhotoLinks: async () => {
+    return await db.loadAllGalleryPhotoLinks();
+  },
 
   loadPhotos: async (lang?: string) => {
     return await db.loadPhotos(lang);

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -77,6 +77,7 @@ export default () => {
     unlinkGalleryPhoto,
     unlinkAllPhotos,
     unlinkAllGalleries,
+    loadAllGalleryPhotoLinks,
     loadGalleryPhoto,
 
     loadPhotos,
@@ -475,6 +476,14 @@ const linkGalleryPhoto = async (
     });
   });
   insertAll();
+};
+const loadAllGalleryPhotoLinks = async (): Promise<
+  Array<{ galleryId: string; photoId: string }>
+> => {
+  const rows = db
+    .prepare("SELECT gallery_id, photo_id FROM gallery_photo")
+    .all() as Array<{ gallery_id: string; photo_id: string }>;
+  return rows.map((r) => ({ galleryId: r.gallery_id, photoId: r.photo_id }));
 };
 const loadGalleryPhoto = async (
   galleryId: string,

--- a/server/lib/photo-filter.ts
+++ b/server/lib/photo-filter.ts
@@ -1,0 +1,201 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// Audit + filter predicates over loaded photo rows. The CLI (`bin/photo.ts
+// audit`) and the admin photos endpoint (`GET /api/v1/photos`) both walk
+// in-memory photo arrays and apply the same checks — keep the predicates
+// here so the two surfaces can't drift.
+
+export type MissingField =
+  | "taken"
+  | "coords"
+  | "place"
+  | "country"
+  | "author"
+  | "title"
+  | "description"
+  | "state-code";
+
+// Empty-data sentinel: NULL → "" through mapRow; "Invalid date" is the
+// explicit placeholder readExif emits for EXIF-less imports.
+const isMissing = (v: unknown): boolean =>
+  v === null ||
+  v === undefined ||
+  v === "" ||
+  v === "unknown" ||
+  v === "Invalid date";
+
+const hasCoords = (p: any): boolean => {
+  const lat = p.taken?.location?.coordinates?.latitude;
+  const lon = p.taken?.location?.coordinates?.longitude;
+  return !isMissing(lat) && !isMissing(lon);
+};
+
+export const MISSING_PREDICATES: Record<MissingField, (p: any) => boolean> = {
+  taken: (p) => isMissing(p.taken?.instant?.timestamp),
+  coords: (p) => !hasCoords(p),
+  place: (p) => isMissing(p.taken?.location?.place),
+  country: (p) => isMissing(p.taken?.location?.country),
+  author: (p) => isMissing(p.taken?.author),
+  title: (p) => isMissing(p.title),
+  description: (p) => isMissing(p.description),
+  "state-code": (p) =>
+    hasCoords(p) && !!p.geocoded?.city && !p.geocoded?.stateCode,
+};
+
+const countryMismatch = (p: any): boolean => {
+  const operator = p.taken?.location?.country;
+  const geocoded = p.geocoded?.countryCode;
+  if (!operator || !geocoded) return false;
+  return operator.toLowerCase() !== geocoded.toLowerCase();
+};
+
+export interface PhotoFilter {
+  galleryIds?: string[]; // any of these (multi-select)
+  orphan?: boolean; // photos with zero gallery_photo links
+  dateFrom?: string; // ISO timestamp, inclusive
+  dateTo?: string; // ISO timestamp, inclusive
+  missing?: MissingField[]; // intersection (all of these missing)
+  duplicates?: boolean; // shares originalFilename with another row
+  countryMismatch?: boolean; // operator country ≠ geocoded country
+  q?: string; // free-text over title/description/originalFilename/place
+}
+
+const galleryMembershipPredicate = (
+  filter: PhotoFilter,
+  galleryMembers: Map<string, Set<string>>,
+  orphanIds: Set<string>
+): ((p: any) => boolean) | undefined => {
+  const wantGalleries =
+    filter.galleryIds && filter.galleryIds.length > 0
+      ? new Set(filter.galleryIds)
+      : undefined;
+  const wantOrphan = filter.orphan === true;
+  if (!wantGalleries && !wantOrphan) return undefined;
+  return (p: any) => {
+    if (wantOrphan && orphanIds.has(p.id)) return true;
+    if (!wantGalleries) return false;
+    const memberOf = galleryMembers.get(p.id);
+    if (!memberOf) return false;
+    for (const g of wantGalleries) if (memberOf.has(g)) return true;
+    return false;
+  };
+};
+
+const dateRangePredicate = (
+  filter: PhotoFilter
+): ((p: any) => boolean) | undefined => {
+  if (!filter.dateFrom && !filter.dateTo) return undefined;
+  return (p: any) => {
+    const ts = p.taken?.instant?.timestamp as string | undefined;
+    if (!ts) return false;
+    if (filter.dateFrom && ts < filter.dateFrom) return false;
+    if (filter.dateTo && ts > filter.dateTo) return false;
+    return true;
+  };
+};
+
+const missingPredicate = (
+  filter: PhotoFilter
+): ((p: any) => boolean) | undefined => {
+  if (!filter.missing || filter.missing.length === 0) return undefined;
+  const probes = filter.missing.map((m) => MISSING_PREDICATES[m]);
+  return (p: any) => probes.every((probe) => probe(p));
+};
+
+const duplicatesPredicate = (
+  photos: any[]
+): ((p: any) => boolean) => {
+  const counts = new Map<string, number>();
+  for (const p of photos) {
+    const name = p.originalFilename as string | undefined;
+    if (!name) continue;
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  return (p: any) => {
+    const name = p.originalFilename as string | undefined;
+    return !!name && (counts.get(name) ?? 0) > 1;
+  };
+};
+
+const freeTextPredicate = (
+  filter: PhotoFilter
+): ((p: any) => boolean) | undefined => {
+  if (!filter.q) return undefined;
+  const needle = filter.q.toLowerCase();
+  return (p: any) => {
+    const haystacks = [
+      p.title,
+      p.description,
+      p.originalFilename,
+      p.taken?.location?.place,
+      p.taken?.location?.country,
+      p.geocoded?.city,
+    ];
+    for (const h of haystacks) {
+      if (typeof h === "string" && h.toLowerCase().includes(needle)) return true;
+    }
+    return false;
+  };
+};
+
+export interface FilterInputs {
+  galleryMembers: Map<string, Set<string>>;
+  orphanIds: Set<string>;
+}
+
+export const applyFilter = (
+  photos: any[],
+  filter: PhotoFilter,
+  inputs: FilterInputs
+): any[] => {
+  const predicates: Array<(p: any) => boolean> = [];
+  const membership = galleryMembershipPredicate(
+    filter,
+    inputs.galleryMembers,
+    inputs.orphanIds
+  );
+  if (membership) predicates.push(membership);
+  const dateRange = dateRangePredicate(filter);
+  if (dateRange) predicates.push(dateRange);
+  const missing = missingPredicate(filter);
+  if (missing) predicates.push(missing);
+  if (filter.duplicates) predicates.push(duplicatesPredicate(photos));
+  if (filter.countryMismatch) predicates.push(countryMismatch);
+  const freeText = freeTextPredicate(filter);
+  if (freeText) predicates.push(freeText);
+
+  if (predicates.length === 0) return photos.slice();
+  return photos.filter((p) => predicates.every((pred) => pred(p)));
+};
+
+// Newest-first by capture timestamp. Photos without a timestamp sort to
+// the end (treated as oldest), then by id for stable ordering.
+export const sortByTakenDesc = (photos: any[]): any[] =>
+  photos.slice().sort((a, b) => {
+    const ta = a.taken?.instant?.timestamp as string | undefined;
+    const tb = b.taken?.instant?.timestamp as string | undefined;
+    if (ta && tb) {
+      if (ta < tb) return 1;
+      if (ta > tb) return -1;
+    } else if (ta && !tb) {
+      return -1;
+    } else if (!ta && tb) {
+      return 1;
+    }
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+
+export const paginate = <T>(
+  items: T[],
+  page: number,
+  pageSize: number
+): { items: T[]; page: number; pageSize: number; total: number } => {
+  const total = items.length;
+  const start = (page - 1) * pageSize;
+  return {
+    items: items.slice(start, start + pageSize),
+    page,
+    pageSize,
+    total,
+  };
+};

--- a/server/models/photo.ts
+++ b/server/models/photo.ts
@@ -1,11 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import logger from "../lib/logger.js";
 import db from "../db/index.js";
+import {
+  applyFilter,
+  paginate,
+  sortByTakenDesc,
+  type PhotoFilter,
+} from "../lib/photo-filter.js";
 
 export default () => {
   return {
     init,
     getPhotos,
+    listPhotos,
     createPhoto,
     getPhoto,
     updatePhoto,
@@ -18,6 +25,71 @@ const init = async () => {};
 const getPhotos = async () => {
   logger.debug("Getting all photos");
   return await db.loadPhotos();
+};
+
+// Filtered + paginated list. Loads every row and applies predicates in
+// memory — fine at current catalogue sizes; SQL-side optimisation is
+// deferred (#286 / #406).
+export interface ListOptions {
+  filter?: PhotoFilter;
+  page?: number;
+  pageSize?: number;
+  // Additional id allow-list applied alongside the filter. The
+  // virtual-host scope (#386) passes its in-scope photo set here so
+  // pagination still produces a correctly-sized window.
+  restrictToIds?: Set<string>;
+}
+
+export interface ListResult {
+  photos: any[];
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+const DEFAULT_PAGE_SIZE = 100;
+const MAX_PAGE_SIZE = 500;
+
+const toArray = (photos: unknown): any[] =>
+  Array.isArray(photos)
+    ? (photos as any[])
+    : (Object.values(photos as Record<string, any>) as any[]);
+
+const listPhotos = async (opts: ListOptions = {}): Promise<ListResult> => {
+  const filter = opts.filter ?? {};
+  const page = Math.max(1, Math.floor(opts.page ?? 1));
+  const pageSize = Math.min(
+    MAX_PAGE_SIZE,
+    Math.max(1, Math.floor(opts.pageSize ?? DEFAULT_PAGE_SIZE))
+  );
+  logger.debug("Listing photos", { filter, page, pageSize });
+
+  const photos = toArray(await db.loadPhotos());
+  const orphanIds = new Set<string>(await db.loadOrphanPhotoIds());
+  const links = await db.loadAllGalleryPhotoLinks();
+  const galleryMembers = new Map<string, Set<string>>();
+  for (const link of links) {
+    let set = galleryMembers.get(link.photoId);
+    if (!set) {
+      set = new Set();
+      galleryMembers.set(link.photoId, set);
+    }
+    set.add(link.galleryId);
+  }
+
+  let matched = applyFilter(photos, filter, { galleryMembers, orphanIds });
+  if (opts.restrictToIds) {
+    const allow = opts.restrictToIds;
+    matched = matched.filter((p) => allow.has(p.id));
+  }
+  const sorted = sortByTakenDesc(matched);
+  const result = paginate(sorted, page, pageSize);
+  return {
+    photos: result.items,
+    page: result.page,
+    pageSize: result.pageSize,
+    total: result.total,
+  };
 };
 
 const createPhoto = async (photo: { id: string } & Record<string, any>) => {

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -894,9 +894,217 @@
     },
     "/api/v1/photos": {
       "get": {
-        "summary": "List all photos",
+        "summary": "List photos with optional filters; returns a paginated page of the matching set sorted newest-first by capture timestamp",
         "tags": [
           "photos"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              ]
+            },
+            "in": "query",
+            "name": "gallery",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "orphan",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "dateFrom",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "dateTo",
+            "required": false
+          },
+          {
+            "schema": {
+              "anyOf": [
+                {
+                  "anyOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "taken"
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "coords"
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "place"
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "country"
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "author"
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "title"
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "description"
+                      ]
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "state-code"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "taken"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "coords"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "place"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "country"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "author"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "title"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "description"
+                        ]
+                      },
+                      {
+                        "type": "string",
+                        "enum": [
+                          "state-code"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "in": "query",
+            "name": "missing",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "duplicates",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "query",
+            "name": "countryMismatch",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "q",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "in": "query",
+            "name": "page",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 500
+            },
+            "in": "query",
+            "name": "pageSize",
+            "required": false
+          }
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
         ],
         "responses": {
           "200": {

--- a/server/tests/api/host-scope.test.ts
+++ b/server/tests/api/host-scope.test.ts
@@ -301,9 +301,9 @@ describe("scoped host (single match: gallery1.example.com → gallery1)", () => 
     // gallery1's fixture photos are gallery1photo.jpg + gallery12photo.jpg
     // (the latter also lives in gallery2). gallery2photo.jpg /
     // gallery3photo.jpg / orphanphoto.jpg are out.
-    const ids = Array.isArray(result.body)
-      ? (result.body as Array<{ id: string }>).map((p) => p.id).sort()
-      : Object.keys(result.body as Record<string, unknown>).sort();
+    const ids = (result.body.photos as Array<{ id: string }>)
+      .map((p) => p.id)
+      .sort();
     expect(ids).toStrictEqual(["gallery12photo.jpg", "gallery1photo.jpg"]);
   });
 

--- a/server/tests/api/photos.test.ts
+++ b/server/tests/api/photos.test.ts
@@ -21,9 +21,13 @@ const getPhoto = async (token: string | undefined, photoId: string, status = 200
     .set("Authorization", `Bearer ${token}`)
     .expect(status);
 
-const expectPhoto = (result: { body: Record<string, { id: string }> }, photo: string) => {
-  expect(result.body[photo]).toBeDefined();
-  expect(result.body[photo].id).toBe(photo);
+const expectPhoto = (
+  result: { body: { photos: Array<{ id: string }> } },
+  photo: string
+) => {
+  const match = result.body.photos.find((p) => p.id === photo);
+  expect(match).toBeDefined();
+  expect(match?.id).toBe(photo);
 };
 
 describe("As guest", () => {
@@ -116,7 +120,10 @@ describe("As admin", () => {
 
   test("List photos", async () => {
     const result = await getPhotos(token);
-    expect(Object.keys(result.body).length).toBe(5);
+    expect(result.body.photos.length).toBe(5);
+    expect(result.body.total).toBe(5);
+    expect(result.body.page).toBe(1);
+    expect(result.body.pageSize).toBe(100);
     expectPhoto(result, "gallery1photo.jpg");
     expectPhoto(result, "gallery12photo.jpg");
     expectPhoto(result, "gallery2photo.jpg");
@@ -401,5 +408,113 @@ describe("Mutations as admin", () => {
       .set("Authorization", `Bearer ${token}`)
       .send({ exposure: { iso: 100 } })
       .expect(400));
+});
+
+describe("List photos: filters + pagination", () => {
+  let token: string | undefined = undefined;
+  beforeAll(async () => {
+    token = await loginUser(api, "admin");
+  });
+
+  const ids = (body: { photos: Array<{ id: string }> }) =>
+    body.photos.map((p) => p.id);
+
+  test("Newest-first by capture timestamp", async () => {
+    const result = await getPhotos(token);
+    // Fixture timestamps (desc): orphan 2020-08, gallery3 2020-07-05,
+    // gallery2 2020-07-05, gallery12 2020-07-04, gallery1 2018-05-04.
+    expect(ids(result.body)).toStrictEqual([
+      "orphanphoto.jpg",
+      "gallery3photo.jpg",
+      "gallery2photo.jpg",
+      "gallery12photo.jpg",
+      "gallery1photo.jpg",
+    ]);
+  });
+
+  test("gallery=gallery1 narrows to that gallery's photos", async () => {
+    const result = await api
+      .get("/api/v1/photos")
+      .query({ gallery: "gallery1" })
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    expect(ids(result.body).sort()).toStrictEqual([
+      "gallery12photo.jpg",
+      "gallery1photo.jpg",
+    ]);
+  });
+
+  test("orphan=true returns only the orphan", async () => {
+    const result = await api
+      .get("/api/v1/photos")
+      .query({ orphan: true })
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    expect(ids(result.body)).toStrictEqual(["orphanphoto.jpg"]);
+  });
+
+  test("missing=coords returns rows without lat/lon", async () => {
+    const result = await api
+      .get("/api/v1/photos")
+      .query({ missing: "coords" })
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    // gallery1photo has coords; the other four don't.
+    expect(ids(result.body).sort()).toStrictEqual([
+      "gallery12photo.jpg",
+      "gallery2photo.jpg",
+      "gallery3photo.jpg",
+      "orphanphoto.jpg",
+    ]);
+  });
+
+  test("missing=country returns the empty-country rows", async () => {
+    const result = await api
+      .get("/api/v1/photos")
+      .query({ missing: "country" })
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    // Every fixture has a country, so this filter matches nothing.
+    expect(result.body.photos.length).toBe(0);
+    expect(result.body.total).toBe(0);
+  });
+
+  test("dateFrom / dateTo narrow to the range", async () => {
+    const result = await api
+      .get("/api/v1/photos")
+      .query({ dateFrom: "2020-07-01", dateTo: "2020-07-31" })
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    expect(ids(result.body).sort()).toStrictEqual([
+      "gallery12photo.jpg",
+      "gallery2photo.jpg",
+      "gallery3photo.jpg",
+    ]);
+  });
+
+  test("Pagination: pageSize=2 + page=2 returns the next two", async () => {
+    const result = await api
+      .get("/api/v1/photos")
+      .query({ pageSize: 2, page: 2 })
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    // Newest-first order: 0=orphan, 1=gallery3, 2=gallery2, 3=gallery12, 4=gallery1
+    // page 2 (pageSize 2) → indices 2 + 3.
+    expect(ids(result.body)).toStrictEqual([
+      "gallery2photo.jpg",
+      "gallery12photo.jpg",
+    ]);
+    expect(result.body.total).toBe(5);
+    expect(result.body.page).toBe(2);
+    expect(result.body.pageSize).toBe(2);
+  });
+
+  test("Unknown query param is rejected (additionalProperties: false via TypeBox)", async () => {
+    await api
+      .get("/api/v1/photos")
+      .query({ bogus: "x" })
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400);
+  });
 });
 


### PR DESCRIPTION
## Summary

First of the eight PRs in #10. Adds query params and pagination to `GET /api/v1/photos` so the admin photos page (PR 3) has a data source. The same predicates that power `bin/photo.ts audit` lift into `server/lib/photo-filter.ts`, shared between the CLI and the controller.

## Filters

| Param | Type | Notes |
| --- | --- | --- |
| `gallery` | string \| string[] | repeated `?gallery=g1&gallery=g2` accumulates; "any-of" |
| `orphan` | boolean | photos with zero `gallery_photo` links; OR-ed with `gallery` |
| `dateFrom`, `dateTo` | string | inclusive range on `taken.instant.timestamp` |
| `missing` | enum \| enum[] | `taken \| coords \| place \| country \| author \| title \| description \| state-code`; intersection (all of these missing) |
| `duplicates` | boolean | shares `originalFilename` with another row |
| `countryMismatch` | boolean | operator country ≠ Nominatim geocoded country |
| `q` | string | free-text over title / description / originalFilename / place / country / city |
| `page`, `pageSize` | integer | default 1 / 100; `pageSize` max 500 |

Unknown query params are rejected (TypeBox `additionalProperties: false`).

## Response

```
{
  "photos": [ ...rows... ],
  "page": 1,
  "pageSize": 100,
  "total": 12345
}
```

Sorted newest-first by `taken.instant.timestamp`; ties broken by id. Photos without a timestamp sort to the end.

## Notes

- **Single source of truth for predicates.** `server/lib/photo-filter.ts` exports `MISSING_PREDICATES`, `applyFilter`, `sortByTakenDesc`, `paginate`. `bin/photo.ts audit` now imports the same predicates instead of duplicating them; the audit's structure (titles, why-labels, footer) stays.
- **No SQL optimization yet.** The model loads all rows + applies predicates in memory. Fine at current catalogue size; SQL-side filtering is deferred to #286 / #406.
- **Virtual-host scope** (#386) passes its in-scope photo set into the model as `restrictToIds` so pagination produces a correctly-sized window. The off-scope photo on a scoped host case (existing host-scope test) is preserved.
- **API consumers.** The SPA still uses `/api/v1/gallery-photos/:galleryId` for the public viewer; this endpoint is the admin path.

## Test plan

- [x] `npm run typecheck` + `npm run lint` clean for server, react-app, converter.
- [x] Server tests: 599 → 607 (8 new filter / pagination cases).
- [x] React-app tests: 977 / 977.
- [x] Converter tests: 21 / 21.
- [x] OpenAPI regenerated; react-app `api:codegen` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)