### PR TITLE
Identifier inputs: opt out of mobile autocapitalize (#465)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Frontend
 
+- Identifier inputs (login username, new user / gallery / group ids, gallery hostname regex) opt out of mobile autocapitalize / autocorrect / spellcheck via `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}`. iOS Safari was capitalizing the first letter of the username on the login page, producing `Admin` for a case-sensitive lookup that expected `admin`; the same default applied to every other identifier-shaped field. Free-text fields (title, description, place, country typeahead) unchanged. (closes #465)
 - Instance `DEFAULT_THEME` (from `/api/v1/meta`'s `defaultTheme`) now actually applies on the Manage and Global Stats surfaces. The meta-to-config side-effect runs *after* render, so the first render with fresh meta still saw `config.DEFAULT_THEME = "blue"` (the hardcoded module-load baseline) and the mutated value never triggered another render. App.tsx, Gallery/index.tsx, and GlobalStats/index.tsx now read `meta?.defaultTheme` directly, falling back to `config.DEFAULT_THEME` only when meta hasn't resolved yet. GlobalStats also drops its own `<Global>` since the App-level one now handles theming for every route.
 
 ## [0.13.0] - 2026-06-06

--- a/react-app/src/components/Login.tsx
+++ b/react-app/src/components/Login.tsx
@@ -135,6 +135,9 @@ const Login = ({ onSuccess, autoFocus = true }: Props): React.ReactElement => {
         value={userId}
         name="userId"
         autoComplete="username"
+        autoCapitalize="none"
+        autoCorrect="off"
+        spellCheck={false}
         placeholder={t("login-username")}
         autoFocus={autoFocus}
         onChange={({ target }) => setUserId(target.value)}

--- a/react-app/src/components/Manage/GalleryCreate.tsx
+++ b/react-app/src/components/Manage/GalleryCreate.tsx
@@ -159,6 +159,9 @@ const GalleryCreate = (): React.ReactElement => {
             onChange={(e) => setId(e.target.value)}
             $invalid={idTouched && !idValid}
             autoFocus
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
           />
           <FieldHint>{t("manage-gallery-field-id-hint")}</FieldHint>
         </Field>

--- a/react-app/src/components/Manage/GalleryForm.tsx
+++ b/react-app/src/components/Manage/GalleryForm.tsx
@@ -231,6 +231,9 @@ const GalleryFormFields = ({ form, setField }: Props): React.ReactElement => {
           <Input
             value={form.hostname}
             onChange={(e) => setField("hostname", e.target.value)}
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
           />
           <FieldHint>{t("manage-gallery-field-hostname-hint")}</FieldHint>
         </Field>

--- a/react-app/src/components/Manage/GroupCreate.tsx
+++ b/react-app/src/components/Manage/GroupCreate.tsx
@@ -157,6 +157,9 @@ const GroupCreate = (): React.ReactElement => {
             onChange={(e) => setId(e.target.value)}
             $invalid={idTouched && !idValid}
             autoFocus
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
           />
           <FieldHint>{t("manage-group-field-id-hint")}</FieldHint>
         </Field>

--- a/react-app/src/components/Manage/UserCreate.tsx
+++ b/react-app/src/components/Manage/UserCreate.tsx
@@ -147,6 +147,9 @@ const UserCreate = (): React.ReactElement => {
             onChange={(e) => setId(e.target.value)}
             $invalid={idTouched && !idValid}
             autoFocus
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
           />
           <FieldHint>{t("manage-user-field-id-hint")}</FieldHint>
         </Field>


### PR DESCRIPTION
## Summary

Mobile browsers (Safari on iOS in particular) capitalize the first letter of any text input by default. Fine for title / description / place fields, but corrupts identifier inputs — type `admin` on the login page, Safari submits `Admin`, the case-sensitive lookup rejects it.

Add `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}` to:

- **Login.tsx** — username field.
- **Manage/UserCreate.tsx** — user id field.
- **Manage/GalleryCreate.tsx** — gallery id field.
- **Manage/GroupCreate.tsx** — group id field.
- **Manage/GalleryForm.tsx** — hostname regex field.

Free-text fields (title, description, place, country typeahead) keep the default browser behaviour — autocapitalize on a photo title is the right default.

The server-side belt-and-suspenders (case-insensitive lookup on `user.id`) is the parallel fix in #466.

## Test plan

- [ ] iOS Safari: tap into login username → keyboard opens in lowercase mode; typing `admin` produces `admin`, not `Admin`.
- [ ] Android Chrome / Samsung Internet: same.
- [ ] iOS: New user / gallery / group id fields don't auto-capitalize the first letter.
- [ ] iOS: Photo title / description fields still auto-capitalize (no regression).
- [ ] Desktop: no behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)