### PR TITLE
Honour instance DEFAULT_THEME on Manage / GlobalStats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Frontend
+
+- Instance `DEFAULT_THEME` (from `/api/v1/meta`'s `defaultTheme`) now actually applies on the Manage and Global Stats surfaces. The meta-to-config side-effect runs *after* render, so the first render with fresh meta still saw `config.DEFAULT_THEME = "blue"` (the hardcoded module-load baseline) and the mutated value never triggered another render. App.tsx, Gallery/index.tsx, and GlobalStats/index.tsx now read `meta?.defaultTheme` directly, falling back to `config.DEFAULT_THEME` only when meta hasn't resolved yet. GlobalStats also drops its own `<Global>` since the App-level one now handles theming for every route.
+
 ## [0.13.0] - 2026-06-06
 
 ### Server

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -128,13 +128,6 @@ const App = (): React.ReactElement => {
   }, [meta, setBetaModes]);
 
   const themePreference = useThemePreferenceStore((s) => s.preference);
-  // Read `meta.defaultTheme` directly rather than going through the
-  // mutated `config.DEFAULT_THEME` — the meta-to-config side-effect
-  // runs after render, so the first render after meta loads still
-  // sees the hardcoded "blue" baseline. Reading meta directly here
-  // means baseTheme is built with the fresh value on that very render.
-  // Falls back to `config.DEFAULT_THEME` (the seeded "blue") when meta
-  // hasn't resolved yet or doesn't set the field.
   const baseTheme = theme.setTheme(
     themePreference ?? meta?.defaultTheme ?? config.DEFAULT_THEME
   );

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -128,7 +128,16 @@ const App = (): React.ReactElement => {
   }, [meta, setBetaModes]);
 
   const themePreference = useThemePreferenceStore((s) => s.preference);
