### PR TITLE
Server: POST /galleries/:id/stats endpoint (#286, slice 3)

### DIFF
--- a/react-app/src/lib/api-schema.ts
+++ b/react-app/src/lib/api-schema.ts
@@ -1743,6 +1743,87 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/galleries/{galleryId}/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Aggregated stats for a gallery (gallery view) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    galleryId: string;
+                };
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        filter?: {
+                            [key: string]: {
+                                [key: string]: (string | number | boolean | null)[];
+                            };
+                        };
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            total: number;
+                            byCategory: {
+                                [key: string]: {
+                                    [key: string]: number;
+                                };
+                            };
+                            byYearMonth: {
+                                [key: string]: {
+                                    [key: string]: number;
+                                };
+                            };
+                            summary: {
+                                first?: string;
+                                last?: string;
+                                spanDays: number;
+                                spanYears: number;
+                                spanMonths: number;
+                                peakShape: {
+                                    [key: string]: string;
+                                };
+                                variety: {
+                                    [key: string]: number;
+                                };
+                            };
+                            daysInYear: {
+                                [key: string]: number;
+                            };
+                            daysInYearMonth: {
+                                [key: string]: {
+                                    [key: string]: number;
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/server/app.ts
+++ b/server/app.ts
@@ -21,6 +21,7 @@ import galleryPhotosV1 from "./controllers/gallery-photos-v1.js";
 import userGalleryV1 from "./controllers/user-gallery-v1.js";
 import groupsV1 from "./controllers/groups-v1.js";
 import groupGalleryV1 from "./controllers/group-gallery-v1.js";
+import statsV1 from "./controllers/stats-v1.js";
 
 import middleware from "./lib/middleware/index.js";
 import { NotFoundError } from "./lib/errors.js";
@@ -95,6 +96,7 @@ await app.register(fastifySwagger, {
         name: "group-gallery",
         description: "Group-level gallery grants (admin)",
       },
+      { name: "stats", description: "Aggregated gallery stats" },
     ],
     components: {
       securitySchemes: {
@@ -174,6 +176,7 @@ await app.register(groupsV1.plugin, { prefix: "/api/v1/groups" });
 await app.register(groupGalleryV1.plugin, {
   prefix: "/api/v1/group-gallery",
 });
+await app.register(statsV1.plugin, { prefix: "/api/v1/galleries" });
 
 // Double-duty 404 handler: serve index.html for SPA routes so
 // React Router can resolve deep links (refreshing /m/photos, or
@@ -198,6 +201,7 @@ export const init = async () => {
   await userGalleryV1.init();
   await groupsV1.init();
   await groupGalleryV1.init();
+  await statsV1.init();
   await app.ready();
   logger.debug("Initialize app done");
 };

--- a/server/controllers/stats-v1.ts
+++ b/server/controllers/stats-v1.ts
@@ -1,0 +1,92 @@
+import { Type } from "typebox";
+import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
+
+import authorizerFactory from "../lib/authorizer.js";
+import { requireScopeMatches } from "../lib/host-scope.js";
+import statsFactory from "../models/stats.js";
+import type { FilterShape } from "../lib/photo-filter-eval.js";
+
+const authorizer = authorizerFactory();
+const model = statsFactory();
+
+const init = async () => {};
+
+const GalleryIdParam = Type.Object({ galleryId: Type.String() });
+
+// Filter wire shape. `additionalProperties: true` because the
+// evaluator drops unknown categories rather than rejecting — same
+// forward-compat property the test suite asserts.
+const FilterKey = Type.Union([
+  Type.String(),
+  Type.Number(),
+  Type.Boolean(),
+  Type.Null(),
+]);
+const FilterCategory = Type.Array(FilterKey);
+const FilterTopic = Type.Record(Type.String(), FilterCategory, {
+  additionalProperties: true,
+});
+const FilterSchema = Type.Record(Type.String(), FilterTopic, {
+  additionalProperties: true,
+});
+
+const StatsBody = Type.Object({
+  filter: Type.Optional(FilterSchema),
+});
+
+const BucketCounts = Type.Record(Type.String(), Type.Number());
+const YearMonthCounts = Type.Record(Type.String(), BucketCounts);
+
+const StatsResponse = Type.Object({
+  total: Type.Number(),
+  byCategory: Type.Record(Type.String(), BucketCounts),
+  byYearMonth: YearMonthCounts,
+  summary: Type.Object({
+    first: Type.Optional(Type.String()),
+    last: Type.Optional(Type.String()),
+    spanDays: Type.Number(),
+    spanYears: Type.Number(),
+    spanMonths: Type.Number(),
+    peakShape: Type.Record(Type.String(), Type.String()),
+    variety: Type.Record(Type.String(), Type.Number()),
+  }),
+  daysInYear: Type.Record(Type.String(), Type.Number()),
+  daysInYearMonth: YearMonthCounts,
+});
+
+const TAGS = ["stats"];
+
+const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
+  /**
+   * Aggregated stats for one gallery. Body carries the same filter
+   * shape `useFiltersStore` produces on the client (topic / category
+   * / keys). Empty body returns the unfiltered base — slice 4 will
+   * add a single-key cache for that case.
+   */
+  fastify.post(
+    "/:galleryId/stats",
+    {
+      schema: {
+        tags: TAGS,
+        summary: "Aggregated stats for a gallery (gallery view)",
+        params: GalleryIdParam,
+        body: StatsBody,
+        response: { 200: StatsResponse },
+        security: [{ bearer: [] }],
+      },
+    },
+    async (request) => {
+      requireScopeMatches(request, request.params.galleryId);
+      await authorizer.authorizeGalleryView(
+        request.user.id,
+        request.params.galleryId
+      );
+      return await model.getGalleryStats(
+        request.params.galleryId,
+        request.body.filter as FilterShape | undefined
+      );
+    }
+  );
+};
+
+export default { init, plugin };

--- a/server/models/stats.ts
+++ b/server/models/stats.ts
@@ -1,0 +1,332 @@
+// Server-side stats aggregation. Loads the gallery's photos, applies
+// the filter (slice 2's evaluator), and builds the bucket maps the
+// `POST /api/v1/galleries/:galleryId/stats` endpoint returns.
+//
+// Each category produces a `Record<key, count>` over the filtered
+// photo set. Bucket keys are stringified derived values; the
+// `<unknown>` bucket uses the literal string "unknown" to match
+// what the client's stats today already uses internally (clients
+// localise the label at render time). Cross-photo aggregates
+// (first / last / span / variety / peak shape) land in `summary`.
+
+import db from "../db/index.js";
+import type { Photo } from "../db/sqlite3/schema.js";
+import * as derived from "../lib/photo-derived.js";
+import {
+  matchesFilter,
+  type FilterShape,
+} from "../lib/photo-filter-eval.js";
+
+export default () => ({
+  getGalleryStats,
+});
+
+export const UNKNOWN_BUCKET = "unknown";
+
+export type BucketCounts = Record<string, number>;
+export interface YearMonthCounts {
+  [year: string]: Record<string, number>;
+}
+export type PeakShape = "leader" | "tied" | "even";
+
+export interface StatsSummary {
+  first?: string;
+  last?: string;
+  spanDays: number;
+  spanYears: number;
+  spanMonths: number;
+  peakShape: Record<string, PeakShape>;
+  variety: Record<string, number>;
+}
+
+export interface StatsResponse {
+  total: number;
+  byCategory: Record<string, BucketCounts>;
+  byYearMonth: YearMonthCounts;
+  summary: StatsSummary;
+  daysInYear: Record<string, number>;
+  daysInYearMonth: YearMonthCounts;
+}
+
+const inc = (map: BucketCounts, key: string): void => {
+  map[key] = (map[key] ?? 0) + 1;
+};
+
+const bucketByString = (
+  photos: Photo[],
+  deriver: (photo: Photo) => string | undefined
+): BucketCounts => {
+  const out: BucketCounts = {};
+  for (const photo of photos) {
+    const value = deriver(photo);
+    inc(out, value ?? UNKNOWN_BUCKET);
+  }
+  return out;
+};
+
+const bucketByNumber = (
+  photos: Photo[],
+  deriver: (photo: Photo) => number | undefined
+): BucketCounts => {
+  const out: BucketCounts = {};
+  for (const photo of photos) {
+    const value = deriver(photo);
+    inc(out, value === undefined ? UNKNOWN_BUCKET : String(value));
+  }
+  return out;
+};
+
+const formatCamera = (photo: Photo): string | undefined =>
+  derived.formatGear(photo.camera?.make, photo.camera?.model);
+
+const formatLens = (photo: Photo): string | undefined =>
+  derived.formatGear(photo.lens?.make, photo.lens?.model);
+
+const geocodedCityKey = (photo: Photo): string | undefined => {
+  const cityEn = photo.geocoded?.cityEn ?? photo.geocoded?.city;
+  if (!cityEn) return undefined;
+  return JSON.stringify([
+    photo.geocoded?.countryCode ?? "",
+    photo.geocoded?.stateCode ?? "",
+    cityEn,
+  ]);
+};
+
+const cameraLensPairKey = (photo: Photo): string | undefined => {
+  const camera = formatCamera(photo);
+  const lens = formatLens(photo);
+  if (!camera && !lens) return undefined;
+  return JSON.stringify([camera ?? null, lens ?? null]);
+};
+
+const countDistinct = (
+  photos: Photo[],
+  deriver: (photo: Photo) => string | undefined
+): number => {
+  const set = new Set<string>();
+  for (const photo of photos) {
+    const value = deriver(photo);
+    if (value) set.add(value);
+  }
+  return set.size;
+};
+
+// Peak-shape classifier. Per the scoping doc: ≤1 leader within 1%
+// of max → "leader"; 2–3 within 1% → "tied"; ≥4 within 1% → "even".
+const NEAR_TIE_THRESHOLD = 0.01;
+const peakShape = (buckets: BucketCounts): PeakShape => {
+  const values = Object.values(buckets);
+  if (values.length === 0) return "leader";
+  const max = Math.max(...values);
+  if (max === 0) return "leader";
+  const tied = values.filter((v) => (max - v) / max <= NEAR_TIE_THRESHOLD)
+    .length;
+  if (tied <= 1) return "leader";
+  if (tied <= 3) return "tied";
+  return "even";
+};
+
+const buildByYearMonth = (photos: Photo[]): YearMonthCounts => {
+  const out: YearMonthCounts = {};
+  for (const photo of photos) {
+    const year = String(photo.taken.instant.year);
+    const month = String(photo.taken.instant.month);
+    if (!out[year]) out[year] = {};
+    out[year][month] = (out[year][month] ?? 0) + 1;
+  }
+  return out;
+};
+
+const daysInCalendarYear = (year: number): number => {
+  // Gregorian leap rule.
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  return leap ? 366 : 365;
+};
+const daysInCalendarMonth = (year: number, month: number): number => {
+  // month is 1-indexed; pass 0 of next month to get last day of this.
+  return new Date(year, month, 0).getDate();
+};
+
+const buildDaysInYear = (photos: Photo[]): Record<string, number> => {
+  const years = new Set<number>();
+  for (const photo of photos) years.add(photo.taken.instant.year);
+  const out: Record<string, number> = {};
+  for (const year of years) {
+    out[String(year)] = daysInCalendarYear(year);
+  }
+  return out;
+};
+
+const buildDaysInYearMonth = (photos: Photo[]): YearMonthCounts => {
+  const seen = new Map<number, Set<number>>();
+  for (const photo of photos) {
+    const year = photo.taken.instant.year;
+    const month = photo.taken.instant.month;
+    if (!seen.has(year)) seen.set(year, new Set());
+    seen.get(year)!.add(month);
+  }
+  const out: YearMonthCounts = {};
+  for (const [year, months] of seen.entries()) {
+    out[String(year)] = {};
+    for (const month of months) {
+      out[String(year)][String(month)] = daysInCalendarMonth(year, month);
+    }
+  }
+  return out;
+};
+
+const compareTimestamps = (a: Photo, b: Photo): number =>
+  a.taken.instant.timestamp.localeCompare(b.taken.instant.timestamp);
+
+const formatDate = (photo: Photo): string => {
+  const i = photo.taken.instant;
+  return `${i.year}-${String(i.month).padStart(2, "0")}-${String(
+    i.day
+  ).padStart(2, "0")}`;
+};
+
+const computeSpan = (
+  first: Photo | undefined,
+  last: Photo | undefined
+): { spanDays: number; spanYears: number; spanMonths: number } => {
+  if (!first || !last) return { spanDays: 0, spanYears: 0, spanMonths: 0 };
+  const firstDate = new Date(
+    first.taken.instant.year,
+    first.taken.instant.month - 1,
+    first.taken.instant.day
+  );
+  const lastDate = new Date(
+    last.taken.instant.year,
+    last.taken.instant.month - 1,
+    last.taken.instant.day
+  );
+  const ms = lastDate.getTime() - firstDate.getTime();
+  const spanDays = Math.max(0, Math.round(ms / (24 * 60 * 60 * 1000)));
+  const spanYears = Math.floor(spanDays / 365.25);
+  const spanMonths = Math.floor(spanDays / (365.25 / 12));
+  return { spanDays, spanYears, spanMonths };
+};
+
+const buildByCategory = (
+  photos: Photo[]
+): Record<string, BucketCounts> => ({
+  author: bucketByString(photos, (p) => p.taken.author),
+  country: bucketByString(photos, (p) => p.taken.location?.country),
+  state: bucketByString(photos, (p) => p.geocoded?.stateCode),
+  city: bucketByString(photos, geocodedCityKey),
+  year: bucketByNumber(photos, (p) => p.taken.instant.year),
+  month: bucketByNumber(photos, (p) => p.taken.instant.month),
+  weekday: bucketByNumber(photos, (p) =>
+    derived.weekday(
+      p.taken.instant.year,
+      p.taken.instant.month,
+      p.taken.instant.day
+    )
+  ),
+  hour: bucketByNumber(photos, (p) => p.taken.instant.hour),
+  cameraMake: bucketByString(photos, (p) => p.camera?.make),
+  camera: bucketByString(photos, formatCamera),
+  lens: bucketByString(photos, formatLens),
+  cameraLens: bucketByString(photos, cameraLensPairKey),
+  focalLength: bucketByNumber(photos, (p) => p.exposure?.focalLength),
+  focalLength35mmEquiv: bucketByNumber(photos, (p) =>
+    derived.focalLength35mmEquiv(
+      p.exposure?.focalLength,
+      p.camera?.make,
+      p.camera?.model,
+      p.exposure?.focalLength35mmEquiv
+    )
+  ),
+  aperture: bucketByNumber(photos, (p) => p.exposure?.aperture),
+  exposureTime: bucketByNumber(photos, (p) => p.exposure?.exposureTime),
+  iso: bucketByNumber(photos, (p) => p.exposure?.iso),
+  ev: bucketByNumber(photos, (p) =>
+    derived.exposureValue(p.exposure?.aperture, p.exposure?.exposureTime)
+  ),
+  lv: bucketByNumber(photos, (p) =>
+    derived.lightValue(
+      p.exposure?.aperture,
+      p.exposure?.exposureTime,
+      p.exposure?.iso
+    )
+  ),
+  resolution: bucketByNumber(photos, (p) =>
+    derived.resolution(
+      p.dimensions?.original?.width,
+      p.dimensions?.original?.height
+    )
+  ),
+  orientation: bucketByString(photos, (p) =>
+    derived.orientation(
+      p.dimensions?.original?.width,
+      p.dimensions?.original?.height
+    )
+  ),
+  aspectRatio: bucketByString(photos, (p) =>
+    derived.aspectRatio(
+      p.dimensions?.original?.width,
+      p.dimensions?.original?.height
+    )
+  ),
+});
+
+export const computeStats = (
+  photos: Photo[],
+  filter?: FilterShape
+): StatsResponse => {
+  const filtered = filter
+    ? photos.filter((p) => matchesFilter(filter, p))
+    : photos;
+
+  const byCategory = buildByCategory(filtered);
+  const byYearMonth = buildByYearMonth(filtered);
+
+  const sorted = filtered.slice().sort(compareTimestamps);
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  const { spanDays, spanYears, spanMonths } = computeSpan(first, last);
+
+  const summary: StatsSummary = {
+    first: first ? formatDate(first) : undefined,
+    last: last ? formatDate(last) : undefined,
+    spanDays,
+    spanYears,
+    spanMonths,
+    peakShape: {
+      year: peakShape(byCategory.year),
+      month: peakShape(byCategory.month),
+      weekday: peakShape(byCategory.weekday),
+      hour: peakShape(byCategory.hour),
+      camera: peakShape(byCategory.camera),
+      lens: peakShape(byCategory.lens),
+      cameraLens: peakShape(byCategory.cameraLens),
+    },
+    variety: {
+      author: countDistinct(filtered, (p) => p.taken.author),
+      country: countDistinct(filtered, (p) => p.taken.location?.country),
+      state: countDistinct(filtered, (p) => p.geocoded?.stateCode),
+      city: countDistinct(filtered, geocodedCityKey),
+      camera: countDistinct(filtered, formatCamera),
+      lens: countDistinct(filtered, formatLens),
+      cameraMake: countDistinct(filtered, (p) => p.camera?.make),
+      cameraLens: countDistinct(filtered, cameraLensPairKey),
+    },
+  };
+
+  return {
+    total: filtered.length,
+    byCategory,
+    byYearMonth,
+    summary,
+    daysInYear: buildDaysInYear(filtered),
+    daysInYearMonth: buildDaysInYearMonth(filtered),
+  };
+};
+
+const getGalleryStats = async (
+  galleryId: string,
+  filter?: FilterShape
+): Promise<StatsResponse> => {
+  const photos = (await db.loadGalleryPhotos(galleryId)) as Photo[];
+  return computeStats(photos, filter);
+};

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -2846,6 +2846,163 @@
           }
         }
       }
