### PR TITLE
Fix `:guest` add-grant: split at first colon

### DIFF
--- a/react-app/src/components/Manage/Access.tsx
+++ b/react-app/src/components/Manage/Access.tsx
@@ -789,10 +789,12 @@ const AddGrantPanel = ({
 
   const handleAdd = () => {
     if (!galleryId || !subjectValue) return;
-    const [subjectType, subjectId] = subjectValue.split(":", 2) as [
-      "user" | "group",
-      string,
-    ];
+    // Encoded as `<type>:<id>`. Split at the FIRST colon only —
+    // ids can themselves contain colons (`:guest`), which the
+    // limit-2 form of `.split(":", 2)` would eat.
+    const colonIdx = subjectValue.indexOf(":");
+    const subjectType = subjectValue.slice(0, colonIdx) as "user" | "group";
+    const subjectId = subjectValue.slice(colonIdx + 1);
     onAdd({ galleryId, subjectType, subjectId, isAdmin, hideMap });
     setSubjectValue("");
     setIsAdmin(false);

--- a/server/controllers/group-gallery-v1.ts
+++ b/server/controllers/group-gallery-v1.ts
@@ -17,8 +17,8 @@ const FilterQuery = Type.Object({
   galleryId: Type.Optional(Type.String()),
 });
 const RowParams = Type.Object({
-  groupId: Type.String(),
-  galleryId: Type.String(),
+  groupId: Type.String({ minLength: 1 }),
+  galleryId: Type.String({ minLength: 1 }),
 });
 const RowResponse = Type.Object({
   group_id: Type.String(),

--- a/server/controllers/user-gallery-v1.ts
+++ b/server/controllers/user-gallery-v1.ts
@@ -17,8 +17,8 @@ const FilterQuery = Type.Object({
   galleryId: Type.Optional(Type.String()),
 });
 const RowParams = Type.Object({
-  userId: Type.String(),
-  galleryId: Type.String(),
+  userId: Type.String({ minLength: 1 }),
+  galleryId: Type.String({ minLength: 1 }),
 });
 const RowResponse = Type.Object({
   user_id: Type.String(),

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1890,7 +1890,8 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "in": "path",
             "name": "userId",
@@ -1898,7 +1899,8 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "in": "path",
             "name": "galleryId",
@@ -1924,7 +1926,8 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "in": "path",
             "name": "userId",
@@ -1932,7 +1935,8 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "in": "path",
             "name": "galleryId",
@@ -2393,7 +2397,8 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "in": "path",
             "name": "groupId",
@@ -2401,7 +2406,8 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "in": "path",
             "name": "galleryId",
@@ -2427,7 +2433,8 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "in": "path",
             "name": "groupId",
@@ -2435,7 +2442,8 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "in": "path",
             "name": "galleryId",


### PR DESCRIPTION
## Summary

Adding a `:guest` access grant via `/m/access` produced an access row with an empty `user_id`. Root cause is in `Access.tsx`'s subject parser — the picker encodes its value as `<type>:<id>` and parses with `subjectValue.split(":", 2)`, but JS's limit parameter doesn't mean "split N times", it truncates the array to N entries. For `"user::guest".split(":", 2)` the array is `["user", ""]` and the `:guest` payload falls off the end.

Fix: switch to `indexOf`-based split so the second segment can carry its own colon. Plus a defensive guard on the server's path param schemas — `minLength: 1` on the `userId` / `groupId` path params for `PUT/DELETE /api/v1/user-gallery/<userId>/<galleryId>` and the corresponding group-gallery endpoints. The schema is regenerated into the OpenAPI dump.

## Existing bad data

The bug succeeded silently — server accepted the empty path segment and wrote the row. Operator can clean up with:

```sql
DELETE FROM user_gallery WHERE user_id = '';
DELETE FROM group_gallery WHERE group_id = '';
```

(Only the first DELETE applies to the reported instance, but mirror it for safety.)

## Test plan

- [ ] `/m/access` add-grant → pick `:guest` as subject → row appears with `id = :guest` (not empty).
- [ ] Same on `/m/g/<id>/access`.
- [ ] Regular users (no colon prefix) still work — no regression.
- [ ] Server rejects a hand-crafted `PUT /api/v1/user-gallery//<gid>` with the typebox minLength validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)