-  const baseTheme = theme.setTheme(themePreference ?? config.DEFAULT_THEME);
+  // Read `meta.defaultTheme` directly rather than going through the
+  // mutated `config.DEFAULT_THEME` — the meta-to-config side-effect
+  // runs after render, so the first render after meta loads still
+  // sees the hardcoded "blue" baseline. Reading meta directly here
+  // means baseTheme is built with the fresh value on that very render.
+  // Falls back to `config.DEFAULT_THEME` (the seeded "blue") when meta
+  // hasn't resolved yet or doesn't set the field.
+  const baseTheme = theme.setTheme(
+    themePreference ?? meta?.defaultTheme ?? config.DEFAULT_THEME
+  );
 
   return (
     <>

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -180,11 +180,16 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
 
   // Theme resolution priority: user preference → gallery theme → instance default.
   const selectedThemeName = selectedGallery?.theme();
+  // Read `meta.defaultTheme` directly rather than via the mutated
+  // `config.DEFAULT_THEME` — the meta-to-config side-effect in App
+  // runs after render, so the first render with fresh meta would
+  // otherwise pick up the hardcoded baseline. See App.tsx for the
+  // same workaround on the base Global.
   const activeTheme = themePreference
     ? theme.setTheme(themePreference)
     : selectedGallery && selectedGallery.hasTheme() && selectedThemeName
       ? theme.setTheme(selectedThemeName)
-      : theme.setTheme(config.DEFAULT_THEME);
+      : theme.setTheme(meta?.defaultTheme ?? config.DEFAULT_THEME);
 
   if (error) {
     return <div className="error">Loading failed</div>;

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -180,11 +180,6 @@ const Gallery = ({ isStats = false }: Props): React.ReactElement => {
 
   // Theme resolution priority: user preference → gallery theme → instance default.
   const selectedThemeName = selectedGallery?.theme();
-  // Read `meta.defaultTheme` directly rather than via the mutated
-  // `config.DEFAULT_THEME` — the meta-to-config side-effect in App
-  // runs after render, so the first render with fresh meta would
-  // otherwise pick up the hardcoded baseline. See App.tsx for the
-  // same workaround on the base Global.
   const activeTheme = themePreference
     ? theme.setTheme(themePreference)
     : selectedGallery && selectedGallery.hasTheme() && selectedThemeName

--- a/react-app/src/components/GlobalStats/index.tsx
+++ b/react-app/src/components/GlobalStats/index.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import styled from "@emotion/styled";
-import { Global, css } from "@emotion/react";
 import { useQuery } from "@tanstack/react-query";
 import { BsHouseFill, BsBarChartLine } from "react-icons/bs";
 
@@ -12,6 +11,7 @@ import Galleries from "./Galleries";
 import PhotoModel, { type Photo as PhotoT } from "../../models/PhotoModel";
 import photosService from "../../services/photos";
 import galleriesService from "../../services/galleries";
+import metaService from "../../services/meta";
 import theme from "../../lib/theme";
 import { type UniqueValues } from "../../lib/stats";
 import { buildUniqueValues } from "../../lib/uniqueValues";
@@ -22,23 +22,6 @@ import {
   useThemePreferenceStore,
   useUserStore,
 } from "../../stores";
-
-type ActiveTheme = ReturnType<typeof theme.setTheme>;
-
-const globalStyles = (active: ActiveTheme) => css`
-  html {
-    --primary-color: ${active.get("primary-color")};
-    --primary-background: ${active.get("primary-background")};
-    --inactive-color: ${active.get("inactive-color")};
-    --header-color: ${active.get("header-color")};
-    --header-sub-color: ${active.get("header-sub-color")};
-    --header-background: ${active.get("header-background")};
-    --tile-background: ${active.get("tile-background")};
-    --photo-frame-mat: ${active.get("photo-frame-mat")};
-    --photo-frame-border: ${active.get("photo-frame-border")};
-    filter: ${active.get("filter")};
-  }
-`;
 
 const Header = styled.div`
   display: flex;
@@ -98,10 +81,19 @@ const GlobalStats = (): React.ReactElement => {
   const filters = useFiltersStore((s) => s.filters);
   const setFilters = useFiltersStore((s) => s.setFilters);
   const themePreference = useThemePreferenceStore((s) => s.preference);
-
+  // App's base Global already paints html with the right theme on
+  // this route, so this `activeTheme` only carries through to chart
+  // gradients via the Stats prop. Read meta directly to dodge the
+  // same stale-config race App resolves. The metaQuery is cached so
+  // this is a free read.
+  const metaQuery = useQuery({
+    queryKey: ["meta"],
+    queryFn: () => metaService.getAll(),
+  });
+  const meta = metaQuery.data as { defaultTheme?: string } | undefined;
   const activeTheme = themePreference
     ? theme.setTheme(themePreference)
-    : theme.setTheme(config.DEFAULT_THEME);
+    : theme.setTheme(meta?.defaultTheme ?? config.DEFAULT_THEME);
 
   const photosQuery = useQuery({
     queryKey: ["global-stats-photos", user?.id ?? null],
@@ -123,7 +115,6 @@ const GlobalStats = (): React.ReactElement => {
 
   const frame = (body: React.ReactNode): React.ReactElement => (
     <>
-      <Global styles={globalStyles(activeTheme)} />
       <Header aria-label={String(t("stats-global-nav-group"))}>
         <HomeLink
           onClick={() => navigate("/")}

--- a/react-app/src/components/GlobalStats/index.tsx
+++ b/react-app/src/components/GlobalStats/index.tsx
@@ -81,11 +81,6 @@ const GlobalStats = (): React.ReactElement => {
   const filters = useFiltersStore((s) => s.filters);
   const setFilters = useFiltersStore((s) => s.setFilters);
   const themePreference = useThemePreferenceStore((s) => s.preference);
-  // App's base Global already paints html with the right theme on
-  // this route, so this `activeTheme` only carries through to chart
-  // gradients via the Stats prop. Read meta directly to dodge the
-  // same stale-config race App resolves. The metaQuery is cached so
-  // this is a free read.
   const metaQuery = useQuery({
     queryKey: ["meta"],
     queryFn: () => metaService.getAll(),


### PR DESCRIPTION
## Summary

`config.DEFAULT_THEME` starts at the hardcoded "blue" baseline at module load and gets mutated to `meta.defaultTheme` in App's useEffect after `/api/v1/meta` resolves. The mutation is a plain property assignment on the shared `config` object — not React state — so it doesn't trigger a re-render. Components that read `config.DEFAULT_THEME` at render time keep the stale "blue" until something else (user clicking the picker, navigating, …) re-renders.

On Gallery routes the per-gallery `gallery.theme()` priority masks this (a stored gallery theme wins over DEFAULT_THEME in practice). On Manage and Global Stats there's no gallery context to fall back to, so the operator-set instance default never visibly applies — the operator sees "blue" forever.

Fix: read `meta?.defaultTheme` directly in `App.tsx`, `Gallery/index.tsx`, and `GlobalStats/index.tsx`, with `config.DEFAULT_THEME` as the pre-meta fallback. The mutated config keeps existing call sites working but is no longer load-bearing for the render-time read.

GlobalStats also drops its own `<Global>` — the App-level Global (lifted earlier this milestone) already paints the html CSS variables on every route, and keeping an identical second Global on this route was duplicate work. The local `globalStyles` helper + `ActiveTheme` alias delete with it.

## Reproduction (pre-fix)

1. Server `.env` sets `DEFAULT_THEME=paper`.
2. User has no theme preference (`themePreference: null`).
3. Visit `/m` (Manage) → expected `paper`, got `blue`.
4. Cause: App's `<Global>` was built from `config.DEFAULT_THEME`, still "blue" on first render after meta loaded.

## Test plan

- [ ] Set `DEFAULT_THEME=paper` (or any non-blue) in server `.env`.
- [ ] Cold-load `/m` as admin with no theme preference → page renders in `paper` (no flash of "blue").
- [ ] Cold-load `/s` as admin with no theme preference → same.
- [ ] Cold-load `/g/<gallery>` with the gallery's own theme set → renders the gallery theme (no regression).
- [ ] Cold-load `/g/<gallery>` with no gallery theme, no user preference → renders `paper`.
- [ ] Pick a theme via the swatch picker → still applies live across all routes.
- [ ] Click "Follow gallery default" in the picker → reverts to gallery theme on `/g`, to `paper` on `/m` and `/s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)