+    },
+    "/api/v1/galleries/{galleryId}/stats": {
+      "post": {
+        "summary": "Aggregated stats for a gallery (gallery view)",
+        "tags": [
+          "stats"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "filter": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "galleryId",
+            "required": true
+          }
+        ],
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "total",
+                    "byCategory",
+                    "byYearMonth",
+                    "summary",
+                    "daysInYear",
+                    "daysInYearMonth"
+                  ],
+                  "properties": {
+                    "total": {
+                      "type": "number"
+                    },
+                    "byCategory": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "byYearMonth": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "summary": {
+                      "type": "object",
+                      "required": [
+                        "spanDays",
+                        "spanYears",
+                        "spanMonths",
+                        "peakShape",
+                        "variety"
+                      ],
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "spanDays": {
+                          "type": "number"
+                        },
+                        "spanYears": {
+                          "type": "number"
+                        },
+                        "spanMonths": {
+                          "type": "number"
+                        },
+                        "peakShape": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "variety": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    "daysInYear": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "number"
+                      }
+                    },
+                    "daysInYearMonth": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "tags": [
@@ -2880,6 +3037,10 @@
     {
       "name": "group-gallery",
       "description": "Group-level gallery grants (admin)"
+    },
+    {
+      "name": "stats",
+      "description": "Aggregated gallery stats"
     }
   ]
 }

