### PR TITLE
Release 0.13.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,20 @@ Server tests use `DB_DRIVER=dummy` via the npm script, so no SQLite file is touc
 
 Run `npm test` and `npm run typecheck` before pushing. The build step rolls up bundle sizes — worth running for visual changes that might touch chunking.
 
+## Cutting a release
+
+The release step touches several files that need to stay in lockstep. Miss one and CI fails (the openapi-version check, the version-string assertions in the docs).
+
+1. **Close the milestone.** Verify all open issues in `<version>` are merged or moved out, then `gh api repos/vlumi/photo-diary/milestones/<n> -X PATCH -f state=closed`.
+2. **Branch.** `git checkout -b release/<version>` off main.
+3. **Bump `version`** in all four `package.json` files: root, `server/`, `react-app/`, `converter/`. Same value everywhere.
+4. **Regenerate the OpenAPI dump.** `cd server && npm run docs:dump` writes `server/openapi.json` with `info.version` from `server/package.json`. Then `cd ../react-app && npm run api:codegen` regenerates `src/lib/api-schema.ts` from the new dump. Both must be committed — CI rejects a version bump without the matching regen.
+5. **Stamp CHANGELOG.** Rename `[Unreleased]` to `[<version>] - <YYYY-MM-DD>`; add a fresh empty `[Unreleased]` heading above it.
+6. **README.** Bump the install / upgrade `0.x.y` examples to the new version (search for the prior version string). Move the released milestone's bullet out of the Roadmap section into Version History with a one-paragraph release summary. Update the "what's in flight after 0.x" footer pointer.
+7. **Validate.** `npm test`, `npm run typecheck`, `npm run lint` across all three subtrees.
+8. **Open the release PR.** Title `Release <version>`. Body summarises what shipped + any milestone reorg.
+9. **After merge, tag.** `git checkout main && git pull && git tag v<version> && git push origin v<version>`. GitHub auto-generates the tarball that `bin/instance.ts` examples reference.
+
 ## Workflow conventions
 
 - **One PR per ticket.** Don't bundle a multi-ticket milestone into one PR; don't bundle multiple discrete bugs into one commit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-06-06
