### PR TITLE
Landing: admin-only Manage + Statistics shortcut cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Frontend
 
+- Landing page gains admin-only quick-access cards for `/m` (Manage) and `/s` (Statistics), shown above the gallery picker. UserMenu picks up a parallel `Statistics` entry next to the existing `Manage` one. Non-admins see no change. Discoverability fix for the global stats and admin surfaces that until now were URL-typing only from the landing.
 - Admin UI shell — `/m/*` (global) + `/m/g/<gallery>/*` (gallery-scoped) routes with placeholder sub-pages, a `Manage` tab in the title-bar context group, and a `Manage` entry in the UserMenu, all gated on `user.isAdmin`. (part of #10)
 - Public ↔ admin photo navigation closes the loop: a "Manage this photo" floating button on the public photo view (admins only, below the fullscreen button) jumps to the photo's gallery-scoped admin drawer; the admin drawer's header carries a return link back to the same photo's public view. The admin photos grid highlights the open photo's tile and auto-scrolls to the page containing it via a new `photoIdFocus` query param on `GET /api/v1/photos`. (closes #427)
 - Admin dashboard at `/m` replaces the placeholder with a grid of nav tiles (Photos / Galleries / Users), each linking to its sub-page; the UserMenu gains a "Manage" entry for admins. The global `/m/*` pages are now reachable without typing the URL or starting from a gallery's Manage pill. (closes #421)

--- a/react-app/src/components/Gallery/ListBody.tsx
+++ b/react-app/src/components/Gallery/ListBody.tsx
@@ -1,17 +1,21 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import styled from "@emotion/styled";
+import { BsBarChartLine, BsGearFill } from "react-icons/bs";
 
 import Link from "./Link";
 
 import config from "../../lib/config";
 import theme from "../../lib/theme";
+import { useUserStore } from "../../stores";
 
 import type { Gallery as GalleryT } from "../../models/GalleryModel";
 
 const Root = styled.div`
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
 `;
 const Gallery = styled.div`
   width: 214px;
@@ -21,6 +25,46 @@ const Gallery = styled.div`
   border-style: solid;
   border-width: 1px;
   background-color: var(--header-color);
+`;
+const Row = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+`;
+const ShortcutsRow = styled(Row)`
+  margin-bottom: 8px;
+`;
+const Shortcut = styled.button`
+  width: 214px;
+  min-height: 96px;
+  margin: 5px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid var(--inactive-color);
+  border-radius: 4px;
+  background: var(--primary-background);
+  color: var(--primary-color);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  &:hover {
+    background: var(--header-background);
+    color: var(--header-color);
+    border-color: var(--header-background);
+  }
+`;
+const ShortcutTitle = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: bold;
+`;
+const ShortcutBlurb = styled.div`
+  font-size: 0.85em;
+  opacity: 0.75;
+  line-height: 1.4;
 `;
 const GalleryTitle = styled("h3", {
   shouldForwardProp: (prop) => prop !== "$color" && prop !== "$background",
@@ -47,6 +91,10 @@ interface Props {
 }
 
 const ListBody = ({ galleries }: Props): React.ReactElement => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const user = useUserStore((s) => s.user);
+  const isAdmin = !!user?.isAdmin();
   const renderIcon = (gallery: GalleryT) => {
     if (!gallery.hasIcon()) {
       return "";
@@ -79,6 +127,28 @@ const ListBody = ({ galleries }: Props): React.ReactElement => {
       </Link>
     );
   };
-  return <Root>{galleries.map((gallery) => renderGallery(gallery))}</Root>;
+  return (
+    <Root>
+      {isAdmin && (
+        <ShortcutsRow>
+          <Shortcut type="button" onClick={() => navigate("/m")}>
+            <ShortcutTitle>
+              <BsGearFill aria-hidden />
+              {t("landing-shortcut-manage")}
+            </ShortcutTitle>
+            <ShortcutBlurb>{t("landing-shortcut-manage-blurb")}</ShortcutBlurb>
+          </Shortcut>
+          <Shortcut type="button" onClick={() => navigate("/s")}>
+            <ShortcutTitle>
+              <BsBarChartLine aria-hidden />
+              {t("landing-shortcut-stats")}
+            </ShortcutTitle>
+            <ShortcutBlurb>{t("landing-shortcut-stats-blurb")}</ShortcutBlurb>
+          </Shortcut>
+        </ShortcutsRow>
+      )}
+      <Row>{galleries.map((gallery) => renderGallery(gallery))}</Row>
+    </Root>
+  );
 };
 export default ListBody;

--- a/react-app/src/components/UserMenu.tsx
+++ b/react-app/src/components/UserMenu.tsx
@@ -224,6 +224,18 @@ const UserMenu = (): React.ReactElement => {
               {t("manage-menu-entry")}
             </MenuItem>
           )}
+          {user.isAdmin() && (
+            <MenuItem
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setIsOpen(false);
+                navigate("/s");
+              }}
+            >
+              {t("stats-menu-entry")}
+            </MenuItem>
+          )}
           <ThemeRow>
             <span>{t("theme-label")}</span>
             <ThemeSelect

--- a/react-app/src/lib/translations/en.json
+++ b/react-app/src/lib/translations/en.json
@@ -40,6 +40,11 @@
     "nav-context-group": "View",
 
     "manage-menu-entry": "Manage",
+    "stats-menu-entry": "Statistics",
+    "landing-shortcut-manage": "Manage",
+    "landing-shortcut-manage-blurb": "Photos, galleries, users, access — admin tools.",
+    "landing-shortcut-stats": "Statistics",
+    "landing-shortcut-stats-blurb": "Cross-gallery counts and trends.",
     "manage-nav-group": "Management",
     "manage-root": "Manage",
     "home": "Home",

--- a/react-app/src/lib/translations/fi.json
+++ b/react-app/src/lib/translations/fi.json
@@ -40,6 +40,11 @@
     "nav-context-group": "Näkymä",
 
     "manage-menu-entry": "Hallinta",
+    "stats-menu-entry": "Tilastot",
+    "landing-shortcut-manage": "Hallinta",
+    "landing-shortcut-manage-blurb": "Valokuvat, galleriat, käyttäjät, käyttöoikeudet — ylläpitotyökalut.",
+    "landing-shortcut-stats": "Tilastot",
+    "landing-shortcut-stats-blurb": "Galleriarajat ylittävät lukemat ja kehityskäyrät.",
     "manage-nav-group": "Hallinta",
     "manage-root": "Hallinta",
     "home": "Etusivu",

--- a/react-app/src/lib/translations/ja.json
+++ b/react-app/src/lib/translations/ja.json
@@ -40,6 +40,11 @@
     "nav-context-group": "表示",
 
     "manage-menu-entry": "管理",
+    "stats-menu-entry": "統計",
+    "landing-shortcut-manage": "管理",
+    "landing-shortcut-manage-blurb": "写真、ギャラリー、ユーザー、アクセス権 — 管理者ツール。",
+    "landing-shortcut-stats": "統計",
+    "landing-shortcut-stats-blurb": "ギャラリー横断の集計と推移。",
     "manage-nav-group": "管理",
     "manage-root": "管理",
     "home": "ホーム",


### PR DESCRIPTION
## Summary

Adds discoverability cards on the landing tile picker for `/m` and `/s`, plus a parallel **Statistics** entry in the UserMenu.

Before: admins reached `/m` via the UserMenu's `Manage` entry or by typing the URL; `/s` (global stats) had no entry point at all. The landing showed only gallery tiles. Non-admins are unaffected — the shortcuts are gated on `user.isAdmin()`.

## Behaviour

- `Gallery/ListBody` (the landing picker) now renders a **Shortcuts** row above the gallery tiles, with two cards:
  - **Manage** (`BsGearFill`) → `/m`.
  - **Statistics** (`BsBarChartLine`) → `/s`.
  - Each card has a short blurb hinting at what's there.
- `UserMenu` grows a **Statistics** menu item next to the existing **Manage** item. Same admin gate.

`/s` itself still 404s until the global stats page lands — this PR is the discoverability piece of #404. The cards co-exist with whatever role-aware redirect logic eventually answers #387 (the picker shows up only when redirects fall through to it).

## Code

- `Gallery/ListBody.tsx` — wraps the existing gallery list in a column; admin-only `ShortcutsRow` precedes it. Two new styled components for the shortcut card.
- `UserMenu.tsx` — second admin-gated `MenuItem` after the Manage one.
- i18n: `stats-menu-entry`, `landing-shortcut-manage`, `landing-shortcut-manage-blurb`, `landing-shortcut-stats`, `landing-shortcut-stats-blurb` across en / fi / ja.

## Test plan

- [x] `npm run typecheck` + `npm run lint` + `npm test` clean (react-app).
- [x] Smoke as admin: visit `/g` → see two cards above the gallery tiles. Click Manage → `/m`. Click Statistics → `/s` (will currently show empty / 404 until the global stats page ships).
- [x] Smoke as non-admin: visit `/g` → no shortcut row, gallery tiles render as before. UserMenu has no new entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)