### PR TITLE
Global Statistics at /s (part of #404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Frontend
 
+- Global Statistics page at `/s` — admin-only, aggregates every photo in the catalogue (paginated fetch under the existing `/api/v1/photos` endpoint) through the same Stats / Filters UI the per-gallery `/s/<gallery>` view uses. The shared `uniqueValues` build moves out of `Gallery/index.tsx` into `lib/uniqueValues.ts` so the two pages can't drift. (part of #404)
 - Landing page gains admin-only quick-access cards for `/m` (Manage) and `/s` (Statistics), shown above the gallery picker. UserMenu picks up a parallel `Statistics` entry next to the existing `Manage` one. Non-admins see no change. Discoverability fix for the global stats and admin surfaces that until now were URL-typing only from the landing.
 - Admin UI shell — `/m/*` (global) + `/m/g/<gallery>/*` (gallery-scoped) routes with placeholder sub-pages, a `Manage` tab in the title-bar context group, and a `Manage` entry in the UserMenu, all gated on `user.isAdmin`. (part of #10)
 - Public ↔ admin photo navigation closes the loop: a "Manage this photo" floating button on the public photo view (admins only, below the fullscreen button) jumps to the photo's gallery-scoped admin drawer; the admin drawer's header carries a return link back to the same photo's public view. The admin photos grid highlights the open photo's tile and auto-scrolls to the page containing it via a new `photoIdFocus` query param on `GET /api/v1/photos`. (closes #427)

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -31,6 +31,7 @@ import ManageGroupEdit from "./components/Manage/GroupEdit";
 import ManageGroupCreate from "./components/Manage/GroupCreate";
 import ManageGalleryAccess from "./components/Manage/GalleryAccess";
 import ManageAccess from "./components/Manage/Access";
+import GlobalStats from "./components/GlobalStats";
 import Notifications from "./components/Notifications";
 import LoginModal from "./components/LoginModal";
 import ChangePasswordModal from "./components/ChangePasswordModal";
@@ -119,6 +120,7 @@ const App = (): React.ReactElement => {
                 path="/s/:galleryId"
                 element={<Gallery isStats={true} />}
               />
+              <Route path="/s" element={<GlobalStats />} />
               <Route
                 path="/g/:galleryId/:year/:month/:day/:photoId"
                 element={<Gallery />}

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -27,10 +27,8 @@ import collection from "../../lib/collection";
 import config from "../../lib/config";
 import format from "../../lib/format";
 import { galleriesForHost } from "../../lib/host-scope";
-import stats, {
-  type UniqueValues,
-  type UniqueValueEntry,
-} from "../../lib/stats";
+import stats, { type UniqueValues } from "../../lib/stats";
+import { buildUniqueValues } from "../../lib/uniqueValues";
 import theme from "../../lib/theme";
 
 import {
@@ -154,65 +152,7 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
   // Recomputes on language change too — display values are localised.
   const uniqueValues = React.useMemo<UniqueValues | undefined>(() => {
     if (!photos || !countryData) return undefined;
-    const accumulator: Record<string, Record<string, Set<unknown>>> = photos
-      .map((photo) => photo.uniqueValues())
-      .reduce(
-        collection.mergeObjects<unknown>(
-          (a, b) => new Set([...a, ...b]) as Set<unknown>
-        ),
-        {}
-      ) as Record<string, Record<string, Set<unknown>>>;
-    const categoryValueFormatter = format.categoryValue(lang, t, countryData);
-    const formatCountryName = format.countryName(lang, countryData);
-    const flattened: UniqueValues = {} as UniqueValues;
-    Object.keys(accumulator).forEach((topic) => {
-      const topicBag: Record<string, UniqueValueEntry[]> = {};
-      Object.keys(accumulator[topic]).forEach((category) => {
-        const cityLocalizedByKey: Record<string, string> =
-          category === "city"
-            ? photos.reduce<Record<string, string>>((acc, photo) => {
-                const k = photo.geocodedCityKey();
-                const v = photo.geocodedCity();
-                if (k && v && !acc[k]) acc[k] = v;
-                return acc;
-              }, {})
-            : {};
-        const cityLabels =
-          category === "city"
-            ? format.buildCityLabels(
-                [...accumulator[topic][category]].filter(
-                  (v): v is string => typeof v === "string" && !!v
-                ),
-                lang,
-                formatCountryName,
-                cityLocalizedByKey
-              )
-            : null;
-        topicBag[category] = [...accumulator[topic][category]]
-          .map((value) => {
-            if (value === "" || value === undefined || value === null) {
-              return {
-                key: stats.UNKNOWN,
-                value: String(t("stats-unknown")),
-              };
-            }
-            if (cityLabels) {
-              return {
-                key: value as string,
-                value: cityLabels[value as string] ?? String(value),
-              };
-            }
-            return {
-              key: value as string | number,
-              value: categoryValueFormatter(category)(value),
-            };
-          })
-          .sort(format.categorySorter("key", "value")(category));
-      });
-      (flattened as Record<string, Record<string, UniqueValueEntry[]>>)[topic] =
-        topicBag;
-    });
-    return flattened;
+    return buildUniqueValues(photos, lang, t, countryData);
   }, [photos, lang, t, countryData]);
 
   const gallery = React.useMemo<GalleryT | undefined>(() => {

--- a/react-app/src/components/GlobalStats/index.tsx
+++ b/react-app/src/components/GlobalStats/index.tsx
@@ -1,0 +1,177 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import styled from "@emotion/styled";
+import { Global, css } from "@emotion/react";
+import { useQuery } from "@tanstack/react-query";
+import { BsHouseFill, BsBarChartLine } from "react-icons/bs";
+
+import Filters from "../Gallery/Filters";
+import Stats from "../Gallery/Stats";
+import PhotoModel, { type Photo as PhotoT } from "../../models/PhotoModel";
+import photosService from "../../services/photos";
+import theme from "../../lib/theme";
+import { type UniqueValues } from "../../lib/stats";
+import { buildUniqueValues } from "../../lib/uniqueValues";
+import config from "../../lib/config";
+import {
+  useFiltersStore,
+  useLangStore,
+  useThemePreferenceStore,
+  useUserStore,
+} from "../../stores";
+
+type ActiveTheme = ReturnType<typeof theme.setTheme>;
+
+const globalStyles = (active: ActiveTheme) => css`
+  html {
+    --primary-color: ${active.get("primary-color")};
+    --primary-background: ${active.get("primary-background")};
+    --inactive-color: ${active.get("inactive-color")};
+    --header-color: ${active.get("header-color")};
+    --header-sub-color: ${active.get("header-sub-color")};
+    --header-background: ${active.get("header-background")};
+    --tile-background: ${active.get("tile-background")};
+    --photo-frame-mat: ${active.get("photo-frame-mat")};
+    --photo-frame-border: ${active.get("photo-frame-border")};
+    filter: ${active.get("filter")};
+  }
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 5px;
+  min-height: 44px;
+`;
+const HomeLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  color: inherit;
+  text-decoration: none;
+`;
+const Separator = styled.span`
+  opacity: 0.55;
+`;
+const Crumb = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+`;
+const Notice = styled.div`
+  padding: 16px;
+  font-style: italic;
+  color: var(--inactive-color);
+`;
+
+// All-photos fetch is paginated under /api/v1/photos's existing
+// admin endpoint. pageSize is the server's maximum (500). The
+// queryFn loops over pages until the full set is in hand — fine
+// for current catalogue sizes; if the global instance ever grows
+// past tens of thousands the server-side stats aggregation in
+// #286 supersedes this.
+const PAGE_SIZE = 500;
+
+const fetchAllPhotos = async (): Promise<PhotoT[]> => {
+  const first = await photosService.list({}, 1, PAGE_SIZE);
+  const raw = [...first.photos];
+  const totalPages = Math.max(1, Math.ceil(first.total / PAGE_SIZE));
+  for (let page = 2; page <= totalPages; page++) {
+    const next = await photosService.list({}, page, PAGE_SIZE);
+    raw.push(...next.photos);
+  }
+  return raw
+    .map((photo) => PhotoModel(photo))
+    .filter((p): p is PhotoT => !!p);
+};
+
+const GlobalStats = (): React.ReactElement => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const user = useUserStore((s) => s.user);
+  const lang = useLangStore((s) => s.lang);
+  const countryData = useLangStore((s) => s.countryData);
+  const filters = useFiltersStore((s) => s.filters);
+  const setFilters = useFiltersStore((s) => s.setFilters);
+  const themePreference = useThemePreferenceStore((s) => s.preference);
+
+  const activeTheme = themePreference
+    ? theme.setTheme(themePreference)
+    : theme.setTheme(config.DEFAULT_THEME);
+
+  const photosQuery = useQuery({
+    queryKey: ["global-stats-photos", user?.id ?? null],
+    queryFn: fetchAllPhotos,
+    enabled: !!user?.isAdmin(),
+  });
+
+  const photos = photosQuery.data;
+  const uniqueValues = React.useMemo<UniqueValues | undefined>(() => {
+    if (!photos || !countryData) return undefined;
+    return buildUniqueValues(photos, lang, t, countryData);
+  }, [photos, lang, t, countryData]);
+
+  const frame = (body: React.ReactNode): React.ReactElement => (
+    <>
+      <Global styles={globalStyles(activeTheme)} />
+      <Header aria-label={String(t("stats-global-nav-group"))}>
+        <HomeLink
+          onClick={() => navigate("/")}
+          title={String(t("home"))}
+          role="link"
+          tabIndex={0}
+        >
+          <BsHouseFill aria-hidden />
+        </HomeLink>
+        <Separator>›</Separator>
+        <Crumb>
+          <BsBarChartLine aria-hidden />
+          <span>{t("stats-global-title")}</span>
+        </Crumb>
+      </Header>
+      {body}
+    </>
+  );
+
+  if (!user) {
+    return frame(<Notice>{t("manage-not-logged-in")}</Notice>);
+  }
+  if (!user.isAdmin()) {
+    return frame(<Notice>{t("manage-not-admin")}</Notice>);
+  }
+  if (!countryData || photosQuery.isLoading || !photos || !uniqueValues) {
+    return frame(<Notice>{t("loading")}</Notice>);
+  }
+  if (photosQuery.isError) {
+    return frame(<Notice>{t("stats-global-load-error")}</Notice>);
+  }
+  if (photos.length === 0) {
+    return frame(<Notice>{t("stats-global-empty")}</Notice>);
+  }
+
+  return frame(
+    <Stats
+      photos={photos}
+      uniqueValues={uniqueValues}
+      filters={filters}
+      setFilters={setFilters}
+      lang={lang}
+      countryData={countryData}
+      theme={activeTheme}
+      hideMap={false}
+    >
+      <Filters
+        filters={filters}
+        setFilters={setFilters}
+        uniqueValues={uniqueValues}
+        lang={lang}
+        countryData={countryData}
+        hideMap={false}
+      />
+    </Stats>
+  );
+};
+
+export default GlobalStats;

--- a/react-app/src/lib/translations/en.json
+++ b/react-app/src/lib/translations/en.json
@@ -41,6 +41,10 @@
 
     "manage-menu-entry": "Manage",
     "stats-menu-entry": "Statistics",
+    "stats-global-title": "Statistics",
+    "stats-global-nav-group": "Global stats",
+    "stats-global-load-error": "Failed to load photos.",
+    "stats-global-empty": "No photos in the catalogue yet.",
     "landing-shortcut-manage": "Manage",
     "landing-shortcut-manage-blurb": "Photos, galleries, users, access — admin tools.",
     "landing-shortcut-stats": "Statistics",

--- a/react-app/src/lib/translations/fi.json
+++ b/react-app/src/lib/translations/fi.json
@@ -41,6 +41,10 @@
 
     "manage-menu-entry": "Hallinta",
     "stats-menu-entry": "Tilastot",
+    "stats-global-title": "Tilastot",
+    "stats-global-nav-group": "Globaalit tilastot",
+    "stats-global-load-error": "Valokuvien lataus epäonnistui.",
+    "stats-global-empty": "Katalogissa ei ole vielä valokuvia.",
     "landing-shortcut-manage": "Hallinta",
     "landing-shortcut-manage-blurb": "Valokuvat, galleriat, käyttäjät, käyttöoikeudet — ylläpitotyökalut.",
     "landing-shortcut-stats": "Tilastot",

--- a/react-app/src/lib/translations/ja.json
+++ b/react-app/src/lib/translations/ja.json
@@ -41,6 +41,10 @@
 
     "manage-menu-entry": "管理",
     "stats-menu-entry": "統計",
+    "stats-global-title": "統計",
+    "stats-global-nav-group": "全体統計",
+    "stats-global-load-error": "写真の読み込みに失敗しました。",
+    "stats-global-empty": "カタログにまだ写真がありません。",
     "landing-shortcut-manage": "管理",
     "landing-shortcut-manage-blurb": "写真、ギャラリー、ユーザー、アクセス権 — 管理者ツール。",
     "landing-shortcut-stats": "統計",

--- a/react-app/src/lib/uniqueValues.ts
+++ b/react-app/src/lib/uniqueValues.ts
@@ -1,0 +1,86 @@
+import type { TFunction } from "i18next";
+
+import collection from "./collection";
+import format from "./format";
+import stats, {
+  type UniqueValueEntry,
+  type UniqueValues,
+} from "./stats";
+
+import type { Photo as PhotoT } from "../models/PhotoModel";
+
+interface CountryData {
+  getName(code: string, lang: string): string | undefined;
+}
+
+// Build the per-topic / per-category UniqueValues bag the stats UI
+// consumes. Pure transform: in → photos, lang, t, countryData;
+// out → UniqueValues. The per-gallery `/g/<id>/...` and the global
+// `/s` view both build the same shape over their respective photo
+// arrays, so the logic stays in one place.
+export const buildUniqueValues = (
+  photos: PhotoT[],
+  lang: string,
+  t: TFunction,
+  countryData: CountryData
+): UniqueValues => {
+  const accumulator: Record<string, Record<string, Set<unknown>>> = photos
+    .map((photo) => photo.uniqueValues())
+    .reduce(
+      collection.mergeObjects<unknown>(
+        (a, b) => new Set([...a, ...b]) as Set<unknown>
+      ),
+      {}
+    ) as Record<string, Record<string, Set<unknown>>>;
+  const categoryValueFormatter = format.categoryValue(lang, t, countryData);
+  const formatCountryName = format.countryName(lang, countryData);
+  const flattened: UniqueValues = {} as UniqueValues;
+  Object.keys(accumulator).forEach((topic) => {
+    const topicBag: Record<string, UniqueValueEntry[]> = {};
+    Object.keys(accumulator[topic]).forEach((category) => {
+      const cityLocalizedByKey: Record<string, string> =
+        category === "city"
+          ? photos.reduce<Record<string, string>>((acc, photo) => {
+              const k = photo.geocodedCityKey();
+              const v = photo.geocodedCity();
+              if (k && v && !acc[k]) acc[k] = v;
+              return acc;
+            }, {})
+          : {};
+      const cityLabels =
+        category === "city"
+          ? format.buildCityLabels(
+              [...accumulator[topic][category]].filter(
+                (v): v is string => typeof v === "string" && !!v
+              ),
+              lang,
+              formatCountryName,
+              cityLocalizedByKey
+            )
+          : null;
+      topicBag[category] = [...accumulator[topic][category]]
+        .map((value) => {
+          if (value === "" || value === undefined || value === null) {
+            return {
+              key: stats.UNKNOWN,
+              value: String(t("stats-unknown")),
+            };
+          }
+          if (cityLabels) {
+            return {
+              key: value as string,
+              value: cityLabels[value as string] ?? String(value),
+            };
+          }
+          return {
+            key: value as string | number,
+            value: categoryValueFormatter(category)(value),
+          };
+        })
+        .sort(format.categorySorter("key", "value")(category));
+    });
+    (flattened as Record<string, Record<string, UniqueValueEntry[]>>)[topic] =
+      topicBag;
+  });
+  return flattened;
+};


### PR DESCRIPTION
## Summary

Closes the destination side of the discoverability cards from #442. `/s` (no gallery id) is admin-only and renders the existing per-gallery Stats UI over every photo in the catalogue.

## Behaviour

- Admin gate: non-logged-in users see "Sign in to access management"; non-admins see "no permission". Same notice pattern as `/m`.
- Loading state shows the same "Loading…" notice the rest of the app uses.
- Stats body identical to `/s/<gallery>` — same topic cards, same Filters sidebar, same map (with `hideMap: false` since admins see everything).
- Minimal header: 🏠 › 📊 Statistics. No gallery selector, no Gallery / Stats / Manage toggle (none of those make sense without a gallery).

## Data path

`fetchAllPhotos` loops the existing admin `/api/v1/photos` endpoint at `pageSize: 500` until `total` is covered. For current catalogue sizes that's one fetch in practice. Server-side aggregation (#286) is the right move once the catalogue outgrows a single page.

## Shared `uniqueValues` build

Per-gallery and global views construct the same `UniqueValues` bag. The 60-line builder lived inline in `Gallery/index.tsx`; pulled to `lib/uniqueValues.ts` so the two callers can't drift. `Gallery/index.tsx` now calls `buildUniqueValues(photos, lang, t, countryData)`.

## Out of scope (next #404 sub-PR)

The **Galleries topic** — a card showing photo count per gallery with click-to-drill into `/s/<id>`. Needs either a small `galleryIds: string[]` join on the photo response or a dedicated `/api/v1/stats/gallery-counts` endpoint. Filing as a follow-up.

## Test plan

- [x] `npm run typecheck` + `npm run lint` + `npm test` clean (react-app). 977/977.
- [x] Smoke as admin: click the Statistics card on the landing → `/s` loads the same Stats UI as a per-gallery view, populated from every photo in the catalogue. Filters work. Map renders with every geotagged photo.
- [ ] Smoke as non-admin: visit `/s` directly → "no permission" notice; no fetch.
- [ ] Smoke on a fresh / empty instance: `/s` shows the empty notice instead of the Stats UI.
- [ ] Per-gallery `/s/<id>` still works — uniqueValues comes from the same helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)