+
 ### Server
 
 - Coord-change geocoded-clear is now consistent across every path that mutates `taken.location.coordinates`: the admin `PUT /api/v1/photos/<id>` already did it (#415); the converter's JSON-sidecar `processJson` now does it too (was only refilling via `geocodeAtIntake` and only when `REVERSE_GEOCODE` was enabled — a sidecar with the feature off, or a failed Nominatim fetch, would leave stale geocoded values pinned to the previous location); and `bin/photo.ts update --latitude / --longitude / --altitude` gains the same semantic. Shared `coordsDiffer` / `mergeCoords` / `readCurrentCoords` extracted to `server/lib/photo-coords.ts` so the three call sites can't drift.

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  0.12.1/                               #   so different instances can run different versions
+  0.13.0/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/0.12.1      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/0.13.0      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  display/  thumbnail/
@@ -136,7 +136,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.12.1
+V=0.13.0
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -151,7 +151,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.12.1/bin/instance.ts dailybw
+/opt/photo-diary/0.13.0/bin/instance.ts dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The script can be invoked from any working directory; the instance dir is derived from the name (and the `--base <dir>` flag, default `/var/photo-diary`, if you want instances under a different parent). Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -182,7 +182,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.12.1/bin/instance.ts dailybw          # backs up the DB, flips the symlink
+/opt/photo-diary/0.13.0/bin/instance.ts dailybw          # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                    # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                         # migration runner applies any schema bumps
@@ -403,9 +403,8 @@ End-to-end flow from a new JPG arriving on the host to it being browsable in the
 
 Active milestones on the way to 1.0. Each bullet links the GitHub milestone for live status.
 
-- [**0.13 — Admin UI bundle**](https://github.com/vlumi/photo-diary/milestone/14): the admin frontend (#10) shipped across eight PRs ending with multi-select + bulk actions on the admin photos grid. Stats split (#404) and Galleries topic on `/s` (#444) also landed. Wrap-up items still open: theme selector UI / additional themes (#279) and stronger landing-page redirects (#387).
-- [**0.14 — Composition + scale**](https://github.com/vlumi/photo-diary/milestone/15): hybrid galleries (#22), DB drivers beyond SQLite (#265), saved filters / sub-galleries (#285), server-side stats with language-agnostic values and a single-key base cache (#286), content localization for photo metadata (#281), per-language editing for place / title / description (#343), stats category evolution over time (#383), year view full Jan–Dec on wide screens (#399), per-view fetch + server-side filtering (#406), retire the dummy DB driver in favour of real `:memory:` sqlite (#434), Galleries section composes with the Filters sidebar (#446).
-- [**0.15 — Admin UI polish**](https://github.com/vlumi/photo-diary/milestone/17): everything that came out of the #10 closure plus admin UX gaps. Mobile / small-screen admin layout (#412), tree-nav for the admin breadcrumb (#438), revisit the Inbox surface post-daemon (#439), set-field bulk action (#451), mobile multi-select polish — long-press + drag-rectangle (#452), surface the gallery-admin tier in the UI (#453), dashboard audit-count cards (#454), filter-sidebar month-picker / timeline strip (#455).
+- [**0.14 — Admin UI polish**](https://github.com/vlumi/photo-diary/milestone/17): completes the admin surface — mobile / small-screen admin layout (#412), tree-nav for the admin breadcrumb (#438), revisit the Inbox surface post-daemon (#439), set-field bulk action (#451), mobile multi-select polish — long-press + drag-rectangle (#452), surface the gallery-admin tier in the UI (#453), dashboard audit-count cards (#454), filter-sidebar month-picker / timeline strip (#455), build the gallery icon from an existing photo via a live crop (#457).
+- [**0.15 — Composition + scale**](https://github.com/vlumi/photo-diary/milestone/15): the larger architectural shifts. Hybrid galleries (#22), DB drivers beyond SQLite (#265), saved filters / sub-galleries (#285), server-side stats with language-agnostic values and a single-key base cache (#286), content localization for photo metadata (#281), per-language editing for place / title / description (#343), stats category evolution over time (#383), year view full Jan–Dec on wide screens (#399), per-view fetch + server-side filtering (#406), retire the dummy DB driver in favour of real `:memory:` sqlite (#434), Galleries section composes with the Filters sidebar (#446).
 - [**1.0 — Pre-release audits**](https://github.com/vlumi/photo-diary/milestone/4): test-coverage gap analysis (#194), frontend security audit (#217), end-to-end UI test suite (#261), documentation overhaul (#283), `bin/photo.ts` subcommand-surface tidy (#376).
 
 ## Backlog
@@ -454,5 +453,6 @@ After the hiatus, a burst of releases that modernized the stack, formalized the 
 - **0.10** (May 2026) — UI/UX polish across the calendar and Stats views. Photo view becomes a modal over Month with touch-tracking swipe and controlled zoom. Stats grows an expanded Summary, a Location card with map-in-modal, and modal-based deep dives for each category. Title bar carries a clickable breadcrumb with Up-navigation and a gallery/stats segmented control. The standalone Day view merges into Month, and seven new built-in themes ship. Server-side logout via refresh-token sessions.
 - **0.11** (May 2026) — Reverse-geocoded place hierarchy: converter intake fetches structured Nominatim data per photo (English canonical + optional extra languages), backfill daemon (`bin/photo-geocode.ts`) fills the existing archive, and `bin/photo.ts audit --country-mismatch` surfaces operator-vs-geocoded drift. Converter hardens around filename collisions (stable `<taken>-<uuid>.<ext>` rename at intake) and stub flows (writes a DB row directly, dedups on `(originalFilename, EXIF DateTimeOriginal)`). New `bin/meta.ts` operator script and `audit` subcommands across `bin/{photo,gallery,user,access,meta}.ts`. Stats Location card splits geotagged / not-geotagged with click-to-filter chips.
 - **0.12** (May 2026) — Geocoded location surfaced across the app: per-language city / state / country address line in the MetadataPanel with locale-aware flag positioning, City + State filter categories, Stats Places + State topics with the same drill-down, per-language city overlay JSON layered on top of Nominatim. Converter intake now flows JSONs + recursive subdirs (`inbox/<gallery>/...` auto-link, JPG processing in place, no mid-pipeline rename). MetadataPanel polished into a label-value table with author overlay on the photo Frame. Stats Exposure topic splits into Settings / Image / Light; By-value mode drops the "Other (N+)" aggregation. New beta-gated Focal length 35mm equivalent (`focal_35mm_equiv` column + crop-factor fallback). `bin/photo.ts audit` defaults to a counts-only summary; city subcommands consolidated under `cities <action>`.
+- **0.13** (Jun 2026) — Admin frontend bundle. Full `/m/*` surface — dashboard, Photos grid with faceted filter sidebar + edit drawer + multi-select bulk actions (Link / Unlink / Delete) + EXIF-revert + draggable map marker + audit chips, Galleries CRUD, Users + Groups + per-gallery and global Access pages — all behind `user.is_admin`. Stats splits into its own `/s/` URL root with a new admin-only global stats page and a Galleries topic that drills into per-gallery stats. Mutation API hardens (#222) with TypeBox-validated bodies, field-locked photo overrides, the `:private` pseudo-gallery and `:all`/`:public` plumbing retire (#385/#394), virtual-host scope (#386) narrows reads + writes to a bound gallery, and ACL gains user groups (#270). Theme picker becomes a swatch grid with hover preview, six new built-in themes (Amber / Lavender / Sage / Slate / Midnight / Espresso), and converter coord-change paths consistently clear geocoded fields so place names track the photo.
 
-See the [Roadmap](#roadmap) for what's in flight after 0.12.
+See the [Roadmap](#roadmap) for what's in flight after 0.13.

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.1"
   },
-  "version": "0.12.1"
+  "version": "0.13.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -65,5 +65,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.12.1"
+  "version": "0.13.0"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.12.1"
+    "version": "0.13.0"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -55,5 +55,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.12.1"
+  "version": "0.13.0"
 }


### PR DESCRIPTION
## Summary

Cuts the 0.13.0 release — closes the Admin UI bundle milestone (20 issues shipped) and stamps the changelog.

### Release boundary

- `CHANGELOG.md` — `[Unreleased]` → `[0.13.0] - 2026-06-06`.
- Version bumped to `0.13.0` in `package.json` (root), `server/package.json`, `react-app/package.json`, `converter/package.json`.
- `README.md` — install / upgrade snippets now reference `0.13.0`; the 0.13 Roadmap bullet moves into the Version History list with a one-paragraph release summary; the "what's in flight" footer pointer bumps to 0.13.

### Roadmap reorg

0.14 and 0.15 milestones swapped. The argument was: the admin UI just shipped, polishing it (gallery-admin tier, audit-count cards, sidebar timeline, set-field bulk action, mobile, …) is the natural follow-on and stays in one coherent release rather than pausing while composition+scale ships. The two milestones contain the same issues as before — only the version labels swapped.

- **0.14 — Admin UI polish** (was 0.15): #412, #438, #439, #451, #452, #453, #454, #455, #457.
- **0.15 — Composition + scale** (was 0.14): #22, #265, #281, #285, #286, #343, #383, #399, #406, #434, #446.

The milestone URLs by number didn't change (renaming swaps the title, not the ID), so existing links keep working.

### What shipped in 0.13

The admin frontend (#10) shipped across PRs #407, #408, #409, #411, #424, #425, #435, #436, #437, #449 — server filter endpoint, admin shell + routing, photos grid + filters, per-photo edit drawer, multi-select + bulk actions, Galleries CRUD, Users + Groups + Access pages. PR 8 (inbox preview) was dropped after we confirmed orphan thumbnails already work via the converter pipeline. Three sub-tickets split out: #451 set-field, #452 mobile multi-select, #453 gallery-admin UI tier.

The stats split (#404) shipped via #443 (global `/s`), #445 (Galleries topic on `/s`), #448 (per-gallery back-link). #446 deferred to 0.15.

Server-side: mutation API (#222) with TypeBox bodies, field-locked photo overrides, ACL user groups (#270), virtual-host scope (#386), `:private` / `:all` / `:public` plumbing retired (#385/#394), JWT carries `is_admin`. Converter coord-change paths consistently clear geocoded fields. Six new built-in themes (Amber / Lavender / Sage / Slate / Midnight / Espresso) plus the swatch picker with hover preview.

## Test plan

- [ ] `git tag v0.13.0` after merge.
- [ ] `npm test` + `npm run typecheck` + `npm run lint` green across all three subtrees (verified pre-PR).
- [ ] CHANGELOG `[Unreleased]` section is empty (next-release placeholder).
- [ ] README install snippets dereference to `v0.13.0` tag once it exists.
- [ ] Operator can `bin/instance.ts` from `/opt/photo-diary/0.13.0/` on a fresh host without error.