### PR TITLE
Admin Galleries list: drop edge-padding overrides so hover doesn't touch the table edges

### DIFF
--- a/react-app/src/components/Manage/Galleries.tsx
+++ b/react-app/src/components/Manage/Galleries.tsx
@@ -53,14 +53,7 @@ const Table = styled.table`
   border-collapse: collapse;
   font-size: 0.9em;
 `;
-// width: 1% + white-space: nowrap on the trailing actions column
-// is the classic "shrink to fit content" idiom for auto-layout
-// tables. Without it the actions cell soaks up the slack space the
-// browser distributes across auto-sized columns, leaving the
-// buttons floating at the cell's left edge with empty space to
-// their right. Uniform inner padding on every cell keeps the row
-// hover background away from the table edges so the text never
-// touches the highlight border.
+// last-of-type width: 1% + nowrap shrinks the column to fit.
 const Th = styled.th`
   text-align: left;
   padding: 8px 12px;

--- a/react-app/src/components/Manage/Galleries.tsx
+++ b/react-app/src/components/Manage/Galleries.tsx
@@ -53,15 +53,14 @@ const Table = styled.table`
   border-collapse: collapse;
   font-size: 0.9em;
 `;
-// First column's inner padding would push its content right of the
-// Title (which sits at Root's padding edge); zeroing the leading
-// pad on first-of-type cells lines the column up with the heading.
 // width: 1% + white-space: nowrap on the trailing actions column
 // is the classic "shrink to fit content" idiom for auto-layout
 // tables. Without it the actions cell soaks up the slack space the
 // browser distributes across auto-sized columns, leaving the
 // buttons floating at the cell's left edge with empty space to
-// their right.
+// their right. Uniform inner padding on every cell keeps the row
+// hover background away from the table edges so the text never
+// touches the highlight border.
 const Th = styled.th`
   text-align: left;
   padding: 8px 12px;
@@ -71,11 +70,7 @@ const Th = styled.th`
   text-transform: uppercase;
   font-size: 0.85em;
   letter-spacing: 0.05em;
-  &:first-of-type {
-    padding-left: 0;
-  }
   &:last-of-type {
-    padding-right: 0;
     width: 1%;
     white-space: nowrap;
   }
@@ -84,11 +79,7 @@ const Td = styled.td`
   padding: 8px 12px;
   border-bottom: 1px solid var(--inactive-color);
   vertical-align: middle;
-  &:first-of-type {
-    padding-left: 0;
-  }
   &:last-of-type {
-    padding-right: 0;
     width: 1%;
     white-space: nowrap;
   }


### PR DESCRIPTION
## Summary

Small polish on the Galleries list table. The row hover background reached the very edge of the table on both sides, with text and button glyphs touching the highlight border. Drops the `&:first-of-type { padding-left: 0 }` / `&:last-of-type { padding-right: 0 }` overrides on `Th` / `Td` so every cell carries the same 8px / 12px padding.

The trailing column keeps `width: 1%; white-space: nowrap;` so the actions cell still hugs its two buttons rather than soaking up the slack from the auto-layout — only the inner pad-zeroing goes away.

## Test plan

- [x] `npm run typecheck` + `npm run lint` + `npm test` clean (react-app).
- [x] Smoke: hover a row on `/m/galleries` — the highlight band stops ~12px short of each edge, no text or button glyph touching the row border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)