### PR TITLE
Server: stats response gains state/city annotations + lang param (#286, slice 5a)

### DIFF
--- a/react-app/src/lib/api-schema.ts
+++ b/react-app/src/lib/api-schema.ts
@@ -1770,6 +1770,7 @@ export interface paths {
                                 [key: string]: (string | number | boolean | null)[];
                             };
                         };
+                        lang?: string;
                     };
                 };
             };
@@ -1812,6 +1813,15 @@ export interface paths {
                                 [key: string]: {
                                     [key: string]: number;
                                 };
+                            };
+                            byStateCountry: {
+                                [key: string]: string;
+                            };
+                            byCityCountry: {
+                                [key: string]: string;
+                            };
+                            byCityLocalized: {
+                                [key: string]: string;
                             };
                         };
                     };

--- a/server/controllers/stats-v1.ts
+++ b/server/controllers/stats-v1.ts
@@ -32,6 +32,7 @@ const FilterSchema = Type.Record(Type.String(), FilterTopic, {
 
 const StatsBody = Type.Object({
   filter: Type.Optional(FilterSchema),
+  lang: Type.Optional(Type.String({ minLength: 2, maxLength: 8 })),
 });
 
 const BucketCounts = Type.Record(Type.String(), Type.Number());
@@ -52,6 +53,9 @@ const StatsResponse = Type.Object({
   }),
   daysInYear: Type.Record(Type.String(), Type.Number()),
   daysInYearMonth: YearMonthCounts,
+  byStateCountry: Type.Record(Type.String(), Type.String()),
+  byCityCountry: Type.Record(Type.String(), Type.String()),
+  byCityLocalized: Type.Record(Type.String(), Type.String()),
 });
 
 const TAGS = ["stats"];
@@ -83,7 +87,8 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       );
       return await model.getGalleryStats(
         request.params.galleryId,
-        request.body.filter as FilterShape | undefined
+        request.body.filter as FilterShape | undefined,
+        request.body.lang
       );
     }
   );

--- a/server/models/stats.ts
+++ b/server/models/stats.ts
@@ -47,6 +47,15 @@ export interface StatsResponse {
   summary: StatsSummary;
   daysInYear: Record<string, number>;
   daysInYearMonth: YearMonthCounts;
+  // Display-side annotations. `byStateCountry` maps a state code
+  // (e.g. "jp-13") to its country code so the state table can
+  // render "Tokyo, JP" without a second lookup; `byCityCountry`
+  // does the same for the city key; `byCityLocalized` carries the
+  // localized city display name keyed by the same city key so a
+  // language switch is a label re-render, not a refetch.
+  byStateCountry: Record<string, string>;
+  byCityCountry: Record<string, string>;
+  byCityLocalized: Record<string, string>;
 }
 
 const inc = (map: BucketCounts, key: string): void => {
@@ -271,6 +280,33 @@ const buildByCategory = (
   ),
 });
 
+const buildAnnotations = (
+  photos: Photo[]
+): {
+  byStateCountry: Record<string, string>;
+  byCityCountry: Record<string, string>;
+  byCityLocalized: Record<string, string>;
+} => {
+  const byStateCountry: Record<string, string> = {};
+  const byCityCountry: Record<string, string> = {};
+  const byCityLocalized: Record<string, string> = {};
+  for (const photo of photos) {
+    const country = photo.geocoded?.countryCode;
+    const state = photo.geocoded?.stateCode;
+    if (state && country && !byStateCountry[state]) {
+      byStateCountry[state] = country;
+    }
+    const cityKey = geocodedCityKey(photo);
+    if (cityKey && country && !byCityCountry[cityKey]) {
+      byCityCountry[cityKey] = country;
+    }
+    if (cityKey && photo.geocoded?.city && !byCityLocalized[cityKey]) {
+      byCityLocalized[cityKey] = photo.geocoded.city;
+    }
+  }
+  return { byStateCountry, byCityCountry, byCityLocalized };
+};
+
 export const computeStats = (
   photos: Photo[],
   filter?: FilterShape
@@ -281,6 +317,7 @@ export const computeStats = (
 
   const byCategory = buildByCategory(filtered);
   const byYearMonth = buildByYearMonth(filtered);
+  const annotations = buildAnnotations(filtered);
 
   const sorted = filtered.slice().sort(compareTimestamps);
   const first = sorted[0];
@@ -321,6 +358,9 @@ export const computeStats = (
     summary,
     daysInYear: buildDaysInYear(filtered),
     daysInYearMonth: buildDaysInYearMonth(filtered),
+    byStateCountry: annotations.byStateCountry,
+    byCityCountry: annotations.byCityCountry,
+    byCityLocalized: annotations.byCityLocalized,
   };
 };
 
@@ -337,17 +377,26 @@ const isUnfilteredBase = (filter?: FilterShape): boolean => {
   return true;
 };
 
+// Cache key includes lang because `byCityLocalized` differs per
+// language; en is the baseline (matches `loadGalleryPhotos` with
+// no lang argument) and shares the bare `galleryId` key so cache
+// hits accrue across requests without a language overlay.
+const cacheKey = (galleryId: string, lang?: string): string =>
+  !lang || lang === "en" ? galleryId : `${galleryId}:${lang}`;
+
 const getGalleryStats = async (
   galleryId: string,
-  filter?: FilterShape
+  filter?: FilterShape,
+  lang?: string
 ): Promise<StatsResponse> => {
   const cacheable = isUnfilteredBase(filter);
+  const key = cacheKey(galleryId, lang);
   if (cacheable) {
-    const cached = cacheGet<StatsResponse>(galleryId);
+    const cached = cacheGet<StatsResponse>(key);
     if (cached) return cached;
   }
-  const photos = (await db.loadGalleryPhotos(galleryId)) as Photo[];
+  const photos = (await db.loadGalleryPhotos(galleryId, lang)) as Photo[];
   const stats = computeStats(photos, filter);
-  if (cacheable) cacheSet(galleryId, stats);
+  if (cacheable) cacheSet(key, stats);
   return stats;
 };

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -2884,6 +2884,11 @@
                         }
                       }
                     }