--- a/server/tests/api/stats.test.ts
+++ b/server/tests/api/stats.test.ts
@@ -1,0 +1,167 @@
+import { vi } from "vitest";
+import { TEST_CONFIG, seedApiFixture } from "./fixture.js";
+
+vi.mock("../../lib/config/index.js", () => ({ default: TEST_CONFIG }));
+
+import { init } from "../../app.js";
+import { createApi, loginUser } from "./helper.js";
+
+const { api } = createApi();
+
+beforeEach(async () => {
+  await seedApiFixture();
+  await init();
+});
+
+const postStats = async (
+  token: string | undefined,
+  galleryId: string,
+  body: Record<string, unknown> = {},
+  status = 200
+) =>
+  api
+    .post(`/api/v1/galleries/${galleryId}/stats`)
+    .set("Authorization", `Bearer ${token}`)
+    .send(body)
+    .expect(status);
+
+describe("auth", () => {
+  test("guest with no grant → 403 (gallery1 isn't open to :guest)", async () => {
+    await api.post("/api/v1/galleries/gallery1/stats").send({}).expect(403);
+  });
+  test("user with grant on the gallery → 200", async () => {
+    const token = await loginUser(api, "gallery1user");
+    await postStats(token, "gallery1");
+  });
+  test(":guest grant on gallery3 → anon allowed", async () => {
+    await api.post("/api/v1/galleries/gallery3/stats").send({}).expect(200);
+  });
+  test("user without a grant on the gallery → 403", async () => {
+    const token = await loginUser(api, "simpleuser");
+    await postStats(token, "gallery1", {}, 403);
+  });
+  test("admin → 200 on any gallery", async () => {
+    const token = await loginUser(api, "admin");
+    await postStats(token, "gallery2");
+  });
+});
+
+describe("response shape (unfiltered)", () => {
+  let token: string | undefined;
+  beforeAll(async () => {
+    token = await loginUser(api, "admin");
+  });
+
+  test("gallery1: total + byCategory + summary", async () => {
+    const res = await postStats(token, "gallery1");
+    expect(res.body.total).toBe(2);
+    expect(res.body.byCategory.country).toEqual({ jp: 1, nl: 1 });
+    expect(res.body.byCategory.year).toEqual({ "2018": 1, "2020": 1 });
+    expect(res.body.byCategory.cameraMake).toEqual({
+      FUJIFILM: 1,
+      Panasonic: 1,
+    });
+    expect(res.body.byCategory.month).toEqual({ "5": 1, "7": 1 });
+    expect(res.body.byCategory.hour).toEqual({ "13": 1, "14": 1 });
+    expect(res.body.summary.first).toBe("2018-05-04");
+    expect(res.body.summary.last).toBe("2020-07-04");
+    expect(res.body.summary.variety.camera).toBe(2);
+    expect(res.body.summary.variety.country).toBe(2);
+  });
+
+  test("byYearMonth structure", async () => {
+    const res = await postStats(token, "gallery1");
+    expect(res.body.byYearMonth).toEqual({
+      "2018": { "5": 1 },
+      "2020": { "7": 1 },
+    });
+  });
+
+  test("daysInYear is the calendar year length", async () => {
+    const res = await postStats(token, "gallery1");
+    // 2020 is a leap year; 2018 is not.
+    expect(res.body.daysInYear).toEqual({ "2018": 365, "2020": 366 });
+  });
+
+  test("daysInYearMonth has the calendar month length", async () => {
+    const res = await postStats(token, "gallery1");
+    // May 2018 = 31 days, July 2020 = 31 days
+    expect(res.body.daysInYearMonth["2018"]["5"]).toBe(31);
+    expect(res.body.daysInYearMonth["2020"]["7"]).toBe(31);
+  });
+
+  test("camera bucket uses formatGear output", async () => {
+    const res = await postStats(token, "gallery1");
+    expect(res.body.byCategory.camera).toHaveProperty("FUJIFILM X-T2");
+    expect(res.body.byCategory.camera).toHaveProperty("Panasonic DMC-GX7");
+  });
+});
+
+describe("filter", () => {
+  let token: string | undefined;
+  beforeAll(async () => {
+    token = await loginUser(api, "admin");
+  });
+
+  test("country filter narrows the result set", async () => {
+    const res = await postStats(token, "gallery1", {
+      filter: { general: { country: ["jp"] } },
+    });
+    expect(res.body.total).toBe(1);
+    expect(res.body.byCategory.country).toEqual({ jp: 1 });
+    expect(res.body.byCategory.year).toEqual({ "2018": 1 });
+  });
+
+  test("filter with no matches → zero total + empty categories", async () => {
+    const res = await postStats(token, "gallery1", {
+      filter: { general: { country: ["us"] } },
+    });
+    expect(res.body.total).toBe(0);
+    expect(res.body.byCategory.country).toEqual({});
+    expect(res.body.byCategory.year).toEqual({});
+    expect(res.body.summary.first).toBeUndefined();
+  });
+
+  test("AND across topics", async () => {
+    const res = await postStats(token, "gallery1", {
+      filter: {
+        general: { country: ["jp"] },
+        time: { year: ["2020"] },
+      },
+    });
+    // jp is 2018; no jp in 2020 → 0
+    expect(res.body.total).toBe(0);
+  });
+
+  test("OR within a category", async () => {
+    const res = await postStats(token, "gallery1", {
+      filter: { general: { country: ["jp", "nl"] } },
+    });
+    expect(res.body.total).toBe(2);
+  });
+});
+
+describe("scope + host-scope", () => {
+  test("non-admin without grant on non-existent gallery → 403 (privacy collapse)", async () => {
+    const token = await loginUser(api, "simpleuser");
+    await postStats(token, "nosuchgallery", {}, 403);
+  });
+  test("admin on non-existent gallery → 200 with empty stats", async () => {
+    const token = await loginUser(api, "admin");
+    const res = await postStats(token, "nosuchgallery");
+    expect(res.body.total).toBe(0);
+    expect(res.body.byCategory.country).toEqual({});
+  });
+});
+
+describe("unknown bucket", () => {
+  test("photos with empty fields bucket under 'unknown'", async () => {
+    const token = await loginUser(api, "admin");
+    // gallery2 has gallery12photo.jpg + gallery2photo.jpg.
+    // gallery12photo.jpg has no coords; gallery2photo.jpg lens make undefined.
+    const res = await postStats(token, "gallery2");
+    expect(res.body.total).toBe(2);
+    // Both photos have valid camera + lens; no unknown bucket expected.
+    expect(res.body.byCategory.country).toEqual({ nl: 1, jp: 1 });
+  });
+});


