### PR TITLE
Per-gallery stats: back-link to /s for admins (#447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Frontend
 
+- Per-gallery stats title bar gains a `Statistics` breadcrumb between Home and the gallery dropdown for admins, linking back to `/s` (global stats). Without it, the Galleries-section drill from `/s` into `/s/<gallery>` was a one-way trip. Non-admins are unchanged. (closes #447)
 - Global Statistics page at `/s` — admin-only, aggregates every photo in the catalogue (paginated fetch under the existing `/api/v1/photos` endpoint) through the same Stats / Filters UI the per-gallery `/s/<gallery>` view uses. The shared `uniqueValues` build moves out of `Gallery/index.tsx` into `lib/uniqueValues.ts` so the two pages can't drift. (part of #404)
 - Landing page gains admin-only quick-access cards for `/m` (Manage) and `/s` (Statistics), shown above the gallery picker. UserMenu picks up a parallel `Statistics` entry next to the existing `Manage` one. Non-admins see no change. Discoverability fix for the global stats and admin surfaces that until now were URL-typing only from the landing.
 - Admin UI shell — `/m/*` (global) + `/m/g/<gallery>/*` (gallery-scoped) routes with placeholder sub-pages, a `Manage` tab in the title-bar context group, and a `Manage` entry in the UserMenu, all gated on `user.isAdmin`. (part of #10)

--- a/react-app/src/components/Gallery/Title.tsx
+++ b/react-app/src/components/Gallery/Title.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { Link as RouterLink, useNavigate } from "react-router-dom";
 import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
 import { BsFillHouseFill, BsChevronRight, BsMap } from "react-icons/bs";
@@ -351,6 +351,14 @@ const Title = ({
           <BsFillHouseFill />
         </HomeLink>
         <Separator aria-hidden="true" />
+        {context === "stats" && showManage && (
+          <>
+            <LinkCrumb>
+              <RouterLink to="/s">{t("stats-global-title")}</RouterLink>
+            </LinkCrumb>
+            <Separator aria-hidden="true" />
+          </>
+        )}
         {renderGalleryCrumb()}
         {year !== undefined && (
           <>


### PR DESCRIPTION
## Summary

Per-gallery stats at `/s/<gallery>` had no breadcrumb path back to the catalogue-wide `/s` page, so once an admin drilled in from the Galleries section added in #445, they had to type the URL or go via the landing page to return.

Insert a `Statistics` link crumb between the Home icon and the gallery dropdown in `Gallery/Title.tsx`, gated on `context === "stats"` AND `user.isAdmin`. The crumb reuses the existing `stats-global-title` translation across en / fi / ja. Non-admins see no change.

Manage (`/m/g/<gallery>/*`) already has an analogous `Manage` link crumb that points back to `/m`, so no change needed there.

## Test plan

- [x] Admin on `/s/<gallery>` sees `🏠 › Statistics › <Gallery> › …`, with `Statistics` linking to `/s`.
- [x] Non-admin on `/s/<gallery>` sees the existing `🏠 › <Gallery> › …` chain (no `Statistics` crumb).
- [x] Admin on `/g/<gallery>/...` (gallery view, not stats) sees the original chain — the extra crumb is stats-only.
- [x] Click the `Statistics` crumb → navigates to `/s` (global stats).
- [x] Gallery dropdown still works (switching galleries from per-gallery stats stays in the stats context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)