### PR TITLE
Server: convert remaining api + model tests to :memory: sqlite fixture

### DIFF
--- a/server/tests/api/galleries.test.ts
+++ b/server/tests/api/galleries.test.ts
@@ -1,14 +1,16 @@
+import { vi } from "vitest";
+import { TEST_CONFIG, seedApiFixture } from "./fixture.js";
+
+vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));
+
 import { init } from "../../app.js";
-import dummyFactory from "../../db/dummy.js";
 import dbFacade from "../../db/index.js";
 import { createApi, loginUser } from "./helper.js";
-
-const db = dummyFactory();
 
 const { api } = createApi();
 
 beforeEach(async () => {
-  await db.init();
+  await seedApiFixture();
   await init();
 });
 

--- a/server/tests/api/gallery-photos.test.ts
+++ b/server/tests/api/gallery-photos.test.ts
@@ -1,13 +1,15 @@
-import { init } from "../../app.js";
-import dummyFactory from "../../db/dummy.js";
-import { createApi, loginUser } from "./helper.js";
+import { vi } from "vitest";
+import { TEST_CONFIG, seedApiFixture } from "./fixture.js";
 
-const db = dummyFactory();
+vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));
+
+import { init } from "../../app.js";
+import { createApi, loginUser } from "./helper.js";
 
 const { api } = createApi();
 
 beforeEach(async () => {
-  await db.init();
+  await seedApiFixture();
   await init();
 });
 

--- a/server/tests/api/host-scope.test.ts
+++ b/server/tests/api/host-scope.test.ts
@@ -1,16 +1,17 @@
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { Agent } from "supertest";
+import { TEST_CONFIG, seedApiFixture } from "./fixture.js";
+
+vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));
 
 import { init } from "../../app.js";
-import dummyFactory from "../../db/dummy.js";
 import dbFacade from "../../db/index.js";
 import { createApi, loginUser } from "./helper.js";
 
-const db = dummyFactory();
 const { api } = createApi();
 
 beforeEach(async () => {
-  await db.init();
+  await seedApiFixture();
   // Pin two galleries to test hostnames. gallery3 stays unpinned so
   // we can exercise "off-scope gallery from a scoped host."
   await dbFacade.updateGallery("gallery1", {

--- a/server/tests/api/photos.test.ts
+++ b/server/tests/api/photos.test.ts
@@ -1,14 +1,16 @@
+import { vi } from "vitest";
+import { TEST_CONFIG, seedApiFixture } from "./fixture.js";
+
+vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));
+
 import { init } from "../../app.js";
-import dummyFactory from "../../db/dummy.js";
 import dbFacade from "../../db/index.js";
 import { createApi, loginUser } from "./helper.js";
-
-const db = dummyFactory();
 
 const { api } = createApi();
 
 beforeEach(async () => {
-  await db.init();
+  await seedApiFixture();
   await init();
 });
 

--- a/server/tests/models/token.test.ts
+++ b/server/tests/models/token.test.ts
@@ -1,17 +1,18 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { TEST_CONFIG, seedApiFixture } from "../api/fixture.js";
 
-import dbFactory from "../../db/dummy.js";
+vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));
+
 import CONST from "../../lib/constants.js";
 import { InvalidTokenError, TokenExpiredError } from "../../lib/errors.js";
 import tokenFactory from "../../models/token.js";
 
-const db = dbFactory();
 const model = tokenFactory();
 
 beforeEach(async () => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2026-05-23T00:00:00Z"));
-  await db.init();
+  await seedApiFixture();
   await model.init();
 });
 


### PR DESCRIPTION
## Summary

Batch 2 of the #434 follow-ups — the last five files that still imported `db/dummy.ts`. After this PR, every api / model test runs against real `:memory:` sqlite3; `db/dummy.ts` is no longer imported anywhere outside its own module.

## Files

- `tests/api/galleries.test.ts` (gallery CRUD)
- `tests/api/gallery-photos.test.ts` (gallery-photo links)
- `tests/api/photos.test.ts` (photo CRUD, audit, regeocode, by-ids)
- `tests/api/host-scope.test.ts` (virtual-host scope narrowing)
- `tests/models/token.test.ts` (JWT + refresh-token model)

## Mechanics

Same mechanical conversion as batch 1: import `TEST_CONFIG` + `seedApiFixture` from the shared fixture, `vi.mock` the config module, swap `db.init()` for `seedApiFixture()` in `beforeEach`.

- `host-scope.test.ts` keeps its post-seed `dbFacade.updateGallery` calls that pin `gallery1` / `gallery2` to test hostnames — the hostname column isn't part of the shared fixture (it'd narrow every test that ignores hosts).
- `tests/models/token.test.ts` drops its `dummyFactory` import in favour of letting the model's internal `db` resolve through the mocked config. Secrets reload from the seeded sqlite3 rows in `model.init()`, so the test behaves identically to the prior dummy-backed path.

## What's next

Finale PR will:
- Delete `server/db/dummy.ts`.
- Drop the dummy special-case in `server/db/index.ts` (the `drivers` map collapses to just `sqlite3`).
- Remove `DB_DRIVER=dummy` from the `package.json` test script (let it inherit from the per-file `vi.mock`).

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm test` — 28 files, 733 tests, all pass. Every api / model test now runs against `:memory:` sqlite3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)