### PR TITLE
Access add-grant: label the hide-map dropdown (#464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Frontend
 
+- Access add-grant rows on `/m/access` and `/m/g/<id>/access` now label the Inherit / Show / Hide dropdown with "Map visibility" so the three context-less words don't make the operator guess what the select does. Per-row controls inside the access table stay unchanged — their column header already disambiguates. (closes #464)
 - Identifier inputs (login username, new user / gallery / group ids, gallery hostname regex) opt out of mobile autocapitalize / autocorrect / spellcheck via `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck={false}`. iOS Safari was capitalizing the first letter of the username on the login page, producing `Admin` for a case-sensitive lookup that expected `admin`; the same default applied to every other identifier-shaped field. Free-text fields (title, description, place, country typeahead) unchanged. (closes #465)
 - Instance `DEFAULT_THEME` (from `/api/v1/meta`'s `defaultTheme`) now actually applies on the Manage and Global Stats surfaces. The meta-to-config side-effect runs *after* render, so the first render with fresh meta still saw `config.DEFAULT_THEME = "blue"` (the hardcoded module-load baseline) and the mutated value never triggered another render. App.tsx, Gallery/index.tsx, and GlobalStats/index.tsx now read `meta?.defaultTheme` directly, falling back to `config.DEFAULT_THEME` only when meta hasn't resolved yet. GlobalStats also drops its own `<Global>` since the App-level one now handles theming for every route.
 

--- a/react-app/src/components/Manage/Access.tsx
+++ b/react-app/src/components/Manage/Access.tsx
@@ -848,21 +848,23 @@ const AddGrantPanel = ({
           />
           {t("manage-gallery-access-col-admin")}
         </AddLabel>
-        <Select
-          value={hideMap}
-          onChange={(e) => setHideMap(e.target.value as HideMapValue)}
-          aria-label={String(t("manage-gallery-access-col-hidemap"))}
-        >
-          <option value="inherit">
-            {t("manage-gallery-access-hidemap-inherit")}
-          </option>
-          <option value="show">
-            {t("manage-gallery-access-hidemap-show")}
-          </option>
-          <option value="hide">
-            {t("manage-gallery-access-hidemap-hide")}
-          </option>
-        </Select>
+        <AddLabel>
+          {t("manage-gallery-access-col-hidemap")}
+          <Select
+            value={hideMap}
+            onChange={(e) => setHideMap(e.target.value as HideMapValue)}
+          >
+            <option value="inherit">
+              {t("manage-gallery-access-hidemap-inherit")}
+            </option>
+            <option value="show">
+              {t("manage-gallery-access-hidemap-show")}
+            </option>
+            <option value="hide">
+              {t("manage-gallery-access-hidemap-hide")}
+            </option>
+          </Select>
+        </AddLabel>
         <AddButton type="button" onClick={handleAdd} disabled={!canAdd}>
           <BsPlus aria-hidden />
           {t("manage-access-add-button")}

--- a/react-app/src/components/Manage/GalleryAccess.tsx
+++ b/react-app/src/components/Manage/GalleryAccess.tsx
@@ -720,20 +720,23 @@ const AddUserGrant = ({
         />
         {t("manage-gallery-access-col-admin")}
       </AddLabel>
-      <Select
-        value={hideMap}
-        onChange={(e) => setHideMap(e.target.value as HideMapValue)}
-      >
-        <option value="inherit">
-          {t("manage-gallery-access-hidemap-inherit")}
-        </option>
-        <option value="show">
-          {t("manage-gallery-access-hidemap-show")}
-        </option>
-        <option value="hide">
-          {t("manage-gallery-access-hidemap-hide")}
-        </option>
-      </Select>
+      <AddLabel>
+        {t("manage-gallery-access-col-hidemap")}
+        <Select
+          value={hideMap}
+          onChange={(e) => setHideMap(e.target.value as HideMapValue)}
+        >
+          <option value="inherit">
+            {t("manage-gallery-access-hidemap-inherit")}
+          </option>
+          <option value="show">
+            {t("manage-gallery-access-hidemap-show")}
+          </option>
+          <option value="hide">
+            {t("manage-gallery-access-hidemap-hide")}
+          </option>
+        </Select>
+      </AddLabel>
       <AddButton type="button" onClick={handleAdd} disabled={!picked || mutating}>
         <BsPlus aria-hidden />
         {t("manage-gallery-access-add")}
@@ -791,20 +794,23 @@ const AddGroupGrant = ({
         />
         {t("manage-gallery-access-col-admin")}
       </AddLabel>
-      <Select
-        value={hideMap}
-        onChange={(e) => setHideMap(e.target.value as HideMapValue)}
-      >
-        <option value="inherit">
-          {t("manage-gallery-access-hidemap-inherit")}
-        </option>
-        <option value="show">
-          {t("manage-gallery-access-hidemap-show")}
-        </option>
-        <option value="hide">
-          {t("manage-gallery-access-hidemap-hide")}
-        </option>
-      </Select>
+      <AddLabel>
+        {t("manage-gallery-access-col-hidemap")}
+        <Select
+          value={hideMap}
+          onChange={(e) => setHideMap(e.target.value as HideMapValue)}
+        >
+          <option value="inherit">
+            {t("manage-gallery-access-hidemap-inherit")}
+          </option>
+          <option value="show">
+            {t("manage-gallery-access-hidemap-show")}
+          </option>
+          <option value="hide">
+            {t("manage-gallery-access-hidemap-hide")}
+          </option>
+        </Select>
+      </AddLabel>
       <AddButton type="button" onClick={handleAdd} disabled={!picked || mutating}>
         <BsPlus aria-hidden />
         {t("manage-gallery-access-add")}


### PR DESCRIPTION
## Summary

The Inherit / Show / Hide select in the add-grant row on \`/m/access\` (and \`/m/g/<id>/access\`) sat between a "Pick a gallery" placeholder, a "Pick a subject" placeholder, and a labelled "Admin" checkbox — the only control without visible context, so the three context-less words made the operator guess what the select drives.

Wrap the select in an \`AddLabel\` with "Map visibility" preceding it, mirroring the \`AddLabel\` the adjacent Admin checkbox already uses. Same fix in both files.

Per-row controls inside the access table stay unchanged — their column header carries the context.

## Test plan

- [ ] \`/m/access\` add-grant row → "Map visibility" label visible to the left of the dropdown.
- [ ] \`/m/g/<id>/access\` add-grant rows (User grants + Group grants sub-panels) → same label visible.
- [ ] Per-row Inherit / Show / Hide selects inside the access table → unchanged (column header still names the column).
- [ ] Form still submits the chosen value correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)