### PR TITLE
Server: api-test fixture for :memory: sqlite + convert users.test.ts

### DIFF
--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -97,6 +97,8 @@ export default () => {
     deletePhoto,
     loadPhotoLocalized,
     clearLocalizedCity,
+
+    _resetForTests,
   };
 };
 
@@ -865,4 +867,26 @@ const clearLocalizedCity = async (
   db.prepare(
     "UPDATE photo_localized SET geocoded_city = NULL WHERE photo_id = ? AND lang = ?"
   ).run(photoId, lang);
+};
+
+// Test-only seam. The :memory: connection persists for the life of
+// the vitest worker (migrations already applied at module load), so
+// rather than dropping + remigrating between tests we DELETE rows
+// in FK-safe order and let the next `beforeEach` reseed. `:guest`
+// stays — migration 015 seeds it idempotently and the access cascade
+// depends on the row existing.
+const _resetForTests = (): void => {
+  db.exec(`
+    DELETE FROM photo_localized;
+    DELETE FROM gallery_photo;
+    DELETE FROM user_gallery;
+    DELETE FROM group_gallery;
+    DELETE FROM user_group;
+    DELETE FROM session;
+    DELETE FROM photo;
+    DELETE FROM gallery;
+    DELETE FROM "group";
+    DELETE FROM user WHERE id != ':guest';
+    DELETE FROM meta WHERE key != 'schema_version';
+  `);
 };

