### PR TITLE
Release 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-07
+
 ### Server
 
 - User / gallery / group ids tighten to a lowercase slug shape: `^[a-z0-9][a-z0-9_-]*$` (lowercase alnum, may contain `_` / `-`, must start with alnum). Schema migration 017 lowercases any existing uppercase ids and cascades the change through the FK columns (`user_gallery`, `user_group`, `session`, `group_gallery`, `gallery_photo`). Login lowercases the typed id before lookup so iOS-autocapitalized "Admin" matches a stored `admin`. INSERT-time pattern validation lives in the model + TypeBox schemas; the migration's PK UNIQUE constraint surfaces existing case-collisions on first run. (part of #476)

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  0.13.0/                               #   so different instances can run different versions
+  0.14.0/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/0.13.0      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/0.14.0      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  display/  thumbnail/
@@ -136,7 +136,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.13.0
+V=0.14.0
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -151,7 +151,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.13.0/bin/instance.ts dailybw
+/opt/photo-diary/0.14.0/bin/instance.ts dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The script can be invoked from any working directory; the instance dir is derived from the name (and the `--base <dir>` flag, default `/var/photo-diary`, if you want instances under a different parent). Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -182,7 +182,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.13.0/bin/instance.ts dailybw          # backs up the DB, flips the symlink
+/opt/photo-diary/0.14.0/bin/instance.ts dailybw          # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                    # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                         # migration runner applies any schema bumps
@@ -403,7 +403,6 @@ End-to-end flow from a new JPG arriving on the host to it being browsable in the
 
 Active milestones on the way to 1.0, plus the far-out 2.0 direction. Each bullet links the GitHub milestone for live status.
 
