### PR TITLE
Landing page: square icon slot for every gallery card

### DIFF
--- a/react-app/src/components/Gallery/ListBody.tsx
+++ b/react-app/src/components/Gallery/ListBody.tsx
@@ -140,7 +140,9 @@ const ListBody = ({ galleries }: Props): React.ReactElement => {
             {gallery.title()}
           </GalleryTitle>
           {renderIcon(gallery)}
-          <Description>{gallery.description()}</Description>
+          {gallery.description() && (
+            <Description>{gallery.description()}</Description>
+          )}
         </Gallery>
       </Link>
     );

--- a/react-app/src/components/Gallery/ListBody.tsx
+++ b/react-app/src/components/Gallery/ListBody.tsx
@@ -76,11 +76,27 @@ const GalleryTitle = styled("h3", {
   text-align: center;
   margin: 0;
 `;
+// Reserve a square slot for the icon on every card so the layout
+// stays consistent whether or not the operator has cropped one.
+// `aspect-ratio: 1 / 1` pins the height to the card's full 214px
+// width; the placeholder background fills the slot for un-iconed
+// galleries.
 const IconContainer = styled.div`
   margin: 0;
-`;
-const Icon = styled.img`
   width: 100%;
+  aspect-ratio: 1 / 1;
+  background: var(--tile-background);
+`;
+// `display: block` kills the ~4px inline-baseline gap an <img>
+// otherwise leaves between itself and the surrounding box — that
+// gap showed through as a white stripe at the bottom of the
+// header-color tile. `object-fit: cover` keeps the cropped icon
+// filling the square without distortion.
+const Icon = styled.img`
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 `;
 const Description = styled.div`
   margin: 5px;
@@ -99,7 +115,7 @@ const ListBody = ({ galleries }: Props): React.ReactElement => {
   const { isHostScoped } = useHostScope();
   const renderIcon = (gallery: GalleryT) => {
     if (!gallery.hasIcon()) {
-      return "";
+      return <IconContainer aria-hidden />;
     }
     const url = `${config.PHOTO_ROOT_URL}${gallery.icon()}`;
     return (


### PR DESCRIPTION
## Summary

Two layout glitches on the gallery picker, both reported against 0.14:

1. **White stripe at the bottom of cards with an icon.** The `<Icon>` img was rendering inline by default, so the standard ~4px baseline gap below the image showed through as a thin white stripe (the gap revealed the card's own `var(--header-color)` background, typically white). `display: block` removes the gap.
2. **Cards with no icon collapsed to title + description, no square reserved.** `renderIcon` returned an empty string for un-iconed galleries, so those cards had no visual placeholder where the icon would land. Always render the IconContainer; when the gallery has no icon it fills with the theme's `--tile-background` as a square placeholder.

`IconContainer` now pins to `aspect-ratio: 1 / 1` so the slot is a square at the card's full 214px width whether the `<img>` mounts or not. The icon img also gets `object-fit: cover` so the cropper's 1:1 output fills the slot without any letterboxing.

## Test plan

- [ ] Gallery picker page renders cards with an icon → icon fills a square slot with no white stripe at the bottom.
- [ ] Gallery picker page renders cards without an icon → square placeholder slot appears in the same position; card height matches iconed cards.
- [ ] Switching themes → placeholder fills with the new `--tile-background`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)