--- a/server/tests/api/fixture.ts
+++ b/server/tests/api/fixture.ts
@@ -1,0 +1,354 @@
+// Shared fixture for the API integration tests. Each test file
+// must `vi.mock("../../lib/config/index.js", () => ({ default:
+// TEST_CONFIG }))` at its own top level — `vi.mock` is hoisted
+// per file and can't live in this helper.
+//
+// The fixture re-creates the exact shape `db/dummy.ts` synthesises
+// at module load, but inserts it into a real `:memory:` SQLite via
+// the sqlite3 driver so the controllers exercise actual SQL.
+// Mirrors `#433`'s `db/sqlite3/helper.ts` for the parity tests,
+// extended with the broader API-test fixture (users / galleries /
+// photos / ACL / links).
+//
+// `db` and `config` are dynamic-imported inside `seedApiFixture`
+// so the test file's `vi.mock` lands before the driver module
+// reads `config.DB_DRIVER` / `DB_OPTS`. A static `import db` here
+// would load the driver against the real config before the mock
+// applied.
+
+export const TEST_CONFIG = {
+  ENV: "test",
+  PORT: "0",
+  SECRET: "test-secret",
+  DEBUG: false,
+  DB_DRIVER: "sqlite3",
+  DB_OPTS: ":memory:",
+};
+
+// bcrypt hash of "foobar" at cost 10 — same constant the dummy
+// fixture uses. cost 10 verifies fine under the test env's
+// `BCRYPT_ROUNDS=4` (bcrypt reads the cost from the hash prefix
+// for verification; the env var only affects new hashes).
+export const FIXTURE_PASSWORD = "foobar";
+const PASSWORD_HASH =
+  "$2b$10$7edID90/TmAdhGtJRqjDj.hBzXEJZorgDYZ9jwPcdDdqceYlaQ2ZG";
+
+interface UserSeed {
+  id: string;
+  isAdmin?: boolean;
+}
+const USERS: UserSeed[] = [
+  { id: "admin", isAdmin: true },
+  { id: "gallery1admin" },
+  { id: "gallery2admin" },
+  { id: "gallery1user" },
+  { id: "gallery12user" },
+  { id: "plainuser" },
+  { id: "publicuser" },
+  { id: "simpleuser" },
+  { id: "blockeduser" },
+];
+
+interface GallerySeed {
+  id: string;
+  title: string;
+  description: string;
+  theme?: string;
+}
+const GALLERIES: GallerySeed[] = [
+  {
+    id: "gallery1",
+    title: "gallery 1",
+    description: "This is the first gallery",
+  },
+  {
+    id: "gallery2",
+    title: "gallery 2",
+    description: "This is the second gallery",
+    theme: "blue",
+  },
+  {
+    id: "gallery3",
+    title: "gallery 3",
+    description: "This is the third gallery",
+    theme: "grayscale",
+  },
+];
+
+interface AccessSeed {
+  user: string;
+  gallery: string;
+  isEditor?: boolean;
+}
+const ACCESS: AccessSeed[] = [
+  { user: "gallery1admin", gallery: "gallery1", isEditor: true },
+  { user: "gallery2admin", gallery: "gallery2", isEditor: true },
+  { user: "gallery1user", gallery: "gallery1" },
+  { user: "gallery12user", gallery: "gallery1" },
+  { user: "gallery12user", gallery: "gallery2" },
+  // The historical `:all` / `:public` wildcard for plainuser /
+  // publicuser is now explicit per-gallery grants on every real
+  // gallery in the fixture.
+  { user: "plainuser", gallery: "gallery1" },
+  { user: "plainuser", gallery: "gallery2" },
+  { user: "plainuser", gallery: "gallery3" },
+  { user: "publicuser", gallery: "gallery1" },
+  { user: "publicuser", gallery: "gallery2" },
+  { user: "publicuser", gallery: "gallery3" },
+  { user: ":guest", gallery: "gallery3" },
+];
+
+interface PhotoSeed {
+  id: string;
+  index: number;
+  timestamp: string;
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  country: string;
+  latitude?: number;
+  longitude?: number;
+  altitude?: number;
+  cameraMake: string;
+  cameraModel: string;
+  cameraSerial?: string;
+  lensMake?: string;
+  lensModel?: string;
+  lensSerial?: string;
+  focalLength: number;
+  focalLength35mmEquiv?: number;
+  aperture: number;
+  exposureTime: number;
+  iso: number;
+}
+const PHOTOS: PhotoSeed[] = [
+  {
+    id: "gallery1photo.jpg",
+    index: 0,
+    timestamp: "2018-05-04 13:13:03",
+    year: 2018,
+    month: 5,
+    day: 4,
+    hour: 13,
+    minute: 13,
+    second: 3,
+    country: "jp",
+    latitude: 35.6595,
+    longitude: 139.7005,
+    altitude: 36.5,
+    cameraMake: "FUJIFILM",
+    cameraModel: "X-T2",
+    cameraSerial: "123",
+    lensMake: "FUJIFILM",
+    lensModel: "XF27mmF2.8",
+    lensSerial: "456",
+    focalLength: 27,
+    focalLength35mmEquiv: 41,
+    aperture: 5.6,
+    exposureTime: 0.0008,
+    iso: 200,
+  },
+  {
+    id: "gallery12photo.jpg",
+    index: 1,
+    timestamp: "2020-07-04 14:13:03",
+    year: 2020,
+    month: 7,
+    day: 4,
+    hour: 14,
+    minute: 13,
+    second: 3,
+    country: "nl",
+    cameraMake: "Panasonic",
+    cameraModel: "DMC-GX7",
+    lensModel: "LUMIX G 20/F1.7 II",
+    lensSerial: "04JG3165007",
+    focalLength: 20,
+    focalLength35mmEquiv: 40,
+    aperture: 1.7,
+    exposureTime: 0.0006666666666666666,
+    iso: 200,
+  },
+  {
+    id: "gallery2photo.jpg",
+    index: 2,
+    timestamp: "2020-07-05 14:13:03",
+    year: 2020,
+    month: 7,
+    day: 5,
+    hour: 14,
+    minute: 13,
+    second: 3,
+    country: "jp",
+    cameraMake: "FUJIFILM",
+    cameraModel: "X-T2",
+    cameraSerial: "111",
+    lensMake: "FUJIFILM",
+    lensModel: "XF27mmF2.8",
+    lensSerial: "222",
+    focalLength: 27,
+    focalLength35mmEquiv: 41,
+    aperture: 5.6,
+    exposureTime: 0.0008,
+    iso: 200,
+  },
+  {
+    id: "gallery3photo.jpg",
+    index: 3,
+    timestamp: "2020-07-05 14:13:04",
+    year: 2020,
+    month: 7,
+    day: 6,
+    hour: 14,
+    minute: 13,
+    second: 4,
+    country: "jp",
+    cameraMake: "FUJIFILM",
+    cameraModel: "X-T2",
+    cameraSerial: "111",
+    lensMake: "FUJIFILM",
+    lensModel: "XF27mmF2.8",
+    lensSerial: "222",
+    focalLength: 27,
+    focalLength35mmEquiv: 41,
+    aperture: 5.6,
+    exposureTime: 0.0008,
+    iso: 200,
+  },
+  {
+    id: "orphanphoto.jpg",
+    index: 4,
+    timestamp: "2020-08-05 14:13:03",
+    year: 2020,
+    month: 8,
+    day: 5,
+    hour: 14,
+    minute: 13,
+    second: 3,
+    country: "fi",
+    cameraMake: "FUJIFILM",
+    cameraModel: "X100F",
+    cameraSerial: "123456",
+    focalLength: 23,
+    aperture: 5.6,
+    exposureTime: 0.0005263157894736842,
+    iso: 200,
+  },
+];
+
+const LINKS: Record<string, string[]> = {
+  gallery1: ["gallery1photo.jpg", "gallery12photo.jpg"],
+  gallery2: ["gallery12photo.jpg", "gallery2photo.jpg"],
+  gallery3: ["gallery3photo.jpg"],
+};
+
+const META = {
+  instance_name: "dummy instance",
+  instance_description: "dummy instance for automated tests",
+  instance_cdn: "http://localhost",
+  instance_image: "dummy.jpg",
+};
+
+// Wipe + reseed the shared API-test fixture into the `:memory:`
+// sqlite3 connection that backs the test driver. Idempotent so
+// `beforeEach` can call it without ordering surprises between
+// tests in the same file (which all share one connection).
+export const seedApiFixture = async (): Promise<void> => {
+  const config = (await import("../../lib/config/index.js")).default;
+  if (config.DB_DRIVER !== "sqlite3" || config.DB_OPTS !== ":memory:") {
+    throw new Error(
+      "seedApiFixture requires DB_DRIVER=sqlite3 + DB_OPTS=:memory:" +
+        " — make sure vi.mock applied TEST_CONFIG."
+    );
+  }
+  const db = (await import("../../db/index.js")).default;
+  // `_resetForTests` is exposed on the sqlite3 driver factory only,
+  // not re-exported through the `db/index.ts` dispatcher (test-only
+  // seam stays out of the production surface). Reach for it via the
+  // driver factory directly — both factory calls share the same
+  // module-level `Database(":memory:")` connection, so this reset
+  // wipes the same DB the dispatcher writes to.
+  const driverFactory = (await import("../../db/sqlite3/index.js"))
+    .default;
+  driverFactory()._resetForTests();
+
+  for (const [key, value] of Object.entries(META)) {
+    await db.createMeta({ key, value });
+  }
+  for (const u of USERS) {
+    await db.createUser({
+      id: u.id,
+      name: u.id,
+      password: PASSWORD_HASH,
+      secret: "test-secret-" + u.id,
+      is_admin: u.isAdmin ? 1 : 0,
+    });
+  }
+  for (const g of GALLERIES) {
+    await db.createGallery({
+      id: g.id,
+      title: g.title,
+      description: g.description,
+      theme: g.theme ?? "",
+    });
+  }
+  for (const a of ACCESS) {
+    await db.upsertUserGallery({
+      user_id: a.user,
+      gallery_id: a.gallery,
+      is_editor: !!a.isEditor,
+    });
+  }
+  for (const p of PHOTOS) {
+    await db.createPhoto({
+      id: p.id,
+      index: p.index,
+      title: "",
+      description: "",
+      taken: {
+        instant: {
+          timestamp: p.timestamp,
+          year: p.year,
+          month: p.month,
+          day: p.day,
+          hour: p.hour,
+          minute: p.minute,
+          second: p.second,
+        },
+        author: "Ville Misaki",
+        location: {
+          country: p.country,
+          place: "",
+          coordinates: {
+            latitude: p.latitude ?? null,
+            longitude: p.longitude ?? null,
+            altitude: p.altitude ?? null,
+          },
+        },
+      },
+      camera: {
+        make: p.cameraMake,
+        model: p.cameraModel,
+        serial: p.cameraSerial ?? "",
+      },
+      lens: {
+        make: p.lensMake ?? "",
+        model: p.lensModel ?? "",
+        serial: p.lensSerial ?? "",
+      },
+      exposure: {
+        focalLength: p.focalLength,
+        focalLength35mmEquiv: p.focalLength35mmEquiv,
+        aperture: p.aperture,
+        exposureTime: p.exposureTime,
+        iso: p.iso,
+      },
+    });
+  }
+  for (const [galleryId, photoIds] of Object.entries(LINKS)) {
+    await db.linkGalleryPhoto([galleryId], photoIds);
+  }
+};