-- [**0.14 — Admin UI polish**](https://github.com/vlumi/photo-diary/milestone/17): completes the admin surface — mobile / small-screen admin layout (#412), tree-nav for the admin breadcrumb (#438), revisit the Inbox surface post-daemon (#439), set-field bulk action (#451), mobile multi-select polish — long-press + drag-rectangle (#452), surface the gallery-admin tier in the UI (#453), dashboard audit-count cards (#454), filter-sidebar month-picker / timeline strip (#455), build the gallery icon from an existing photo via a live crop (#457).
 - [**0.15 — Composition + scale**](https://github.com/vlumi/photo-diary/milestone/15): the larger architectural shifts. Hybrid galleries (#22), DB drivers beyond SQLite (#265), saved filters / sub-galleries (#285), server-side stats with language-agnostic values and a single-key base cache (#286), content localization for photo metadata (#281), per-language editing for place / title / description (#343), stats category evolution over time (#383), year view full Jan–Dec on wide screens (#399), per-view fetch + server-side filtering (#406), retire the dummy DB driver in favour of real `:memory:` sqlite (#434), Galleries section composes with the Filters sidebar (#446).
 - [**1.0 — Pre-release audits**](https://github.com/vlumi/photo-diary/milestone/4): test-coverage gap analysis (#194), frontend security audit (#217), end-to-end UI test suite (#261), documentation overhaul (#283), `bin/photo.ts` subcommand-surface tidy (#376).
 - [**2.0 — Thin server, cloud-native direction**](https://github.com/vlumi/photo-diary/milestone/18) *(direction-setting, far out)*: shape may change significantly. Originals leave the server and live client-side or in cold storage; the converter's sharp pipeline becomes a local uploader bundled from the admin UI; all DB ops route through the API (no direct backdoor); storage backends behind a vendor-agnostic interface so S3-compatible / CDN deployments are an option. Vision and sub-ticket breakdown in #469. Likely diverges from today's self-hosted-monolith shape enough that it may end up being a different product line.
@@ -455,5 +454,6 @@ After the hiatus, a burst of releases that modernized the stack, formalized the 
 - **0.11** (May 2026) — Reverse-geocoded place hierarchy: converter intake fetches structured Nominatim data per photo (English canonical + optional extra languages), backfill daemon (`bin/photo-geocode.ts`) fills the existing archive, and `bin/photo.ts audit --country-mismatch` surfaces operator-vs-geocoded drift. Converter hardens around filename collisions (stable `<taken>-<uuid>.<ext>` rename at intake) and stub flows (writes a DB row directly, dedups on `(originalFilename, EXIF DateTimeOriginal)`). New `bin/meta.ts` operator script and `audit` subcommands across `bin/{photo,gallery,user,access,meta}.ts`. Stats Location card splits geotagged / not-geotagged with click-to-filter chips.
 - **0.12** (May 2026) — Geocoded location surfaced across the app: per-language city / state / country address line in the MetadataPanel with locale-aware flag positioning, City + State filter categories, Stats Places + State topics with the same drill-down, per-language city overlay JSON layered on top of Nominatim. Converter intake now flows JSONs + recursive subdirs (`inbox/<gallery>/...` auto-link, JPG processing in place, no mid-pipeline rename). MetadataPanel polished into a label-value table with author overlay on the photo Frame. Stats Exposure topic splits into Settings / Image / Light; By-value mode drops the "Other (N+)" aggregation. New beta-gated Focal length 35mm equivalent (`focal_35mm_equiv` column + crop-factor fallback). `bin/photo.ts audit` defaults to a counts-only summary; city subcommands consolidated under `cities <action>`.
 - **0.13** (Jun 2026) — Admin frontend bundle. Full `/m/*` surface — dashboard, Photos grid with faceted filter sidebar + edit drawer + multi-select bulk actions (Link / Unlink / Delete) + EXIF-revert + draggable map marker + audit chips, Galleries CRUD, Users + Groups + per-gallery and global Access pages — all behind `user.is_admin`. Stats splits into its own `/s/` URL root with a new admin-only global stats page and a Galleries topic that drills into per-gallery stats. Mutation API hardens (#222) with TypeBox-validated bodies, field-locked photo overrides, the `:private` pseudo-gallery and `:all`/`:public` plumbing retire (#385/#394), virtual-host scope (#386) narrows reads + writes to a bound gallery, and ACL gains user groups (#270). Theme picker becomes a swatch grid with hover preview, six new built-in themes (Amber / Lavender / Sage / Slate / Midnight / Espresso), and converter coord-change paths consistently clear geocoded fields so place names track the photo.
+- **0.14** (Jun 2026) — Admin UI polish. Slug-shaped (lowercase) ids across `user` / `gallery` / `group` with a one-shot lowercasing migration, mutable `user.name` + renamed `group.name`, per-photo bulk Edit-fields modal (#451), bulk Regeocode (#483), audit-count tiles on the dashboard (#454), filter-sidebar timeline strip with shift-range month picking (#455), gallery-icon cropper from the gallery's own photos (#457), Inbox surface revamp post-daemon (#439), drawer Galleries row + the `/m/g/<id>/photos` route collapsed into `/m/photos?gallery=<id>` (#496/#497), gallery-editor tier surfaced end-to-end via `is_editor` (#498), country dropdown polish (#488/#489) and the new `xx` sentinel for international waters (#486). Mobile / small-screen pass (#412): tables wrap in `TableScroll`, Photos page top-and-bottom pagers with 44px touch targets, Access table redesign (icon-prefixed Subject, centred control headers, trash icon, frosted-glass `BulkActions` bar that floats centred over the grid). Touch multi-select (#452): long-press to anchor, drag to range-fill the anchor → head span, auto-scroll near viewport edges. Manage breadcrumb gains the gear-icon parity with `GlobalStats`. Manage Dashboard navigation reshuffle (#481) plus the manage-galleries-list row-padding (#496) fix.
 
-See the [Roadmap](#roadmap) for what's in flight after 0.13.
+See the [Roadmap](#roadmap) for what's in flight after 0.14.

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.1"
   },
-  "version": "0.13.0"
+  "version": "0.14.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -66,5 +66,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.13.0"
+  "version": "0.14.0"
 }

--- a/server/README.md
+++ b/server/README.md
@@ -82,46 +82,60 @@ The per-instance `bin/` directory (`<instance>/bin/{photo,photo-rename,photo-geo
 
 Bootstrap, doctor, or upgrade a Photo Diary instance directory in one command. Default base is `/var/photo-diary`. Mode is auto-detected from existing state:
 
-- **New** — creates the directory tree, generates `.env` with a fresh random `SECRET`, creates a `code` symlink pointing at this script's own code root, and creates the per-instance `bin/{photo,gallery,user}.ts` shortcuts.
+- **New** — creates the directory tree, generates `.env` with a fresh random `SECRET`, creates a `code` symlink pointing at this script's own code root, and creates the per-instance `bin/{photo,gallery,group,user,meta}.ts` shortcuts.
 - **Doctor** — instance exists, `code` already points at this script's root. Reports missing `.env` keys with `✓`/`✗` markers. Refreshes any missing `bin/` shortcuts. Add `--fix` to append defaults to `.env`.
 - **Upgrade** — `code` points at a different version. Backs up the DB to `db.sqlite3.pre-<new-version>` and flips the symlink. Refreshes `bin/` shortcuts.
 
 #### `user.ts <subcommand> …`
 
-| Subcommand | Purpose |
-| --- | --- |
-| `list` | Print every user as a table with their admin flag (derived from a `(user, ':all', admin)` row in `user_gallery`). |
-| `passwd <id> <password> [--keep-secret]` | Upsert: creates the user if missing, updates the password if present. Default rotates the user's `secret` (kills active JWT sessions, correct for "password lost / leaked"); `--keep-secret` opts out and keeps sessions alive. |
-| `delete <id> [--yes]` | Delete the user and cascade their `user_gallery` rows (access + hide_map). Asks for confirmation unless `--yes` is given. |
-
-Access level changes are handled by [`access.ts`](#accessts-subcommand-) — `user.ts` doesn't touch the `user_gallery` table except to cascade-delete on `delete`.
-
-#### `access.ts <subcommand> …`
-
-Manages rows in the `user_gallery` table — access level (view / admin) and the `hide_map` privacy toggle. Replaces the previous "edit the DB directly with sqlite3" recipes. `:guest` (the sentinel user) and `:all` (the sentinel gallery) are accepted directly as positional arguments.
+Manages the `user` row, the global-admin flag, and the per-user grants in `user_gallery`. `:guest` (the sentinel user representing anonymous visitors) is accepted directly as a positional argument.
 
 | Subcommand | Purpose |
 | --- | --- |
-| `list [--user <id>] [--gallery <id>]` | Print existing rows as a table. Optional filters narrow to one user, one gallery, or both. |
-| `level <user> <gallery> <none\|view\|admin>` | Set the access level on a row (upserts). `none` is the row-level deny — the cascade stops here. Preserves any existing `hide_map` value on the same pair. |
-| `unset <user> <gallery> [--yes]` | Delete the row entirely so the cascade falls through to less-specific rows. Asks for confirmation unless `--yes` is given. |
-| `hide-map <user> <gallery> <hide\|show\|default>` | Set or clear the privacy toggle. `default` clears the override so the cascade falls through to a less-specific row. |
-
-`level … none` and `unset` are not the same: `level … none` writes a row with `access_level=0` and stops the cascade at that row (explicit deny at this level); `unset` deletes the row entirely and lets the cascade fall through to less-specific rows.
+| `list` | Print every user as a table with their `name` and global-admin flag (`user.is_admin`). |
+| `make-admin <id>` | Set `user.is_admin = 1` — global admin bypasses every per-gallery check. |
+| `revoke-admin <id>` | Set `user.is_admin = 0`. Per-gallery grants on `user_gallery` are untouched. |
+| `set-name <id> <name>` | Set the mutable display `name` on a user. |
+| `passwd <id> [password]` | Upsert: creates the user if missing, updates the password if present. Default rotates the user's `secret` (kills active JWT sessions, correct for "password lost / leaked"); `--keep-secret` opts out and keeps sessions alive. |
+| `grant <user> <gallery> [--editor]` | Upsert a `user_gallery` row. Default grants view; `--editor` flips `is_editor = 1` (gallery-editor tier). Re-running with a different `--editor` toggles it. |
+| `revoke <user> <gallery> [--yes]` | Delete the `user_gallery` row entirely. Asks for confirmation unless `--yes` is given. |
+| `hide-map <user> <gallery> <hide\|show\|default>` | Set or clear the privacy override on the row. `default` clears the override so the cascade falls through. |
+| `grants [user]` | Print direct `user_gallery` rows (optionally filtered to one user) plus a listing of users with the global-admin flag. |
+| `access [user]` | Print effective access for a user (direct grants + inherited via groups + `:guest` fallback), with the sources for each row. |
+| `audit` | Find users with no access, warn if the instance has no admin, or report `user_gallery` rows whose user is gone. |
+| `delete <id> [--yes]` | Delete the user and cascade their `user_gallery` rows. Asks for confirmation unless `--yes` is given. |
 
 Examples:
 
 ```sh
-./bin/access.ts level alice :all admin            # alice gets admin everywhere
-./bin/access.ts level :guest :all view            # public visitors can view everything
-./bin/access.ts level alice secret none           # block alice from "secret" even if :all grants view
-./bin/access.ts hide-map :guest dailybw hide      # hide map for guests on one gallery
-./bin/access.ts hide-map alice dailybw default    # clear alice's override on that gallery
-./bin/access.ts list --user alice                 # show alice's rows
-./bin/access.ts unset alice travel                # delete the row (with confirmation)
+./bin/user.ts make-admin alice                    # alice becomes global admin
+./bin/user.ts grant :guest :all                   # public visitors can view everything
+./bin/user.ts grant bob travel --editor           # bob can edit photos in the travel gallery
+./bin/user.ts hide-map :guest dailybw hide        # hide map for guests on one gallery
+./bin/user.ts access alice                        # what alice can actually see / edit, and why
+./bin/user.ts revoke bob secret                   # drop bob's grant on the "secret" gallery
 ```
 
-The cascade resolution lives in [server/lib/privacy.ts](lib/privacy.ts) and `loadUserAccessControl` in [server/db/sqlite3/index.ts](db/sqlite3/index.ts) — privacy-only rows (those with `access_level=NULL`) are filtered out of the access map so they don't break access fall-through to `:all`.
+#### `group.ts <subcommand> …`
+
+Manages user groups and their `group_gallery` grants. Groups are a way to collectively grant view / editor on a set of galleries to a set of users — a user inherits the union of every group they belong to (plus their own direct `user_gallery` grants, plus `:guest`'s grants as the floor).
+
+| Subcommand | Purpose |
+| --- | --- |
+| `list` | Every group with its member count and gallery-grant count. |
+| `show <id>` | Members + per-gallery grants for one group. |
+| `create <id> [--name <s>] [--description <s>]` | Create a group. |
+| `update <id> [--name <s>] [--description <s>]` | Update the metadata on a group. |
+| `delete <id> [--yes]` | Delete the group and cascade `user_group` + `group_gallery`. |
+| `members <id>` | List the members of a group. |
+| `add <user> <group>` | Add a user to a group. |
+| `remove <user> <group>` | Remove a user from a group. |
+| `grant <group> <gallery> [--editor]` | Upsert a `group_gallery` row. Same view / `--editor` toggle as `user.ts grant`. |
+| `revoke <group> <gallery> [--yes]` | Delete the `group_gallery` row. |
+| `hide-map <group> <gallery> <state>` | Set or clear the privacy override on the row. |
+| `audit` | Empty groups, groups with no grants, dangling FK rows. |
+
+The cascade resolution lives in [server/lib/privacy.ts](lib/privacy.ts) and [server/lib/authorizer.ts](lib/authorizer.ts). `user.ts access <user>` is the operator-friendly way to inspect the resolved access map for any user — it shows which row (direct, group-derived, or `:guest`-derived) contributed each gallery grant.
 
 #### `gallery.ts <id> [options]`
 
@@ -205,91 +219,87 @@ Wrapper scripts that source `.env` from the current working directory, prepend t
 
 ### Access control
 
-The access control has three levels of increasing access:
+Two flags carry the entire model:
 
-1. No access
-2. View access
-3. Admin access
+- **`user.is_admin`** — global admin. Bypasses every per-gallery check; can do everything the API exposes.
+- **`is_editor`** on `user_gallery` / `group_gallery` — gallery-editor tier. Can edit photo data on the gallery's photos and update most gallery settings; cannot delete the gallery itself or change `hostname` (instance-level concern).
 
-An access level can be assigned to each user globally, or to any number of galleries.
+A `user_gallery` or `group_gallery` row with `is_editor = 0` is a plain **view** grant — the holder can read the gallery and its photos but not modify anything.
 
-Gallery-level access is also hierarchical, with increasing scope:
+A user's effective access is the union of:
 
-1. Specific gallery
-2. Virtual gallery ":public", matching all galleries and their photos
-3. Virtual gallery ":all", matching every photo (including orphans not linked to any gallery)
+1. Their direct `user_gallery` rows.
+2. The `group_gallery` rows of every group they belong to (`user_group` join).
+3. `:guest`'s grants — the anonymous-visitor floor. Even a logged-in user with no direct or group grants still gets whatever `:guest` is allowed.
+
+The sentinel gallery **`:all`** is a wildcard target — a grant of `(subject, :all, …)` applies to every real gallery the instance owns. Use it for "anyone authenticated can view everything" patterns (`./bin/user.ts grant :guest :all`).
+
+The `hide_map` column on `user_gallery` / `group_gallery` is an independent per-row override of the gallery's map-visibility default — three states (hide / show / inherit-from-gallery) that resolve through the same cascade as the access grant.
+
+The authorization primitives live in [`server/lib/authorizer.ts`](lib/authorizer.ts):
+
+- `authorizeAdmin(userId)` — global admin only.
+- `authorizeGalleryView(userId, galleryId)` — any grant on the gallery (direct, group, or `:guest`).
+- `authorizeGalleryEditor(userId, galleryId)` — global admin OR `is_editor` on the gallery.
+- `authorizePhotoEditor(userId, photoId)` — global admin OR gallery-editor on at least one of the photo's galleries. Orphan photos (no gallery links) are global-admin-only.
+
+The **virtual-host scope** ([`server/lib/host-scope.ts`](lib/host-scope.ts)) layers on top: requests whose `Host` header matches a gallery's `hostname` regex are narrowed to that gallery's photos for both reads and writes. `requireUnscoped(request)` rejects cross-gallery admin operations on a bound hostname — `gh issue` examples in the top-level README.
 
 ### RESTful resources
 
-The required access level is listed in brackets at the end of each resource method. The access levels are hierarchical, with the following, ascending priority:
+The required tier is listed in brackets at the end of each route. From least to most privileged:
 
-1. **[gallery/view]** – User with view access assigned to the specific gallery, ":public", or ":all"
-2. **[view]** – User with global (":all") view access
-3. **[gallery/admin]** – User with admin access assigned to the specific gallery, ":public", or ":all"
-4. **[admin]** – User with global (":all") admin acces
-5. **[none]** – A user with access explicitly denied
-6. **[any]** – Any user with an account
+1. **[any]** — no auth required (anonymous OK, the request still inherits `:guest`'s grants).
+2. **[user]** — any authenticated user.
+3. **[gallery/view]** — any grant on the specific gallery (direct, group, or `:guest`).
+4. **[gallery/editor]** — `is_editor` on the gallery, or global admin.
+5. **[admin]** — global admin only.
+
+A bracketed `[unscoped]` suffix means the route is also rejected on hostname-bound instances (cross-gallery admin operations).
 
 - `/meta`
-  - `GET` – List all metadata **[any]**
-  - `POST` – Create a new metadata **[admin]**
-    1. `meta`
-    - Returns `meta`
-  - `GET ../:key` – Get metadata for the ky **[admin]**
-    - Returns `meta`
-  - `PUT ../:key` – Update metadata **[admin]**
-    1. `meta`
-    - Returns `meta`
-  - `DELETE ../:key` – Delete metadata **[admin]**
+  - `GET` — Boot metadata for the SPA **[any]**
+  - `POST` — Create a meta entry **[admin]**
+  - `GET ../:key` — Read one meta entry **[admin]**
+  - `PUT ../:key` — Update a meta entry **[admin]**
+  - `DELETE ../:key` — Delete a meta entry **[admin]**
 - `/tokens`
-  - `POST` – Login, create an authentication token **[any]**
-    1. `id`
-    2. `password`
-    - Returns `token`
-  - `GET` – Verify the current authenticatio ntoken **[any]**
-  - `DELETE` – Logout, revoke all tokens for the current user **[any]**
-  - `DELETE ../:userId` – Logout, revoke all tokens for the user **[admin]**
-- `/users`
-  - `GET` – List all users **[admin]**
-  - `POST` – Create a new user **[admin]**
-    1. `user`
-    - Returns `users`
-  - `GET ../:userId` – Get user **[admin]**
-    - Returns `user`
-  - `PUT ../:userId` – Update user **[admin]**
-    1. `user`
-    - Returns `user`
-  - `DELETE ../:userId` – Delete user **[admin]**
+  - `POST` — Login, mint an access + refresh token pair **[any]**
+  - `GET` — Verify the current token **[any]**
+  - `DELETE` — Logout the current session **[any]**
+  - `DELETE ../:userId` — Force-logout every session for a user **[admin]**
+- `/users` **[unscoped]**
+  - `GET` — List users **[admin]**
+  - `POST` — Create a user **[admin]**
+  - `GET ../:userId` — Read a user **[admin]**
+  - `PUT ../:userId` — Update a user (name, password, `is_admin`) **[admin]**
+  - `DELETE ../:userId` — Delete a user **[admin]**
+- `/groups` **[unscoped]**
+  - `GET` / `POST` / `GET ../:id` / `PUT ../:id` / `DELETE ../:id` — CRUD on user groups **[admin]**
+  - `GET ../:groupId/members` / `PUT ../:groupId/members/:userId` / `DELETE ../:groupId/members/:userId` — membership **[admin]**
+- `/user-gallery`, `/group-gallery` **[unscoped]**
+  - List + upsert + delete the per-gallery ACL rows **[admin]**
 - `/galleries`
-  - `GET` – List all galleries the user has access to **[view]**
-    - Returns `galleries`
-  - `POST` – Create a new gallery **[admin]**
-    1. `gallery`
-    - Returns `gallery`
-  - `GET ../:galleryId` – Get gallery and its photos **[gallery/view]**
-  - `PUT ../:galleryId` – Update gallery **[gallery/admin]**
-    1. `gallery`
-    - Returns `gallery`
-  - `DELETE ../:galleryId` – Delete gallery **[gallery/admin]**
+  - `GET` — Galleries the caller can see **[user]** (filtered by access map)
+  - `POST` — Create a gallery **[admin]**
+  - `GET ../:galleryId` — Read a gallery + its photos **[gallery/view]**
+  - `PUT ../:galleryId` — Update gallery settings **[gallery/editor]** (editors cannot set `hostname`)
+  - `DELETE ../:galleryId` — Delete a gallery **[admin]**
+  - `PUT ../:galleryId/icon` — Crop + render the gallery icon from one of its photos **[gallery/editor]**
 - `/photos`
-  - `GET` – Get all photos **[view]**
-    - Returns `photos`
-  - `POST` – Create a new photo **[admin]**
-    1. `photo`
-    - Returns `photo`
-  - `GET ../:photoId` – Get photo **[view]**
-    - Returns `photo`
-  - `PUT ../:photoId` – Update photo **[admin]**
-    1. `photo`
-    - Returns `photo`
-  - `DELETE ../:photoId` – Delete photo **[admin]**
+  - `GET` — Cross-gallery photo list (paginated, filterable) **[admin]**
+  - `GET ../:photoId` — Read a single photo **[gallery/view]** on any gallery it's linked to (orphans require **[admin]**)
+  - `PUT ../:photoId` — Update photo data (title, location, exposure, …) **[gallery/editor]** on any gallery it's linked to (orphans **[admin]**)
+  - `POST ../:photoId/regeocode` — Clear `geocoded_*` columns and drop a coord sidecar for the converter daemon **[gallery/editor]** on any of the photo's galleries
+  - `POST ../by-ids` — Batch fetch (cap 500), out-of-scope ids silently dropped **[user]**
+  - `GET ../audit-counts` — Per-predicate tallies for the dashboard tiles **[admin]**
+  - `GET ../year-months` — Per-(year, month) bucket counts for the filter timeline **[admin]**
+  - `DELETE ../:photoId` — Delete a photo row **[admin]**
 - `/gallery-photos`
-  - `GET ../:galleryId/` – Get all photos in the gallery **[gallery/view]**
-    - Returns `photos`
-  - `GET ../:galleryId/:photoId` – Get photo in gallery context **[gallery/view]**
-    - Returns `photo`
-  - `PUT ../:galleryId/:photoId` – Link photo to gallery **[gallery/admin]**
-  - `DELETE ../:galleryId/:photoId` – Unlink photo from gallery **[gallery/admin]**
+  - `PUT ../:galleryId/:photoId` — Link a photo into a gallery **[admin]**
+  - `DELETE ../:galleryId/:photoId` — Unlink **[gallery/editor]**
+
+The OpenAPI dump at `/api/v1/docs` (or `server/openapi.json` checked in) is the authoritative request / response shape for every route.
 
 ### Entities
 

--- a/server/bin/user.ts
+++ b/server/bin/user.ts
@@ -336,7 +336,7 @@ await yargs(hideBin(process.argv))
   )
   .command(
     "grant <user> <gallery>",
-    "Grant a user view (or admin with --admin) on a gallery. Idempotent — re-running with a different --admin toggles it.",
+    "Grant a user view (or gallery-editor with --editor) on a gallery. Idempotent — re-running with a different --editor toggles it.",
     (y) =>
       y
         .positional("user", { describe: "User ID (or :guest)", type: "string", demandOption: true })

--- a/server/lib/authorizer.ts
+++ b/server/lib/authorizer.ts
@@ -60,10 +60,9 @@ const authorizeGalleryView = async (
   return galleryId;
 };
 
-// Gallery-editor tier. Backed by the `is_admin` flag on
-// `user_gallery` / `group_gallery` — the column name predates the
-// tier name; the column stays so old grants keep working. Global
-// admins implicitly pass: they can do everything an editor can.
+// Gallery-editor tier. Backed by the `is_editor` flag on
+// `user_gallery` / `group_gallery`. Global admins implicitly
+// pass — they can do everything an editor can.
 const authorizeGalleryEditor = async (
   userId: string,
   galleryId: string

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.13.0"
+    "version": "0.14.0"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -56,5 +56,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.13.0"
+  "version": "0.14.0"
 }


### PR DESCRIPTION
## Summary

0.14 ships the Admin UI polish milestone plus the mobile / small-screen pass and the gallery-editor tier. Milestone closed at 0 open / 23 closed; #412 closed alongside as the catch-all mobile ticket covered across #502, #503, #504.

## Mechanics

- Version bumped 0.13.0 → 0.14.0 in root + `server` + `react-app` + `converter` `package.json`.
- `server/openapi.json` regenerated against the new `info.version`; `react-app/src/lib/api-schema.ts` regenerated from the new dump.
- `CHANGELOG.md`: `[Unreleased]` content stamped as `[0.14.0] - 2026-06-07`; fresh empty `[Unreleased]` heading added above.
- `README.md`: install / upgrade examples bumped to `0.14.0`; the 0.14 entry moves out of the Roadmap into Version History as a one-paragraph release summary; the post-release "in flight after 0.13" pointer becomes "after 0.14".

## Docs refresh — `server/README.md` ACL section

The ACL docs had drifted ~2 milestones behind the code. The old layout described an `access_level` enum (none / view / admin) per `user_gallery` row, plus a separate `bin/access.ts` script. Reality since 0.13 / 0.14:

- Migration 012 (0.13) collapsed `access_level` → `is_admin` boolean and added `user.is_admin` for the global tier.
- Migration 019 (0.14, part of #498) renamed `is_admin` → `is_editor` on `user_gallery` / `group_gallery` to match the gallery-editor vocabulary end-to-end.
- `bin/access.ts` is gone — grants moved into `bin/user.ts grant/revoke/grants/access/hide-map/audit` and `bin/group.ts grant/revoke/hide-map`.
- Authorization surface is `authorizeAdmin` / `authorizeGalleryView` / `authorizeGalleryEditor` / `authorizePhotoEditor` + `requireUnscoped` for cross-gallery admin routes on hostname-bound instances.

Updated:

- The `user.ts` subcommand table now lists the current 12 subcommands with their actual behaviour.
- A new `group.ts` table covers the parallel surface (CRUD + member + grant management).
- The `access.ts` section is gone (script doesn't exist).
- Access control intro rewritten to describe the two-flag model: `user.is_admin` (global) + `is_editor` (gallery-editor) + plain view grants + hide_map cascade, with `:guest` as the anonymous-visitor floor.
- RESTful resource list re-tagged: `[any]`, `[user]`, `[gallery/view]`, `[gallery/editor]`, `[admin]`, with `[unscoped]` suffix for cross-gallery admin routes; every entry checked against the current controllers.

## Drive-bys

- `server/lib/authorizer.ts`: comment on `authorizeGalleryEditor` referenced the pre-019 column name (`is_admin`); updated to `is_editor`.
- `server/bin/user.ts`: `grant` subcommand's `--help` text said "admin with --admin" but the flag is `--editor` (renamed end-to-end in #498). Fixed.

## Test plan

- [x] `npm run typecheck` + `npm run lint` + `npm test` clean in all three subtrees (react-app 979 tests, server 733 tests).
- [x] `server/openapi.json` `info.version` reports `0.14.0` (and `react-app/src/lib/api-schema.ts` is the matching regen).
- [ ] Skim README + server/README rendered on GitHub to confirm the version examples + ACL section read clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)