### PR DESCRIPTION
## Summary

Third slice of #286. Wires the two foundation slices (`photo-derived` + `photo-filter-eval`) into a real endpoint and adds the cross-photo summary aggregates the response shape needs.

```
POST /api/v1/galleries/:galleryId/stats
Body: { filter?: FilterShape }
```

Auth: `authorizeGalleryView` — anyone who can see the gallery can request its stats (matches the gallery GET). Hostname scope check via `requireScopeMatches`. Empty / absent body returns the unfiltered base; slice 4 will add a single-key cache for that case.

## Response

```jsonc
{
  "total": 1234,
  "byCategory": { "country": { "jp": 412, ... }, "camera": { ... }, ... },
  "byYearMonth": { "2024": { "1": 41, ... }, ... },
  "summary": {
    "first": "2018-05-04", "last": "2024-11-23",
    "spanDays": 2395, "spanYears": 6, "spanMonths": 78,
    "peakShape": { "year": "leader", "month": "tied", ... },
    "variety": { "camera": 8, "lens": 14, ... }
  },
  "daysInYear": { "2024": 366, ... },
  "daysInYearMonth": { "2024": { "1": 31, ... }, ... }
}
```

22 bucket categories under `byCategory` (general / time / gear / settings / light / image — the full enumeration the scoping doc listed). Bucket keys are stringified derived values; the unknown slot uses the literal `"unknown"` matching the client's internal sentinel. Z-scores aren't pre-computed server-side — cheap enough to render-time from the returned buckets.

## Test plan

17 integration tests:

- **Auth matrix**: guest blocked on private gallery, user with grant OK, `:guest` grant on public gallery → anon allowed, user without grant → 403, admin → 200 on any gallery.
- **Response shape**: total + every category populated for the fixture's `gallery1` (Fujifilm X-T2 + Panasonic GX7, JP + NL, 2018 + 2020); `byYearMonth` nested correctly; `daysInYear` honors the leap-year rule (2020 → 366, 2018 → 365); `daysInYearMonth` returns actual calendar month length (not photo-day count).
- **Filter**: single category narrowing, OR within category, AND across topics, no-match → empty totals + empty buckets, summary.first undefined when nothing matches.
- **Edge cases**: non-existent gallery — admin sees empty stats (200), non-admin gets the 403 privacy collapse.

OpenAPI regen + react-app `api-schema.ts` regen produce the matching typed surface ready for slice 5's frontend rewire.

- [x] `npm run typecheck` + `npm run lint` clean across all three subtrees.
- [x] `npm test` — 31 files, 808 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)