### PR TITLE
Global stats: Galleries section with click-to-drill (#444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Frontend
 
+- Global Statistics page gains a Galleries section at the top — one row per gallery showing photo count + share, plus an "(no gallery)" row for orphans; clicking a row drills into that gallery's per-gallery stats at `/s/<id>`. `/api/v1/photos` now attaches each photo's gallery memberships to the response so the count is computed client-side without a second fetch. (closes #444)
 - Per-gallery stats title bar gains a `Statistics` breadcrumb between Home and the gallery dropdown for admins, linking back to `/s` (global stats). Without it, the Galleries-section drill from `/s` into `/s/<gallery>` was a one-way trip. Non-admins are unchanged. (closes #447)
 - Global Statistics page at `/s` — admin-only, aggregates every photo in the catalogue (paginated fetch under the existing `/api/v1/photos` endpoint) through the same Stats / Filters UI the per-gallery `/s/<gallery>` view uses. The shared `uniqueValues` build moves out of `Gallery/index.tsx` into `lib/uniqueValues.ts` so the two pages can't drift. (part of #404)
 - Landing page gains admin-only quick-access cards for `/m` (Manage) and `/s` (Statistics), shown above the gallery picker. UserMenu picks up a parallel `Statistics` entry next to the existing `Manage` one. Non-admins see no change. Discoverability fix for the global stats and admin surfaces that until now were URL-typing only from the landing.

--- a/react-app/src/components/GlobalStats/Galleries.tsx
+++ b/react-app/src/components/GlobalStats/Galleries.tsx
@@ -1,0 +1,195 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import styled from "@emotion/styled";
+
+import format from "../../lib/format";
+import type { Photo as PhotoT } from "../../models/PhotoModel";
+
+interface Gallery {
+  id: string;
+  [key: string]: unknown;
+}
+
+interface Props {
+  photos: PhotoT[];
+  galleries: Gallery[];
+  lang: string;
+}
+
+const Root = styled.section`
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: stretch;
+  margin-bottom: 8px;
+`;
+const Title = styled.h3`
+  text-align: left;
+  writing-mode: vertical-rl;
+  color: var(--header-color);
+  background: var(--header-background);
+  font-size: 18pt;
+  margin: 1px;
+  padding: 5px 3px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: var(--header-background);
+  border-radius: 10px 0;
+`;
+const Body = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
+  gap: 2px;
+  align-content: start;
+  min-width: 0;
+`;
+const Tile = styled.div`
+  margin: 0 0 2px;
+  min-width: 0;
+`;
+const TileTitle = styled.h3`
+  color: var(--header-color);
+  background: var(--header-background);
+  font-size: 18pt;
+  text-align: center;
+  margin: 1px;
+  padding: 5px 3px;
+  border-style: solid;
+  border-width: 1px;
+  border-color: var(--header-background);
+  border-radius: 5px;
+`;
+const Table = styled.table`
+  width: 100%;
+  text-align: left;
+  margin: 0;
+  padding: 0;
+  font-size: small;
+  border-spacing: 0;
+  border-collapse: collapse;
+`;
+const Row = styled.tr`
+  cursor: pointer;
+  &:hover {
+    color: var(--header-color);
+    background-color: var(--header-background);
+  }
+`;
+const RowOrphan = styled(Row)`
+  color: var(--inactive-color);
+  font-style: italic;
+`;
+const Cell = styled("td", {
+  shouldForwardProp: (prop) => prop !== "$align",
+})<{ $align: "left" | "right" }>`
+  padding: 0 2px;
+  vertical-align: top;
+  text-align: ${(props) => props.$align};
+  overflow: hidden;
+  overflow-wrap: anywhere;
+`;
+const RankCell = styled("th", {
+  shouldForwardProp: (prop) => prop !== "$align",
+})<{ $align: "left" | "right" }>`
+  font-weight: bold;
+  padding: 0 2px;
+  vertical-align: top;
+  text-align: ${(props) => props.$align};
+  width: 1em;
+`;
+
+const Galleries = ({
+  photos,
+  galleries,
+  lang,
+}: Props): React.ReactElement | null => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const formatNumber = format.number(lang);
+
+  const titleById = React.useMemo(() => {
+    const m = new Map<string, string>();
+    for (const g of galleries) {
+      const title = typeof g.title === "string" ? g.title : g.id;
+      m.set(g.id, title);
+    }
+    return m;
+  }, [galleries]);
+
+  const { rows, orphanCount, total } = React.useMemo(() => {
+    const counts = new Map<string, number>();
+    let orphans = 0;
+    for (const photo of photos) {
+      const ids = photo.galleries();
+      if (ids.length === 0) {
+        orphans++;
+        continue;
+      }
+      for (const id of ids) {
+        counts.set(id, (counts.get(id) ?? 0) + 1);
+      }
+    }
+    const collator = new Intl.Collator(lang, { sensitivity: "base" });
+    const ranked = [...counts.entries()]
+      .map(([id, count]) => ({
+        id,
+        count,
+        title: titleById.get(id) ?? id,
+      }))
+      .sort((a, b) => b.count - a.count || collator.compare(a.title, b.title));
+    return { rows: ranked, orphanCount: orphans, total: photos.length };
+  }, [photos, titleById, lang]);
+
+  if (rows.length === 0 && orphanCount === 0) {
+    return null;
+  }
+
+  return (
+    <Root>
+      <Title>{t("stats-topic-galleries")}</Title>
+      <Body>
+        <Tile>
+          <TileTitle>{t("stats-category-gallery")}</TileTitle>
+          <Table>
+            <tbody>
+              {rows.map((row, i) => (
+                <Row
+                  key={row.id}
+                  onClick={() => navigate(`/s/${encodeURIComponent(row.id)}`)}
+                >
+                  <RankCell $align="right">
+                    {formatNumber.default(i + 1)}
+                  </RankCell>
+                  <Cell $align="left">{row.title}</Cell>
+                  <Cell $align="right">{formatNumber.default(row.count)}</Cell>
+                  <Cell $align="right">
+                    {`${formatNumber.oneDecimal(
+                      format.share(row.count, total)
+                    )}%`}
+                  </Cell>
+                </Row>
+              ))}
+              {orphanCount > 0 ? (
+                <RowOrphan>
+                  <RankCell $align="right">{""}</RankCell>
+                  <Cell $align="left">{t("stats-galleries-orphans")}</Cell>
+                  <Cell $align="right">
+                    {formatNumber.default(orphanCount)}
+                  </Cell>
+                  <Cell $align="right">
+                    {`${formatNumber.oneDecimal(
+                      format.share(orphanCount, total)
+                    )}%`}
+                  </Cell>
+                </RowOrphan>
+              ) : null}
+            </tbody>
+          </Table>
+        </Tile>
+      </Body>
+    </Root>
+  );
+};
+
+export default Galleries;

--- a/react-app/src/components/GlobalStats/index.tsx
+++ b/react-app/src/components/GlobalStats/index.tsx
@@ -8,8 +8,10 @@ import { BsHouseFill, BsBarChartLine } from "react-icons/bs";
 
 import Filters from "../Gallery/Filters";
 import Stats from "../Gallery/Stats";
+import Galleries from "./Galleries";
 import PhotoModel, { type Photo as PhotoT } from "../../models/PhotoModel";
 import photosService from "../../services/photos";
+import galleriesService from "../../services/galleries";
 import theme from "../../lib/theme";
 import { type UniqueValues } from "../../lib/stats";
 import { buildUniqueValues } from "../../lib/uniqueValues";
@@ -106,8 +108,14 @@ const GlobalStats = (): React.ReactElement => {
     queryFn: fetchAllPhotos,
     enabled: !!user?.isAdmin(),
   });
+  const galleriesQuery = useQuery({
+    queryKey: ["global-stats-galleries", user?.id ?? null],
+    queryFn: () => galleriesService.getAll(),
+    enabled: !!user?.isAdmin(),
+  });
 
   const photos = photosQuery.data;
+  const galleries = galleriesQuery.data ?? [];
   const uniqueValues = React.useMemo<UniqueValues | undefined>(() => {
     if (!photos || !countryData) return undefined;
     return buildUniqueValues(photos, lang, t, countryData);
@@ -152,25 +160,28 @@ const GlobalStats = (): React.ReactElement => {
   }
 
   return frame(
-    <Stats
-      photos={photos}
-      uniqueValues={uniqueValues}
-      filters={filters}
-      setFilters={setFilters}
-      lang={lang}
-      countryData={countryData}
-      theme={activeTheme}
-      hideMap={false}
-    >
-      <Filters
+    <>
+      <Galleries photos={photos} galleries={galleries} lang={lang} />
+      <Stats
+        photos={photos}
+        uniqueValues={uniqueValues}
         filters={filters}
         setFilters={setFilters}
-        uniqueValues={uniqueValues}
         lang={lang}
         countryData={countryData}
+        theme={activeTheme}
         hideMap={false}
-      />
-    </Stats>
+      >
+        <Filters
+          filters={filters}
+          setFilters={setFilters}
+          uniqueValues={uniqueValues}
+          lang={lang}
+          countryData={countryData}
+          hideMap={false}
+        />
+      </Stats>
+    </>
   );
 };
 

--- a/react-app/src/lib/translations/en.json
+++ b/react-app/src/lib/translations/en.json
@@ -407,6 +407,10 @@
     "stats-year-month": "{{month}} {{year}}",
     "stats-per-day": "{{count}}/day",
 
+    "stats-topic-galleries": "Galleries",
+    "stats-category-gallery": "Gallery",
+    "stats-galleries-orphans": "(no gallery)",
+
     "stats-topic-general": "General",
     "stats-category-summary": "Summary",
     "stats-category-author": "Author",

--- a/react-app/src/lib/translations/fi.json
+++ b/react-app/src/lib/translations/fi.json
@@ -407,6 +407,10 @@
     "stats-year-month": "{{month}} {{year}}",
     "stats-per-day": "{{count}}/päivä",
 
+    "stats-topic-galleries": "Galleriat",
+    "stats-category-gallery": "Galleria",
+    "stats-galleries-orphans": "(ei galleriaa)",
+
     "stats-topic-general": "Yleiset tiedot",
     "stats-category-summary": "Yhteenveto",
     "stats-category-author": "Valokuvaaja",

--- a/react-app/src/lib/translations/ja.json
+++ b/react-app/src/lib/translations/ja.json
@@ -407,6 +407,10 @@
     "stats-year-month": "{{year}}年{{month}}",
     "stats-per-day": "{{count}}枚／日",
 
+    "stats-topic-galleries": "ギャラリー",
+    "stats-category-gallery": "ギャラリー",
+    "stats-galleries-orphans": "（ギャラリー未所属）",
+
     "stats-topic-general": "一般",
     "stats-category-summary": "まとめ",
     "stats-category-author": "撮影者",

--- a/react-app/src/models/PhotoModel.ts
+++ b/react-app/src/models/PhotoModel.ts
@@ -72,6 +72,7 @@ export interface PhotoData {
   lens?: Gear;
   exposure?: Exposure;
   geocoded?: Geocoded;
+  galleries?: string[];
 }
 
 interface CountryData {
@@ -124,6 +125,7 @@ const PhotoModel = (photoData: unknown) => {
     title: (): string | undefined => photo.title,
     description: (): string | undefined => photo.description,
     author: (): string | undefined => photo.taken.author,
+    galleries: (): string[] => photo.galleries ?? [],
 
     ymd: (): [number, number, number] => [self.year(), self.month(), self.day()],
     year: (): number => photo.taken.instant.year,

--- a/server/models/photo.ts
+++ b/server/models/photo.ts
@@ -95,8 +95,12 @@ const listPhotos = async (opts: ListOptions = {}): Promise<ListResult> => {
     if (idx >= 0) effectivePage = Math.floor(idx / pageSize) + 1;
   }
   const result = paginate(sorted, effectivePage, pageSize);
+  const decorated = result.items.map((p) => ({
+    ...p,
+    galleries: Array.from(galleryMembers.get(p.id) ?? []),
+  }));
   return {
-    photos: result.items,
+    photos: decorated,
     page: result.page,
     pageSize: result.pageSize,
     total: result.total,


### PR DESCRIPTION
## Summary

Adds a Galleries section to the top of the global stats page at `/s`. One row per gallery shows photo count + share, plus an "(no gallery)" row when orphans exist. Clicking a row navigates to that gallery's own stats at `/s/<galleryId>`, so the operator can drop from the catalogue-wide aggregate straight into the per-gallery view that's already there.

The data plumbing follows option 1 from #444: the existing `/api/v1/photos` endpoint now decorates each response photo with a `galleries: string[]` field listing the real gallery IDs it belongs to. The panel counts client-side off the same fetch the existing global stats already issues. No extra HTTP round-trip. `PhotoModel` exposes the field via a new `.galleries()` accessor; the server-side gallery membership Map was already built for filter evaluation, so the decoration is a Map lookup per response row — the payload delta is just the membership arrays themselves.

The Galleries section deliberately lives outside the filter-aware Stats pipeline for this first cut. Counts are absolute over the full catalogue and don't recompose when the operator narrows via the Filters sidebar. Pulling them into the topic pipeline (with filter composition) is a sizeable change to `lib/stats.tsx` and to the row-click semantics — every existing topic row toggles a filter, not navigates — and is out of scope here. The drill affordance is more useful as a navigation than as a filter chip for this view, so the trade reads cleanly.

i18n keys added across en / fi / ja: `stats-topic-galleries`, `stats-category-gallery`, `stats-galleries-orphans`.

## Test plan

- [x] `/s` as admin: Galleries section renders above the existing topic cards, one row per gallery with title / count / share.
- [ ] Row sort: count desc, ties broken by title in the active locale's collation.
- [ ] Click a gallery row → navigates to `/s/<galleryId>` and renders that gallery's per-gallery stats.
- [ ] Orphans row appears only when at least one photo has no gallery memberships; styled inactive / italic.
- [ ] Gallery titles localise correctly when set; falls back to the gallery id when title is empty.
- [ ] Non-admin visiting `/s` still sees the existing "not admin" notice (Galleries panel doesn't render).
- [ ] Empty catalogue still shows the existing empty notice; Galleries panel doesn't render.
- [ ] `/api/v1/photos` response now carries `galleries: string[]` per photo — existing callers (admin photos page, drawer) keep working since the field is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)