### PR TITLE
Admin lists: sensible order for theme picker + gallery facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Frontend
 
+- Gallery editor theme picker now mirrors the user-menu picker: grouped by category (Coloured / Neutral / Dark / Statement) in canonical manifest order, with each option labelled by display name rather than the raw enum id. The hardcoded arbitrary order is gone; both pickers now read the same `theme.manifest`. Admin photos page's gallery facet + bulk picker also sorts galleries by visible title (not server's id order), since the operator sees titles, not slugs.
 - Global Statistics page gains a Galleries section at the top — one row per gallery showing photo count + share, plus an "(no gallery)" row for orphans; clicking a row drills into that gallery's per-gallery stats at `/s/<id>`. `/api/v1/photos` now attaches each photo's gallery memberships to the response so the count is computed client-side without a second fetch. (closes #444)
 - Per-gallery stats title bar gains a `Statistics` breadcrumb between Home and the gallery dropdown for admins, linking back to `/s` (global stats). Without it, the Galleries-section drill from `/s` into `/s/<gallery>` was a one-way trip. Non-admins are unchanged. (closes #447)
 - Global Statistics page at `/s` — admin-only, aggregates every photo in the catalogue (paginated fetch under the existing `/api/v1/photos` endpoint) through the same Stats / Filters UI the per-gallery `/s/<gallery>` view uses. The shared `uniqueValues` build moves out of `Gallery/index.tsx` into `lib/uniqueValues.ts` so the two pages can't drift. (part of #404)

--- a/react-app/src/components/Manage/GalleryForm.tsx
+++ b/react-app/src/components/Manage/GalleryForm.tsx
@@ -8,25 +8,12 @@ import {
   type InitialView,
   type Theme,
 } from "../../services/galleries";
+import theme, { THEME_CATEGORIES, type ThemeCategory } from "../../lib/theme";
 
 // Enum values must mirror server's GalleryUpdateBody. Kept inline
 // rather than importing from api-schema so the dropdowns don't
 // silently lose values if the typegen output rearranges.
 const EPOCH_TYPES: EpochType[] = ["birthday", "1-index", "0-index"];
-const THEMES: Theme[] = [
-  "blue",
-  "red",
-  "grayscale",
-  "contrast",
-  "alert",
-  "dark",
-  "amoled",
-  "forest",
-  "silver",
-  "showcase",
-  "teal",
-  "paper",
-];
 const INITIAL_VIEWS: InitialView[] = ["year", "month", "day", "photo"];
 
 export interface FormState {
@@ -193,11 +180,24 @@ const GalleryFormFields = ({ form, setField }: Props): React.ReactElement => {
             onChange={(e) => setField("theme", e.target.value)}
           >
             <option value="">{t("manage-gallery-enum-default")}</option>
-            {THEMES.map((th) => (
-              <option key={th} value={th}>
-                {th}
-              </option>
-            ))}
+            {THEME_CATEGORIES.map((category: ThemeCategory) => {
+              const entries = theme.manifest.filter(
+                (e) => e.category === category
+              );
+              if (entries.length === 0) return null;
+              return (
+                <optgroup
+                  key={category}
+                  label={String(t(`theme-group-${category}`))}
+                >
+                  {entries.map((e) => (
+                    <option key={e.id} value={e.id as Theme}>
+                      {e.displayName}
+                    </option>
+                  ))}
+                </optgroup>
+              );
+            })}
           </Select>
         </Field>
         <Field>

--- a/react-app/src/components/Manage/Photos.tsx
+++ b/react-app/src/components/Manage/Photos.tsx
@@ -337,7 +337,15 @@ const Photos = ({ galleryId }: Props): React.ReactElement => {
     queryFn: galleriesService.getAll,
     enabled: !galleryId,
   });
-  const galleries = (galleriesQuery.data as Array<{ id: string; title?: string }> | undefined) ?? [];
+  const galleries = React.useMemo(() => {
+    const raw =
+      (galleriesQuery.data as
+        | Array<{ id: string; title?: string }>
+        | undefined) ?? [];
+    return raw.slice().sort((a, b) =>
+      (a.title || a.id).localeCompare(b.title || b.id)
+    );
+  }, [galleriesQuery.data]);
 
   const setSearchParam = (
     name: string,


### PR DESCRIPTION
## Summary

Two related fixes from the same audit.

**GalleryForm theme picker**: the `<select>` hardcoded its own arbitrary order (`blue, red, grayscale, contrast, alert, dark, amoled, forest, silver, showcase, teal, paper`) and showed raw enum ids (`blue`, `red`, …) as the visible labels. The user-menu theme picker already reads the canonical `theme.manifest` from `lib/theme.ts` and renders one `<optgroup>` per category (Coloured / Neutral / Dark / Statement) with each entry's display name. Switch GalleryForm to the same source so the two pickers can't drift, and the operator sees readable labels in a sensible order.

**Photos page gallery facet**: the filter chip row and the bulk-action picker (`#449`) both consume the `/api/v1/galleries` list, which sorts by `id ASC` server-side. But the operator sees the gallery's title, not its slug — a gallery whose slug starts with `z` but whose title starts with `A` reads out of order alphabetically. Sort by `title || id` in the client `useMemo`. The server schema's `id ASC` stays as the canonical fetch order; the client sorts by what's actually rendered.

EPOCH_TYPES / INITIAL_VIEWS in GalleryForm and MISSING_FIELDS in Photos.tsx were spot-checked and read in natural order already, so they're left alone.

## Test plan

- [ ] `/m/galleries/new` and `/m/galleries/<id>` (Edit) → theme select shows four `<optgroup>`s in order Coloured / Neutral / Dark / Statement, with display names ("Blue", "High Contrast", "AMOLED", …) instead of raw ids.
- [ ] Theme picker in UserMenu still works identically (same source as the gallery editor now).
- [ ] `/m/photos` and `/m/g/<id>/photos` filter sidebar's gallery chips render in alphabetical order by title.
- [ ] Bulk-action picker (after #449 merges) shows galleries in the same title-order.
- [ ] Existing gallery rows with their theme set still load correctly (no data shape change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)