### PR TITLE
Server: convert 5 more api tests to :memory: sqlite fixture

### DIFF
--- a/server/tests/api/group-gallery.test.ts
+++ b/server/tests/api/group-gallery.test.ts
@@ -1,12 +1,15 @@
+import { vi } from "vitest";
+import { TEST_CONFIG, seedApiFixture } from "./fixture.js";
+
+vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));
+
 import { init } from "../../app.js";
-import dummyFactory from "../../db/dummy.js";
 import { createApi, loginUser } from "./helper.js";
 
-const db = dummyFactory();
 const { api } = createApi();
 
 beforeEach(async () => {
-  await db.init();
+  await seedApiFixture();
   await init();
 });
 

--- a/server/tests/api/groups.test.ts
+++ b/server/tests/api/groups.test.ts
@@ -1,12 +1,15 @@
+import { vi } from "vitest";
+import { TEST_CONFIG, seedApiFixture } from "./fixture.js";
+
+vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));
+
 import { init } from "../../app.js";
-import dummyFactory from "../../db/dummy.js";
 import { createApi, loginUser } from "./helper.js";
 
-const db = dummyFactory();
 const { api } = createApi();
 
 beforeEach(async () => {
-  await db.init();
+  await seedApiFixture();
   await init();
 });
 

--- a/server/tests/api/meta.test.ts
+++ b/server/tests/api/meta.test.ts
@@ -1,13 +1,15 @@
-import { init } from "../../app.js";
-import dummyFactory from "../../db/dummy.js";
-import { createApi, loginUser } from "./helper.js";
+import { vi } from "vitest";
+import { TEST_CONFIG, seedApiFixture } from "./fixture.js";
 
-const db = dummyFactory();
+vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));
+
+import { init } from "../../app.js";
+import { createApi, loginUser } from "./helper.js";
 
 const { api } = createApi();
 
 beforeEach(async () => {
-  await db.init();
+  await seedApiFixture();
   await init();
 });
 

--- a/server/tests/api/tokens.test.ts
+++ b/server/tests/api/tokens.test.ts
@@ -1,3 +1,8 @@
+import { vi } from "vitest";
+import { TEST_CONFIG, seedApiFixture } from "./fixture.js";
+
+vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));
+
 import { init } from "../../app.js";
 import { _resetLoginRateLimitForTests } from "../../controllers/tokens-v1.js";
 import { createApi, loginUser, loginUserPair } from "./helper.js";
@@ -5,6 +10,7 @@ import { createApi, loginUser, loginUserPair } from "./helper.js";
 const { api } = createApi();
 
 beforeEach(async () => {
+  await seedApiFixture();
   await init();
   // The login throttle holds in-memory per-IP failure counts that persist
   // across tests (supertest always connects from 127.0.0.1, so every test

--- a/server/tests/api/user-gallery.test.ts
+++ b/server/tests/api/user-gallery.test.ts
@@ -1,13 +1,15 @@
-import { init } from "../../app.js";
-import dummyFactory from "../../db/dummy.js";
-import { createApi, loginUser } from "./helper.js";
+import { vi } from "vitest";
+import { TEST_CONFIG, seedApiFixture } from "./fixture.js";
 
-const db = dummyFactory();
+vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));
+
+import { init } from "../../app.js";
+import { createApi, loginUser } from "./helper.js";
 
 const { api } = createApi();
 
 beforeEach(async () => {
-  await db.init();
+  await seedApiFixture();
   await init();
 });
 


### PR DESCRIPTION
## Summary

Batch 1 of the #434 follow-ups. Five small/medium API test files swap from `dummyFactory().init()` to `seedApiFixture()` + the per-file `vi.mock` of the config module — same mechanical conversion the foundation PR used for `users.test.ts`.

## Files

- `tests/api/tokens.test.ts` (login flow, refresh tokens, rate-limit reset)
- `tests/api/meta.test.ts` (instance meta CRUD)
- `tests/api/groups.test.ts` (user-group CRUD)
- `tests/api/group-gallery.test.ts` (group-gallery ACL)
- `tests/api/user-gallery.test.ts` (user-gallery ACL)

## Notes

`tokens.test.ts` had no `db.init()` call in its prior `beforeEach` — the file relied on the dummy module's load-time init for fresh state. With the underlying connection now a persistent sqlite3 `:memory:`, state would leak between tests within the file, so `await seedApiFixture()` in `beforeEach` is mandatory. The other four files already had a `db.init()` for the same reset purpose; the swap is one-for-one.

## What stays on dummy

Five files: `galleries`, `gallery-photos`, `photos`, `host-scope`, plus `tests/models/token.test.ts`. Bigger files — splitting them into the next batch keeps each PR reviewable.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm test` — 28 files, 733 tests, all pass. Six files now run against `:memory:` sqlite3 (`users` + this batch); the other five api files + `tests/models/token.test.ts` still run against dummy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)