--- a/server/tests/api/users.test.ts
+++ b/server/tests/api/users.test.ts
@@ -1,13 +1,15 @@
-import { init } from "../../app.js";
-import dummyFactory from "../../db/dummy.js";
-import { createApi, loginUser } from "./helper.js";
+import { vi } from "vitest";
+import { TEST_CONFIG, seedApiFixture } from "./fixture.js";
 
-const db = dummyFactory();
+vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));
+
+import { init } from "../../app.js";
+import { createApi, loginUser } from "./helper.js";
 
 const { api } = createApi();
 
 beforeEach(async () => {
-  await db.init();
+  await seedApiFixture();
   await init();
 });
 
@@ -40,7 +42,9 @@ describe("As admin", () => {
     const response = await getUsers(token);
     const users = response.body;
     expect(users).toBeDefined();
-    expect(users.length).toBe(9);
+    // 9 named users in the fixture + `:guest` (seeded by
+    // migration 015 so the admin Users list always surfaces it).
+    expect(users.length).toBe(10);
     const admin = users.find((user: { id: string }) => user.id === "admin");
     expect(admin).toBeDefined();
     expect(admin.id).toBe("admin");


### PR DESCRIPTION
## Summary

First slice of #434 — the dummy → `:memory:`-sqlite migration for the API integration tests.

The dummy driver carries its own JavaScript-Maps implementation of every function on the canonical sqlite3 driver, so the SQL the real driver issues is never exercised by the API tests. Two bugs (the double-`AND` in `loadGalleryPhoto` and the empty `DO UPDATE SET` in `upsertUserGallery` / `upsertGroupGallery`) shipped to prod because the dummy implementation handled both cases in JS. The driver-level parity tests added in #433 caught them at the driver layer; the api / model layer still doesn't.

This PR lays the foundation and converts one file as proof of concept.

## What landed

- **`_resetForTests` on the sqlite3 driver** — a single `db.exec` that `DELETE`s from every user-data table in FK-safe order, keeping `:guest` (seeded by migration 015) so the access cascade stays consistent. Not re-exported through the `db/index.ts` dispatcher so the production surface stays clean; tests reach it via the driver factory directly.
- **`server/tests/api/fixture.ts`** — `TEST_CONFIG` (mirrors the parity-test pattern in `tests/db/sqlite3/helper.ts`), `FIXTURE_PASSWORD`, and `seedApiFixture()`. The seed re-creates the exact users / galleries / photos / ACL shape `db/dummy.ts` synthesises, but inserts via the dispatcher so the controllers exercise actual SQL. `db` + `config` are dynamic-imported inside the seed so each test file's `vi.mock` lands before the driver module reads `config.DB_DRIVER` / `DB_OPTS`.
- **Convert `tests/api/users.test.ts`** — first migrated file. Pattern:
  ```ts
  import { vi } from "vitest";
  import { TEST_CONFIG, seedApiFixture } from "./fixture.js";

  vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));

  import { init } from "../../app.js";
  // ...
  beforeEach(async () => {
    await seedApiFixture();
    await init();
  });
  ```
  The 9 → 10 user-count assertion bumps because migration 015 seeds `:guest` in the `user` table, which the dummy fixture never had. The pre-migration assertion was the inconsistency, not the new test setup.

## What stays for follow-ups

- The other 10 API test files (`galleries`, `gallery-photos`, `groups`, `group-gallery`, `host-scope`, `meta`, `photos`, `tokens`, `user-gallery`) still load `db/dummy.ts` and run against the dummy driver. `tests/models/token.test.ts` likewise.
- `npm test` keeps `DB_DRIVER=dummy` in its env. Files that opt into sqlite3 override per-file via `vi.mock`, so both code paths run side-by-side during the migration.
- After every file is converted: delete `db/dummy.ts`, drop the dummy special-case in `db/index.ts`, remove `DB_DRIVER=dummy` from `package.json`, file the milestone-end PR.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm test` — 28 files, 733 tests, all pass. `users.test.ts` runs against `:memory:` sqlite3 (44 tests); the other 10 api files run against dummy as before.
- [x] `users.test.ts` standalone (`npx vitest run tests/api/users.test.ts`) passes.
- [x] Parity tests in `tests/db/sqlite3/` still pass (10 files, 149 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)