### PR TITLE
react-app: filter store → server wire serializer (#286, slice 5b)

### DIFF
--- a/react-app/src/lib/filter.test.ts
+++ b/react-app/src/lib/filter.test.ts
@@ -168,6 +168,57 @@ describe("removeCategory", () => {
     ).toStrictEqual({ settings: { aperture: { 2.8: ("dummy" as any) } } }));
 });
 
+describe("toServerFilters", () => {
+  const noop = () => true;
+  test("empty filters → empty object", () => {
+    expect(filter.toServerFilters({})).toEqual({});
+  });
+  test("extracts keys per topic / category", () => {
+    const filters = {
+      general: {
+        author: { Alice: noop, Bob: noop },
+        country: { jp: noop },
+      },
+      time: { year: { "2024": noop } },
+    };
+    expect(filter.toServerFilters(filters)).toEqual({
+      general: { author: ["Alice", "Bob"], country: ["jp"] },
+      time: { year: ["2024"] },
+    });
+  });
+  test("'unknown' key serialises to null", () => {
+    const filters = { general: { country: { unknown: noop, jp: noop } } };
+    expect(filter.toServerFilters(filters)).toEqual({
+      general: { country: [null, "jp"] },
+    });
+  });
+  test("empty inner key record drops the category", () => {
+    const filters = {
+      general: { author: {}, country: { jp: noop } },
+    };
+    expect(filter.toServerFilters(filters)).toEqual({
+      general: { country: ["jp"] },
+    });
+  });
+  test("topic with all-empty categories drops the topic", () => {
+    expect(filter.toServerFilters({ general: { author: {} } })).toEqual({});
+  });
+  test("compound JSON-encoded keys pass through (e.g. camera-lens)", () => {
+    const filters = {
+      gear: {
+        "camera-lens": {
+          '["FUJIFILM X-T5","FUJIFILM XF27mmF2.8"]': noop,
+        },
+      },
+    };
+    expect(filter.toServerFilters(filters)).toEqual({
+      gear: {
+        "camera-lens": ['["FUJIFILM X-T5","FUJIFILM XF27mmF2.8"]'],
+      },
+    });
+  });
+});
+
 describe("applyNewFilter", () => {
   let mockPhoto: any;
   beforeEach(() => {

--- a/react-app/src/lib/filter.ts
+++ b/react-app/src/lib/filter.ts
@@ -128,6 +128,38 @@ const applyNewFilter = (
   return newFilters;
 };
 
+// Server wire shape: drop the FilterFn closures, extract just the
+// keys per (topic, category). Used by the upcoming stats endpoint
+// rewire — the server eval expects `null` for the "<unknown>"
+// bucket, so this serializer maps the client's `stats.UNKNOWN`
+// sentinel (the literal string "unknown") to `null` on the wire.
+// JSON-encoded compound keys (camera-lens, city) keep their string
+// form; the server eval parses them at predicate time.
+export type ServerFilterKey = string | null;
+export type ServerFilters = Record<
+  string,
+  Record<string, ServerFilterKey[]>
+>;
+
+const UNKNOWN_SENTINEL = "unknown";
+
+const toServerKey = (key: string): ServerFilterKey =>
+  key === UNKNOWN_SENTINEL ? null : key;
+
+const toServerFilters = (filters: Filters): ServerFilters => {
+  const out: ServerFilters = {};
+  for (const [topic, categories] of Object.entries(filters)) {
+    const topicOut: Record<string, ServerFilterKey[]> = {};
+    for (const [category, keyRecord] of Object.entries(categories)) {
+      const keys = Object.keys(keyRecord);
+      if (keys.length === 0) continue;
+      topicOut[category] = keys.map(toServerKey);
+    }
+    if (Object.keys(topicOut).length > 0) out[topic] = topicOut;
+  }
+  return out;
+};
+
 export default {
   topics,
   categories,
@@ -136,4 +168,5 @@ export default {
   newEmptyCategory,
   removeCategory,
   applyNewFilter,
+  toServerFilters,
 };


### PR DESCRIPTION
## Summary

Smallest standalone piece of the frontend rewire (#286 slice 5). `toServerFilters` walks the existing `Filters` store shape and emits the wire-friendly shape the stats endpoint accepts:

```ts
Record<topic, Record<category, Record<key, FilterFn>>>
  ↓ toServerFilters
Record<topic, Record<category, FilterKey[]>>   // FilterKey = string | null
```

- Drops the `FilterFn` closures — just extracts the keys.
- Converts `stats.UNKNOWN` (literal `"unknown"`) to `null` per the server's wire contract.
- Skips empty inner records so a topic with all-empty categories doesn't survive into the payload.
- Compound JSON-encoded keys (camera-lens, city) pass through verbatim; the server's predicate matrix parses them at match time, same as the client today.

## Test plan

- 6 unit tests: empty input, multi-key extraction, "unknown" → null, empty-category drop, empty-topic drop, compound-key passthrough.
- `npm run typecheck` + `npm run lint` clean.
- `npm test` — 985 tests pass (47 in `filter.test.ts` after the additions).

No consumer yet — the `useQuery` wire-up (slice 5c) imports this in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)