+                  },
+                  "lang": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 8
                   }
                 }
               }
@@ -2918,7 +2923,10 @@
                     "byYearMonth",
                     "summary",
                     "daysInYear",
-                    "daysInYearMonth"
+                    "daysInYearMonth",
+                    "byStateCountry",
+                    "byCityCountry",
+                    "byCityLocalized"
                   ],
                   "properties": {
                     "total": {
@@ -2994,6 +3002,24 @@
                         "additionalProperties": {
                           "type": "number"
                         }
+                      }
+                    },
+                    "byStateCountry": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "byCityCountry": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "byCityLocalized": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
                       }
                     }
                   }

--- a/server/tests/api/stats.test.ts
+++ b/server/tests/api/stats.test.ts
@@ -154,6 +154,20 @@ describe("scope + host-scope", () => {
   });
 });
 
+describe("annotations", () => {
+  let token: string | undefined;
+  beforeAll(async () => {
+    token = await loginUser(api, "admin");
+  });
+
+  test("byStateCountry / byCityCountry / byCityLocalized are present", async () => {
+    const res = await postStats(token, "gallery1");
+    expect(res.body.byStateCountry).toEqual({});
+    expect(res.body.byCityCountry).toEqual({});
+    expect(res.body.byCityLocalized).toEqual({});
+  });
+});
+
 describe("cache", () => {
   test("subsequent unfiltered calls return the same cached object (no DB rebuild)", async () => {
     const token = await loginUser(api, "admin");


### PR DESCRIPTION
## Summary

Prep slice for the frontend rewire (#286 slice 5). Three display-side annotation maps and an optional `lang` body field land on the stats response so slice 5's frontend rewire stays a refetch — not a label recompute.

## Why

The pre-#286 client derived these annotations from the in-memory photo array — the state table needed the country code alongside `state` to render "Tokyo, JP", the city table the same plus the localized display name keyed by the language-stable `[country, state, cityEn]` tuple. With the in-memory array going away in slice 5, the server has to surface them in the response.

## Changes

`StatsResponse` adds:

```jsonc
{
  "byStateCountry":  { "jp-13": "jp", ... },
  "byCityCountry":   { "[\"jp\",\"jp-13\",\"Tokyo\"]": "jp", ... },
  "byCityLocalized": { "[\"jp\",\"jp-13\",\"Tokyo\"]": "東京", ... }
}
```

Built from the filtered photo set's `geocoded.*` fields. `byCityLocalized` carries the per-language `geocoded.city` value, which `loadGalleryPhotos` already pulls from `photo_localized` when a `lang` is supplied.

`StatsBody` gains optional `lang`. The endpoint forwards it to `loadGalleryPhotos` so the localized city names land on photo rows before bucketing. **Cache key** appends `:<lang>` for non-`en`, so localized variants don't poison the English baseline; `en` / no-lang share the same key (matches `loadGalleryPhotos`'s no-arg default).

## Test plan

- [x] `npm run typecheck` + `npm run lint` clean.
- [x] `npm test` — 32 files / 820 tests pass + 1 new assertion that the three maps exist on the response.
- [x] OpenAPI regen + react-app `api-schema.ts` regen (added typed surface for the new fields).

Frontend rewire (slice 5b) follows in the next PR — that's where this groundwork actually gets consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)