### PR TITLE
Server: cross-gallery stats endpoint (#286, slice 6a)

### DIFF
--- a/react-app/src/lib/api-schema.ts
+++ b/react-app/src/lib/api-schema.ts
@@ -1837,6 +1837,98 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Aggregated stats across all galleries (admin) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        filter?: {
+                            [key: string]: {
+                                [key: string]: (string | number | boolean | null)[];
+                            };
+                        };
+                        lang?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            total: number;
+                            byCategory: {
+                                [key: string]: {
+                                    [key: string]: number;
+                                };
+                            };
+                            byYearMonth: {
+                                [key: string]: {
+                                    [key: string]: number;
+                                };
+                            };
+                            summary: {
+                                first?: string;
+                                last?: string;
+                                spanDays: number;
+                                spanYears: number;
+                                spanMonths: number;
+                                peakShape: {
+                                    [key: string]: string;
+                                };
+                                variety: {
+                                    [key: string]: number;
+                                };
+                            };
+                            daysInYear: {
+                                [key: string]: number;
+                            };
+                            daysInYearMonth: {
+                                [key: string]: {
+                                    [key: string]: number;
+                                };
+                            };
+                            byStateCountry: {
+                                [key: string]: string;
+                            };
+                            byCityCountry: {
+                                [key: string]: string;
+                            };
+                            byCityLocalized: {
+                                [key: string]: string;
+                            };
+                            categoryValues: {
+                                [key: string]: string[];
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {

--- a/react-app/src/services/stats.ts
+++ b/react-app/src/services/stats.ts
@@ -18,4 +18,13 @@ const getGalleryStats = async (
     })
   );
 
-export default { getGalleryStats };
+// Cross-gallery (admin-only) stats. Same response shape as the
+// gallery-scoped endpoint, so the client-side adapter +
+// collectTopics work unchanged regardless of scope.
+const getGlobalStats = async (
+  filter: ServerFilters,
+  lang?: string
+): Promise<GalleryStats> =>
+  unwrap(api.POST("/api/v1/stats", { body: { filter, lang } }));
+
+export default { getGalleryStats, getGlobalStats };

--- a/server/app.ts
+++ b/server/app.ts
@@ -176,7 +176,8 @@ await app.register(groupsV1.plugin, { prefix: "/api/v1/groups" });
 await app.register(groupGalleryV1.plugin, {
   prefix: "/api/v1/group-gallery",
 });
-await app.register(statsV1.plugin, { prefix: "/api/v1/galleries" });
+await app.register(statsV1.galleryPlugin, { prefix: "/api/v1/galleries" });
+await app.register(statsV1.globalPlugin, { prefix: "/api/v1/stats" });
 
 // Double-duty 404 handler: serve index.html for SPA routes so
 // React Router can resolve deep links (refreshing /m/photos, or

--- a/server/controllers/stats-v1.ts
+++ b/server/controllers/stats-v1.ts
@@ -2,7 +2,7 @@ import { Type } from "typebox";
 import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import authorizerFactory from "../lib/authorizer.js";
-import { requireScopeMatches } from "../lib/host-scope.js";
+import { requireScopeMatches, requireUnscoped } from "../lib/host-scope.js";
 import statsFactory from "../models/stats.js";
 import type { FilterShape } from "../lib/photo-filter-eval.js";
 
@@ -61,13 +61,8 @@ const StatsResponse = Type.Object({
 
 const TAGS = ["stats"];
 
-const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
-  /**
-   * Aggregated stats for one gallery. Body carries the same filter
-   * shape `useFiltersStore` produces on the client (topic / category
-   * / keys). Empty body returns the unfiltered base — slice 4 will
-   * add a single-key cache for that case.
-   */
+// Gallery-scoped stats. Mounted at `/api/v1/galleries`.
+const galleryPlugin: FastifyPluginAsyncTypebox = async (fastify) => {
   fastify.post(
     "/:galleryId/stats",
     {
@@ -95,4 +90,30 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   );
 };
 
-export default { init, plugin };
+// Cross-gallery stats. Mounted at `/api/v1/stats`. Admin-only and
+// rejected on hostname-bound instances — same surface area as the
+// other unscoped admin routes.
+const globalPlugin: FastifyPluginAsyncTypebox = async (fastify) => {
+  fastify.post(
+    "/",
+    {
+      schema: {
+        tags: TAGS,
+        summary: "Aggregated stats across all galleries (admin)",
+        body: StatsBody,
+        response: { 200: StatsResponse },
+        security: [{ bearer: [] }],
+      },
+    },
+    async (request) => {
+      requireUnscoped(request);
+      await authorizer.authorizeAdmin(request.user.id);
+      return await model.getGlobalStats(
+        request.body.filter as FilterShape | undefined,
+        request.body.lang
+      );
+    }
+  );
+};
+
+export default { init, galleryPlugin, globalPlugin };

--- a/server/lib/stats-cache.ts
+++ b/server/lib/stats-cache.ts
@@ -33,9 +33,38 @@ export const cacheSet = <T>(key: string, value: T): void => {
   cache.set(key, { value, storedAt: Date.now() });
 };
 
+// Gallery-scoped invalidation. Drops every cache entry whose key
+// matches `<galleryId>` or `<galleryId>:<lang>` — a multi-lang
+// instance accumulates separate cached responses per lang and
+// they all need to go on the same mutation.
 export const invalidateGallery = (galleryId: string): void => {
-  if (cache.delete(galleryId)) {
-    logger.debug("Stats cache: invalidated", { galleryId });
+  const prefix = `${galleryId}:`;
+  let dropped = 0;
+  for (const key of cache.keys()) {
+    if (key === galleryId || key.startsWith(prefix)) {
+      cache.delete(key);
+      dropped++;
+    }
+  }
+  if (dropped > 0) {
+    logger.debug("Stats cache: invalidated gallery", { galleryId, dropped });
+  }
+};
+
+// Global namespace invalidation. Drops every `:global` / `:global:lang`
+// entry. Photo writes call both this and `invalidateGallery` for the
+// linked galleries, since a single photo change shifts both views.
+export const invalidateGlobal = (): void => {
+  const prefix = ":global";
+  let dropped = 0;
+  for (const key of cache.keys()) {
+    if (key === prefix || key.startsWith(`${prefix}:`)) {
+      cache.delete(key);
+      dropped++;
+    }
+  }
+  if (dropped > 0) {
+    logger.debug("Stats cache: invalidated global", { dropped });
   }
 };
 

--- a/server/lib/stats-compute.ts
+++ b/server/lib/stats-compute.ts
@@ -1,0 +1,377 @@
+// Pure-function stats compute. Reused by both the gallery-scoped
+// path (`models/stats.ts` → `POST /galleries/:id/stats`) and the
+// cross-gallery path (`POST /stats`), since the only thing that
+// changes between them is which photos the model passes in.
+//
+// No DB access, no cache. Tests can feed a `Photo[]` directly.
+// Bucket keys are stringified derived values; the `<unknown>`
+// bucket uses the literal string "unknown" to match the client's
+// internal sentinel.
+
+import type { Photo } from "../db/sqlite3/schema.js";
+import * as derived from "./photo-derived.js";
+import { matchesFilter, type FilterShape } from "./photo-filter-eval.js";
+
+export const UNKNOWN_BUCKET = "unknown";
+
+export type BucketCounts = Record<string, number>;
+export interface YearMonthCounts {
+  [year: string]: Record<string, number>;
+}
+export type PeakShape = "leader" | "tied" | "even";
+
+export interface StatsSummary {
+  first?: string;
+  last?: string;
+  spanDays: number;
+  spanYears: number;
+  spanMonths: number;
+  peakShape: Record<string, PeakShape>;
+  variety: Record<string, number>;
+}
+
+export interface StatsResponse {
+  total: number;
+  byCategory: Record<string, BucketCounts>;
+  byYearMonth: YearMonthCounts;
+  summary: StatsSummary;
+  daysInYear: Record<string, number>;
+  daysInYearMonth: YearMonthCounts;
+  byStateCountry: Record<string, string>;
+  byCityCountry: Record<string, string>;
+  byCityLocalized: Record<string, string>;
+  categoryValues: Record<string, string[]>;
+}
+
+const inc = (map: BucketCounts, key: string): void => {
+  map[key] = (map[key] ?? 0) + 1;
+};
+
+const bucketByString = (
+  photos: Photo[],
+  deriver: (photo: Photo) => string | undefined
+): BucketCounts => {
+  const out: BucketCounts = {};
+  for (const photo of photos) {
+    const value = deriver(photo);
+    inc(out, value ?? UNKNOWN_BUCKET);
+  }
+  return out;
+};
+
+const bucketByNumber = (
+  photos: Photo[],
+  deriver: (photo: Photo) => number | undefined
+): BucketCounts => {
+  const out: BucketCounts = {};
+  for (const photo of photos) {
+    const value = deriver(photo);
+    inc(out, value === undefined ? UNKNOWN_BUCKET : String(value));
+  }
+  return out;
+};
+
+const formatCamera = (photo: Photo): string | undefined =>
+  derived.formatGear(photo.camera?.make, photo.camera?.model);
+
+const formatLens = (photo: Photo): string | undefined =>
+  derived.formatGear(photo.lens?.make, photo.lens?.model);
+
+const geocodedCityKey = (photo: Photo): string | undefined => {
+  const cityEn = photo.geocoded?.cityEn ?? photo.geocoded?.city;
+  if (!cityEn) return undefined;
+  return JSON.stringify([
+    photo.geocoded?.countryCode ?? "",
+    photo.geocoded?.stateCode ?? "",
+    cityEn,
+  ]);
+};
+
+const cameraLensPairKey = (photo: Photo): string | undefined => {
+  const camera = formatCamera(photo);
+  const lens = formatLens(photo);
+  if (!camera && !lens) return undefined;
+  return JSON.stringify([camera ?? null, lens ?? null]);
+};
+
+const countDistinct = (
+  photos: Photo[],
+  deriver: (photo: Photo) => string | undefined
+): number => {
+  const set = new Set<string>();
+  for (const photo of photos) {
+    const value = deriver(photo);
+    if (value) set.add(value);
+  }
+  return set.size;
+};
+
+// Peak-shape classifier. ≤1 leader within 1% of max → "leader";
+// 2–3 within 1% → "tied"; ≥4 within 1% → "even".
+const NEAR_TIE_THRESHOLD = 0.01;
+const peakShape = (buckets: BucketCounts): PeakShape => {
+  const values = Object.values(buckets);
+  if (values.length === 0) return "leader";
+  const max = Math.max(...values);
+  if (max === 0) return "leader";
+  const tied = values.filter((v) => (max - v) / max <= NEAR_TIE_THRESHOLD)
+    .length;
+  if (tied <= 1) return "leader";
+  if (tied <= 3) return "tied";
+  return "even";
+};
+
+const buildByYearMonth = (photos: Photo[]): YearMonthCounts => {
+  const out: YearMonthCounts = {};
+  for (const photo of photos) {
+    const year = String(photo.taken.instant.year);
+    const month = String(photo.taken.instant.month);
+    if (!out[year]) out[year] = {};
+    out[year][month] = (out[year][month] ?? 0) + 1;
+  }
+  return out;
+};
+
+const daysInCalendarYear = (year: number): number => {
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  return leap ? 366 : 365;
+};
+const daysInCalendarMonth = (year: number, month: number): number =>
+  new Date(year, month, 0).getDate();
+
+const buildDaysInYear = (photos: Photo[]): Record<string, number> => {
+  const years = new Set<number>();
+  for (const photo of photos) years.add(photo.taken.instant.year);
+  const out: Record<string, number> = {};
+  for (const year of years) out[String(year)] = daysInCalendarYear(year);
+  return out;
+};
+
+const buildDaysInYearMonth = (photos: Photo[]): YearMonthCounts => {
+  const seen = new Map<number, Set<number>>();
+  for (const photo of photos) {
+    const year = photo.taken.instant.year;
+    const month = photo.taken.instant.month;
+    if (!seen.has(year)) seen.set(year, new Set());
+    seen.get(year)!.add(month);
+  }
+  const out: YearMonthCounts = {};
+  for (const [year, months] of seen.entries()) {
+    out[String(year)] = {};
+    for (const month of months) {
+      out[String(year)][String(month)] = daysInCalendarMonth(year, month);
+    }
+  }
+  return out;
+};
+
+const compareTimestamps = (a: Photo, b: Photo): number =>
+  a.taken.instant.timestamp.localeCompare(b.taken.instant.timestamp);
+
+const formatDate = (photo: Photo): string => {
+  const i = photo.taken.instant;
+  return `${i.year}-${String(i.month).padStart(2, "0")}-${String(
+    i.day
+  ).padStart(2, "0")}`;
+};
+
+const computeSpan = (
+  first: Photo | undefined,
+  last: Photo | undefined
+): { spanDays: number; spanYears: number; spanMonths: number } => {
+  if (!first || !last) return { spanDays: 0, spanYears: 0, spanMonths: 0 };
+  const firstDate = new Date(
+    first.taken.instant.year,
+    first.taken.instant.month - 1,
+    first.taken.instant.day
+  );
+  const lastDate = new Date(
+    last.taken.instant.year,
+    last.taken.instant.month - 1,
+    last.taken.instant.day
+  );
+  const ms = lastDate.getTime() - firstDate.getTime();
+  const spanDays = Math.max(0, Math.round(ms / (24 * 60 * 60 * 1000)));
+  const spanYears = Math.floor(spanDays / 365.25);
+  const spanMonths = Math.floor(spanDays / (365.25 / 12));
+  return { spanDays, spanYears, spanMonths };
+};
+
+const buildByCategory = (
+  photos: Photo[]
+): Record<string, BucketCounts> => ({
+  author: bucketByString(photos, (p) => p.taken.author),
+  country: bucketByString(photos, (p) => p.taken.location?.country),
+  state: bucketByString(photos, (p) => p.geocoded?.stateCode),
+  city: bucketByString(photos, geocodedCityKey),
+  year: bucketByNumber(photos, (p) => p.taken.instant.year),
+  month: bucketByNumber(photos, (p) => p.taken.instant.month),
+  weekday: bucketByNumber(photos, (p) =>
+    derived.weekday(
+      p.taken.instant.year,
+      p.taken.instant.month,
+      p.taken.instant.day
+    )
+  ),
+  hour: bucketByNumber(photos, (p) => p.taken.instant.hour),
+  cameraMake: bucketByString(photos, (p) => p.camera?.make),
+  camera: bucketByString(photos, formatCamera),
+  lens: bucketByString(photos, formatLens),
+  cameraLens: bucketByString(photos, cameraLensPairKey),
+  focalLength: bucketByNumber(photos, (p) => p.exposure?.focalLength),
+  focalLength35mmEquiv: bucketByNumber(photos, (p) =>
+    derived.focalLength35mmEquiv(
+      p.exposure?.focalLength,
+      p.camera?.make,
+      p.camera?.model,
+      p.exposure?.focalLength35mmEquiv
+    )
+  ),
+  aperture: bucketByNumber(photos, (p) => p.exposure?.aperture),
+  exposureTime: bucketByNumber(photos, (p) => p.exposure?.exposureTime),
+  iso: bucketByNumber(photos, (p) => p.exposure?.iso),
+  ev: bucketByNumber(photos, (p) =>
+    derived.exposureValue(p.exposure?.aperture, p.exposure?.exposureTime)
+  ),
+  lv: bucketByNumber(photos, (p) =>
+    derived.lightValue(
+      p.exposure?.aperture,
+      p.exposure?.exposureTime,
+      p.exposure?.iso
+    )
+  ),
+  resolution: bucketByNumber(photos, (p) =>
+    derived.resolution(
+      p.dimensions?.original?.width,
+      p.dimensions?.original?.height
+    )
+  ),
+  orientation: bucketByString(photos, (p) =>
+    derived.orientation(
+      p.dimensions?.original?.width,
+      p.dimensions?.original?.height
+    )
+  ),
+  aspectRatio: bucketByString(photos, (p) =>
+    derived.aspectRatio(
+      p.dimensions?.original?.width,
+      p.dimensions?.original?.height
+    )
+  ),
+});
+
+const buildAnnotations = (
+  photos: Photo[]
+): {
+  byStateCountry: Record<string, string>;
+  byCityCountry: Record<string, string>;
+  byCityLocalized: Record<string, string>;
+} => {
+  const byStateCountry: Record<string, string> = {};
+  const byCityCountry: Record<string, string> = {};
+  const byCityLocalized: Record<string, string> = {};
+  for (const photo of photos) {
+    const country = photo.geocoded?.countryCode;
+    const state = photo.geocoded?.stateCode;
+    if (state && country && !byStateCountry[state]) {
+      byStateCountry[state] = country;
+    }
+    const cityKey = geocodedCityKey(photo);
+    if (cityKey && country && !byCityCountry[cityKey]) {
+      byCityCountry[cityKey] = country;
+    }
+    if (cityKey && photo.geocoded?.city && !byCityLocalized[cityKey]) {
+      byCityLocalized[cityKey] = photo.geocoded.city;
+    }
+  }
+  return { byStateCountry, byCityCountry, byCityLocalized };
+};
+
+// Universe of bucket keys per category across the unfiltered set.
+// Same buckets `buildByCategory` produces, collapsed to a sorted
+// key list so the wire payload stays small.
+const buildCategoryValues = (
+  photos: Photo[]
+): Record<string, string[]> => {
+  const all = buildByCategory(photos);
+  const out: Record<string, string[]> = {};
+  for (const [category, counts] of Object.entries(all)) {
+    out[category] = Object.keys(counts).sort();
+  }
+  return out;
+};
+
+export const computeStats = (
+  photos: Photo[],
+  filter?: FilterShape
+): StatsResponse => {
+  const filtered = filter
+    ? photos.filter((p) => matchesFilter(filter, p))
+    : photos;
+
+  const byCategory = buildByCategory(filtered);
+  const byYearMonth = buildByYearMonth(filtered);
+  const annotations = buildAnnotations(filtered);
+  // Universe always covers the input's full set so the filter UI
+  // keeps surfacing every value, even when the active filter
+  // narrows the count to zero for some of them.
+  const categoryValues = buildCategoryValues(photos);
+
+  const sorted = filtered.slice().sort(compareTimestamps);
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  const { spanDays, spanYears, spanMonths } = computeSpan(first, last);
+
+  const summary: StatsSummary = {
+    first: first ? formatDate(first) : undefined,
+    last: last ? formatDate(last) : undefined,
+    spanDays,
+    spanYears,
+    spanMonths,
+    peakShape: {
+      year: peakShape(byCategory.year),
+      month: peakShape(byCategory.month),
+      weekday: peakShape(byCategory.weekday),
+      hour: peakShape(byCategory.hour),
+      camera: peakShape(byCategory.camera),
+      lens: peakShape(byCategory.lens),
+      cameraLens: peakShape(byCategory.cameraLens),
+    },
+    variety: {
+      author: countDistinct(filtered, (p) => p.taken.author),
+      country: countDistinct(filtered, (p) => p.taken.location?.country),
+      state: countDistinct(filtered, (p) => p.geocoded?.stateCode),
+      city: countDistinct(filtered, geocodedCityKey),
+      camera: countDistinct(filtered, formatCamera),
+      lens: countDistinct(filtered, formatLens),
+      cameraMake: countDistinct(filtered, (p) => p.camera?.make),
+      cameraLens: countDistinct(filtered, cameraLensPairKey),
+    },
+  };
+
+  return {
+    total: filtered.length,
+    byCategory,
+    byYearMonth,
+    summary,
+    daysInYear: buildDaysInYear(filtered),
+    daysInYearMonth: buildDaysInYearMonth(filtered),
+    byStateCountry: annotations.byStateCountry,
+    byCityCountry: annotations.byCityCountry,
+    byCityLocalized: annotations.byCityLocalized,
+    categoryValues,
+  };
+};
+
+export const isUnfilteredBase = (filter?: FilterShape): boolean => {
+  if (!filter) return true;
+  for (const topic of Object.keys(filter)) {
+    const categories = filter[topic];
+    if (!categories) continue;
+    for (const category of Object.keys(categories)) {
+      const keys = categories[category];
+      if (Array.isArray(keys) && keys.length > 0) return false;
+    }
+  }
+  return true;
+};

--- a/server/models/photo.ts
+++ b/server/models/photo.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import logger from "../lib/logger.js";
 import db from "../db/index.js";
-import { invalidateGallery } from "../lib/stats-cache.js";
+import { invalidateGallery, invalidateGlobal } from "../lib/stats-cache.js";
 import {
   applyFilter,
   countryMismatch as isCountryMismatch,
@@ -243,13 +243,18 @@ const invalidateStatsForPhoto = async (photoId: string): Promise<void> => {
   for (const galleryId of await galleryIdsForPhoto(photoId)) {
     invalidateGallery(galleryId);
   }
+  // Photo-level mutations also shift the cross-gallery (global)
+  // view, regardless of which galleries the photo is linked to.
+  invalidateGlobal();
 };
 
 const createPhoto = async (photo: { id: string } & Record<string, any>) => {
   logger.debug("Creating photo", { id: photo.id });
   await db.createPhoto(photo);
-  // Fresh photo isn't linked yet; the subsequent link call from the
-  // converter / admin UI will invalidate the receiving gallery.
+  // Fresh photo isn't linked to any gallery yet (gallery cache
+  // hits unchanged), but it IS in the cross-gallery catalogue —
+  // global stats must rebuild.
+  invalidateGlobal();
 };
 
 const getPhoto = async (photoId: string) => {
@@ -293,4 +298,5 @@ const deletePhoto = async (photoId: string) => {
   await db.unlinkAllGalleries(photoId);
   await db.deletePhoto(photoId);
   for (const galleryId of galleries) invalidateGallery(galleryId);
+  invalidateGlobal();
 };

--- a/server/models/stats.ts
+++ b/server/models/stats.ts
@@ -1,414 +1,55 @@
-// Server-side stats aggregation. Loads the gallery's photos, applies
-// the filter (slice 2's evaluator), and builds the bucket maps the
-// `POST /api/v1/galleries/:galleryId/stats` endpoint returns.
+// Stats orchestration. Loads photos from the DB and runs them
+// through the pure `computeStats` aggregator in
+// `lib/stats-compute.ts`. Two flavours:
 //
-// Each category produces a `Record<key, count>` over the filtered
-// photo set. Bucket keys are stringified derived values; the
-// `<unknown>` bucket uses the literal string "unknown" to match
-// what the client's stats today already uses internally (clients
-// localise the label at render time). Cross-photo aggregates
-// (first / last / span / variety / peak shape) land in `summary`.
+//   - `getGalleryStats(galleryId, filter?, lang?)` — gallery-scoped,
+//     drives `POST /api/v1/galleries/:id/stats`.
+//   - `getGlobalStats(filter?, lang?)` — cross-gallery, drives
+//     `POST /api/v1/stats` (admin-only). Same compute logic; the
+//     only difference is which photos the DB layer hands us.
+//
+// Single-key cache per scope. The gallery flavour keys by gallery
+// id (plus lang for non-en); the global flavour keys by a
+// dedicated `:global` namespace. Filtered combinations bypass
+// cache and compute on demand.
 
 import db from "../db/index.js";
 import type { Photo } from "../db/sqlite3/schema.js";
-import * as derived from "../lib/photo-derived.js";
-import {
-  matchesFilter,
-  type FilterShape,
-} from "../lib/photo-filter-eval.js";
 import { cacheGet, cacheSet } from "../lib/stats-cache.js";
+import {
+  computeStats,
+  isUnfilteredBase,
+  type StatsResponse,
+} from "../lib/stats-compute.js";
+import type { FilterShape } from "../lib/photo-filter-eval.js";
 
 export default () => ({
   getGalleryStats,
+  getGlobalStats,
 });
 
-export const UNKNOWN_BUCKET = "unknown";
+// Re-export the response shape + types so controllers and tests
+// can stay model-rooted rather than reaching into lib/.
+export type {
+  BucketCounts,
+  PeakShape,
+  StatsResponse,
+  StatsSummary,
+  YearMonthCounts,
+} from "../lib/stats-compute.js";
+export { UNKNOWN_BUCKET } from "../lib/stats-compute.js";
 
-export type BucketCounts = Record<string, number>;
-export interface YearMonthCounts {
-  [year: string]: Record<string, number>;
-}
-export type PeakShape = "leader" | "tied" | "even";
-
-export interface StatsSummary {
-  first?: string;
-  last?: string;
-  spanDays: number;
-  spanYears: number;
-  spanMonths: number;
-  peakShape: Record<string, PeakShape>;
-  variety: Record<string, number>;
-}
-
-export interface StatsResponse {
-  total: number;
-  byCategory: Record<string, BucketCounts>;
-  byYearMonth: YearMonthCounts;
-  summary: StatsSummary;
-  daysInYear: Record<string, number>;
-  daysInYearMonth: YearMonthCounts;
-  // Display-side annotations. `byStateCountry` maps a state code
-  // (e.g. "jp-13") to its country code so the state table can
-  // render "Tokyo, JP" without a second lookup; `byCityCountry`
-  // does the same for the city key; `byCityLocalized` carries the
-  // localized city display name keyed by the same city key so a
-  // language switch is a label re-render, not a refetch.
-  byStateCountry: Record<string, string>;
-  byCityCountry: Record<string, string>;
-  byCityLocalized: Record<string, string>;
-  // Universe of bucket keys per category — computed from ALL
-  // photos in the gallery, regardless of filter. The client pads
-  // each filtered `byCategory[c]` map with 0 entries for keys
-  // present in the universe but missing in the filtered subset,
-  // so the filter UI's "add another value" affordance can still
-  // surface every possible value the user might union-add.
-  categoryValues: Record<string, string[]>;
-}
-
-const inc = (map: BucketCounts, key: string): void => {
-  map[key] = (map[key] ?? 0) + 1;
-};
-
-const bucketByString = (
-  photos: Photo[],
-  deriver: (photo: Photo) => string | undefined
-): BucketCounts => {
-  const out: BucketCounts = {};
-  for (const photo of photos) {
-    const value = deriver(photo);
-    inc(out, value ?? UNKNOWN_BUCKET);
-  }
-  return out;
-};
-
-const bucketByNumber = (
-  photos: Photo[],
-  deriver: (photo: Photo) => number | undefined
-): BucketCounts => {
-  const out: BucketCounts = {};
-  for (const photo of photos) {
-    const value = deriver(photo);
-    inc(out, value === undefined ? UNKNOWN_BUCKET : String(value));
-  }
-  return out;
-};
-
-const formatCamera = (photo: Photo): string | undefined =>
-  derived.formatGear(photo.camera?.make, photo.camera?.model);
-
-const formatLens = (photo: Photo): string | undefined =>
-  derived.formatGear(photo.lens?.make, photo.lens?.model);
-
-const geocodedCityKey = (photo: Photo): string | undefined => {
-  const cityEn = photo.geocoded?.cityEn ?? photo.geocoded?.city;
-  if (!cityEn) return undefined;
-  return JSON.stringify([
-    photo.geocoded?.countryCode ?? "",
-    photo.geocoded?.stateCode ?? "",
-    cityEn,
-  ]);
-};
-
-const cameraLensPairKey = (photo: Photo): string | undefined => {
-  const camera = formatCamera(photo);
-  const lens = formatLens(photo);
-  if (!camera && !lens) return undefined;
-  return JSON.stringify([camera ?? null, lens ?? null]);
-};
-
-const countDistinct = (
-  photos: Photo[],
-  deriver: (photo: Photo) => string | undefined
-): number => {
-  const set = new Set<string>();
-  for (const photo of photos) {
-    const value = deriver(photo);
-    if (value) set.add(value);
-  }
-  return set.size;
-};
-
-// Peak-shape classifier. Per the scoping doc: ≤1 leader within 1%
-// of max → "leader"; 2–3 within 1% → "tied"; ≥4 within 1% → "even".
-const NEAR_TIE_THRESHOLD = 0.01;
-const peakShape = (buckets: BucketCounts): PeakShape => {
-  const values = Object.values(buckets);
-  if (values.length === 0) return "leader";
-  const max = Math.max(...values);
-  if (max === 0) return "leader";
-  const tied = values.filter((v) => (max - v) / max <= NEAR_TIE_THRESHOLD)
-    .length;
-  if (tied <= 1) return "leader";
-  if (tied <= 3) return "tied";
-  return "even";
-};
-
-const buildByYearMonth = (photos: Photo[]): YearMonthCounts => {
-  const out: YearMonthCounts = {};
-  for (const photo of photos) {
-    const year = String(photo.taken.instant.year);
-    const month = String(photo.taken.instant.month);
-    if (!out[year]) out[year] = {};
-    out[year][month] = (out[year][month] ?? 0) + 1;
-  }
-  return out;
-};
-
-const daysInCalendarYear = (year: number): number => {
-  // Gregorian leap rule.
-  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
-  return leap ? 366 : 365;
-};
-const daysInCalendarMonth = (year: number, month: number): number => {
-  // month is 1-indexed; pass 0 of next month to get last day of this.
-  return new Date(year, month, 0).getDate();
-};
-
-const buildDaysInYear = (photos: Photo[]): Record<string, number> => {
-  const years = new Set<number>();
-  for (const photo of photos) years.add(photo.taken.instant.year);
-  const out: Record<string, number> = {};
-  for (const year of years) {
-    out[String(year)] = daysInCalendarYear(year);
-  }
-  return out;
-};
-
-const buildDaysInYearMonth = (photos: Photo[]): YearMonthCounts => {
-  const seen = new Map<number, Set<number>>();
-  for (const photo of photos) {
-    const year = photo.taken.instant.year;
-    const month = photo.taken.instant.month;
-    if (!seen.has(year)) seen.set(year, new Set());
-    seen.get(year)!.add(month);
-  }
-  const out: YearMonthCounts = {};
-  for (const [year, months] of seen.entries()) {
-    out[String(year)] = {};
-    for (const month of months) {
-      out[String(year)][String(month)] = daysInCalendarMonth(year, month);
-    }
-  }
-  return out;
-};
-
-const compareTimestamps = (a: Photo, b: Photo): number =>
-  a.taken.instant.timestamp.localeCompare(b.taken.instant.timestamp);
-
-const formatDate = (photo: Photo): string => {
-  const i = photo.taken.instant;
-  return `${i.year}-${String(i.month).padStart(2, "0")}-${String(
-    i.day
-  ).padStart(2, "0")}`;
-};
-
-const computeSpan = (
-  first: Photo | undefined,
-  last: Photo | undefined
-): { spanDays: number; spanYears: number; spanMonths: number } => {
-  if (!first || !last) return { spanDays: 0, spanYears: 0, spanMonths: 0 };
-  const firstDate = new Date(
-    first.taken.instant.year,
-    first.taken.instant.month - 1,
-    first.taken.instant.day
-  );
-  const lastDate = new Date(
-    last.taken.instant.year,
-    last.taken.instant.month - 1,
-    last.taken.instant.day
-  );
-  const ms = lastDate.getTime() - firstDate.getTime();
-  const spanDays = Math.max(0, Math.round(ms / (24 * 60 * 60 * 1000)));
-  const spanYears = Math.floor(spanDays / 365.25);
-  const spanMonths = Math.floor(spanDays / (365.25 / 12));
-  return { spanDays, spanYears, spanMonths };
-};
-
-const buildByCategory = (
-  photos: Photo[]
-): Record<string, BucketCounts> => ({
-  author: bucketByString(photos, (p) => p.taken.author),
-  country: bucketByString(photos, (p) => p.taken.location?.country),
-  state: bucketByString(photos, (p) => p.geocoded?.stateCode),
-  city: bucketByString(photos, geocodedCityKey),
-  year: bucketByNumber(photos, (p) => p.taken.instant.year),
-  month: bucketByNumber(photos, (p) => p.taken.instant.month),
-  weekday: bucketByNumber(photos, (p) =>
-    derived.weekday(
-      p.taken.instant.year,
-      p.taken.instant.month,
-      p.taken.instant.day
-    )
-  ),
-  hour: bucketByNumber(photos, (p) => p.taken.instant.hour),
-  cameraMake: bucketByString(photos, (p) => p.camera?.make),
-  camera: bucketByString(photos, formatCamera),
-  lens: bucketByString(photos, formatLens),
-  cameraLens: bucketByString(photos, cameraLensPairKey),
-  focalLength: bucketByNumber(photos, (p) => p.exposure?.focalLength),
-  focalLength35mmEquiv: bucketByNumber(photos, (p) =>
-    derived.focalLength35mmEquiv(
-      p.exposure?.focalLength,
-      p.camera?.make,
-      p.camera?.model,
-      p.exposure?.focalLength35mmEquiv
-    )
-  ),
-  aperture: bucketByNumber(photos, (p) => p.exposure?.aperture),
-  exposureTime: bucketByNumber(photos, (p) => p.exposure?.exposureTime),
-  iso: bucketByNumber(photos, (p) => p.exposure?.iso),
-  ev: bucketByNumber(photos, (p) =>
-    derived.exposureValue(p.exposure?.aperture, p.exposure?.exposureTime)
-  ),
-  lv: bucketByNumber(photos, (p) =>
-    derived.lightValue(
-      p.exposure?.aperture,
-      p.exposure?.exposureTime,
-      p.exposure?.iso
-    )
-  ),
-  resolution: bucketByNumber(photos, (p) =>
-    derived.resolution(
-      p.dimensions?.original?.width,
-      p.dimensions?.original?.height
-    )
-  ),
-  orientation: bucketByString(photos, (p) =>
-    derived.orientation(
-      p.dimensions?.original?.width,
-      p.dimensions?.original?.height
-    )
-  ),
-  aspectRatio: bucketByString(photos, (p) =>
-    derived.aspectRatio(
-      p.dimensions?.original?.width,
-      p.dimensions?.original?.height
-    )
-  ),
-});
-
-const buildAnnotations = (
-  photos: Photo[]
-): {
-  byStateCountry: Record<string, string>;
-  byCityCountry: Record<string, string>;
-  byCityLocalized: Record<string, string>;
-} => {
-  const byStateCountry: Record<string, string> = {};
-  const byCityCountry: Record<string, string> = {};
-  const byCityLocalized: Record<string, string> = {};
-  for (const photo of photos) {
-    const country = photo.geocoded?.countryCode;
-    const state = photo.geocoded?.stateCode;
-    if (state && country && !byStateCountry[state]) {
-      byStateCountry[state] = country;
-    }
-    const cityKey = geocodedCityKey(photo);
-    if (cityKey && country && !byCityCountry[cityKey]) {
-      byCityCountry[cityKey] = country;
-    }
-    if (cityKey && photo.geocoded?.city && !byCityLocalized[cityKey]) {
-      byCityLocalized[cityKey] = photo.geocoded.city;
-    }
-  }
-  return { byStateCountry, byCityCountry, byCityLocalized };
-};
-
-// Universe of bucket keys per category across the unfiltered
-// gallery. Same buckets `buildByCategory` produces, just collapsed
-// to a sorted key list so the wire payload stays small.
-const buildCategoryValues = (
-  photos: Photo[]
-): Record<string, string[]> => {
-  const all = buildByCategory(photos);
-  const out: Record<string, string[]> = {};
-  for (const [category, counts] of Object.entries(all)) {
-    out[category] = Object.keys(counts).sort();
-  }
-  return out;
-};
-
-export const computeStats = (
-  photos: Photo[],
-  filter?: FilterShape
-): StatsResponse => {
-  const filtered = filter
-    ? photos.filter((p) => matchesFilter(filter, p))
-    : photos;
-
-  const byCategory = buildByCategory(filtered);
-  const byYearMonth = buildByYearMonth(filtered);
-  const annotations = buildAnnotations(filtered);
-  // The universe always covers the gallery's full set so the
-  // filter UI keeps surfacing every value, even when the active
-  // filter narrows the count to zero for some of them.
-  const categoryValues = buildCategoryValues(photos);
-
-  const sorted = filtered.slice().sort(compareTimestamps);
-  const first = sorted[0];
-  const last = sorted[sorted.length - 1];
-  const { spanDays, spanYears, spanMonths } = computeSpan(first, last);
-
-  const summary: StatsSummary = {
-    first: first ? formatDate(first) : undefined,
-    last: last ? formatDate(last) : undefined,
-    spanDays,
-    spanYears,
-    spanMonths,
-    peakShape: {
-      year: peakShape(byCategory.year),
-      month: peakShape(byCategory.month),
-      weekday: peakShape(byCategory.weekday),
-      hour: peakShape(byCategory.hour),
-      camera: peakShape(byCategory.camera),
-      lens: peakShape(byCategory.lens),
-      cameraLens: peakShape(byCategory.cameraLens),
-    },
-    variety: {
-      author: countDistinct(filtered, (p) => p.taken.author),
-      country: countDistinct(filtered, (p) => p.taken.location?.country),
-      state: countDistinct(filtered, (p) => p.geocoded?.stateCode),
-      city: countDistinct(filtered, geocodedCityKey),
-      camera: countDistinct(filtered, formatCamera),
-      lens: countDistinct(filtered, formatLens),
-      cameraMake: countDistinct(filtered, (p) => p.camera?.make),
-      cameraLens: countDistinct(filtered, cameraLensPairKey),
-    },
-  };
-
-  return {
-    total: filtered.length,
-    byCategory,
-    byYearMonth,
-    summary,
-    daysInYear: buildDaysInYear(filtered),
-    daysInYearMonth: buildDaysInYearMonth(filtered),
-    byStateCountry: annotations.byStateCountry,
-    byCityCountry: annotations.byCityCountry,
-    byCityLocalized: annotations.byCityLocalized,
-    categoryValues,
-  };
-};
-
-const isUnfilteredBase = (filter?: FilterShape): boolean => {
-  if (!filter) return true;
-  for (const topic of Object.keys(filter)) {
-    const categories = filter[topic];
-    if (!categories) continue;
-    for (const category of Object.keys(categories)) {
-      const keys = categories[category];
-      if (Array.isArray(keys) && keys.length > 0) return false;
-    }
-  }
-  return true;
-};
-
-// Cache key includes lang because `byCityLocalized` differs per
-// language; en is the baseline (matches `loadGalleryPhotos` with
-// no lang argument) and shares the bare `galleryId` key so cache
-// hits accrue across requests without a language overlay.
-const cacheKey = (galleryId: string, lang?: string): string =>
+// Cache namespace builder. `en` / no-lang shares the bare key so
+// the most common path accrues hits across requests that don't
+// ask for a localized overlay.
+const galleryCacheKey = (galleryId: string, lang?: string): string =>
   !lang || lang === "en" ? galleryId : `${galleryId}:${lang}`;
+
+// Distinct namespace so a gallery named "global" can't collide
+// with the cross-gallery cache. Hostnames can't carry colons
+// (gallery ids are slug-shaped) so the prefix is collision-free.
+const globalCacheKey = (lang?: string): string =>
+  !lang || lang === "en" ? ":global" : `:global:${lang}`;
 
 const getGalleryStats = async (
   galleryId: string,
@@ -416,12 +57,28 @@ const getGalleryStats = async (
   lang?: string
 ): Promise<StatsResponse> => {
   const cacheable = isUnfilteredBase(filter);
-  const key = cacheKey(galleryId, lang);
+  const key = galleryCacheKey(galleryId, lang);
   if (cacheable) {
     const cached = cacheGet<StatsResponse>(key);
     if (cached) return cached;
   }
   const photos = (await db.loadGalleryPhotos(galleryId, lang)) as Photo[];
+  const stats = computeStats(photos, filter);
+  if (cacheable) cacheSet(key, stats);
+  return stats;
+};
+
+const getGlobalStats = async (
+  filter?: FilterShape,
+  lang?: string
+): Promise<StatsResponse> => {
+  const cacheable = isUnfilteredBase(filter);
+  const key = globalCacheKey(lang);
+  if (cacheable) {
+    const cached = cacheGet<StatsResponse>(key);
+    if (cached) return cached;
+  }
+  const photos = (await db.loadPhotos(lang)) as Photo[];
   const stats = computeStats(photos, filter);
   if (cacheable) cacheSet(key, stats);
   return stats;

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3039,6 +3039,189 @@
           }
         }
       }
+    },
+    "/api/v1/stats": {
+      "post": {
+        "summary": "Aggregated stats across all galleries (admin)",
+        "tags": [
+          "stats"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "filter": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "lang": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 8
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "total",
+                    "byCategory",
+                    "byYearMonth",
+                    "summary",
+                    "daysInYear",
+                    "daysInYearMonth",
+                    "byStateCountry",
+                    "byCityCountry",
+                    "byCityLocalized",
+                    "categoryValues"
+                  ],
+                  "properties": {
+                    "total": {
+                      "type": "number"
+                    },
+                    "byCategory": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "byYearMonth": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "summary": {
+                      "type": "object",
+                      "required": [
+                        "spanDays",
+                        "spanYears",
+                        "spanMonths",
+                        "peakShape",
+                        "variety"
+                      ],
+                      "properties": {
+                        "first": {
+                          "type": "string"
+                        },
+                        "last": {
+                          "type": "string"
+                        },
+                        "spanDays": {
+                          "type": "number"
+                        },
+                        "spanYears": {
+                          "type": "number"
+                        },
+                        "spanMonths": {
+                          "type": "number"
+                        },
+                        "peakShape": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "variety": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    },
+                    "daysInYear": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "number"
+                      }
+                    },
+                    "daysInYearMonth": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "number"
+                        }
+                      }
+                    },
+                    "byStateCountry": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "byCityCountry": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "byCityLocalized": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "categoryValues": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "tags": [

--- a/server/tests/api/stats.test.ts
+++ b/server/tests/api/stats.test.ts
@@ -241,6 +241,66 @@ describe("cache", () => {
   });
 });
 
+describe("global (cross-gallery)", () => {
+  const postGlobal = async (
+    token: string | undefined,
+    body: Record<string, unknown> = {},
+    status = 200
+  ) =>
+    api
+      .post("/api/v1/stats/")
+      .set("Authorization", `Bearer ${token}`)
+      .send(body)
+      .expect(status);
+
+  test("admin → 200 covering every gallery's photos", async () => {
+    const token = await loginUser(api, "admin");
+    const res = await postGlobal(token);
+    // 5 photos in the fixture: gallery1photo, gallery12photo,
+    // gallery2photo, gallery3photo, orphanphoto.
+    expect(res.body.total).toBe(5);
+    // Countries from all photos, including the orphan's fi.
+    expect(Object.keys(res.body.byCategory.country).sort()).toEqual([
+      "fi",
+      "jp",
+      "nl",
+    ]);
+  });
+
+  test("guest blocked → 403 (auth-required, no admin bypass)", async () => {
+    await api.post("/api/v1/stats/").send({}).expect(403);
+  });
+
+  test("non-admin → 403", async () => {
+    const token = await loginUser(api, "plainuser");
+    await postGlobal(token, {}, 403);
+  });
+
+  test("filter narrows across every gallery", async () => {
+    const token = await loginUser(api, "admin");
+    const res = await postGlobal(token, {
+      filter: { general: { country: ["jp"] } },
+    });
+    // jp photos: gallery1photo, gallery2photo, gallery3photo = 3
+    expect(res.body.total).toBe(3);
+  });
+
+  test("photo update invalidates the global cache (next call sees the new value)", async () => {
+    const token = await loginUser(api, "admin");
+    const before = await postGlobal(token);
+    expect(before.body.byCategory.country.fi).toBe(1);
+    // Flip orphanphoto.jpg's country fi → nl.
+    await api
+      .put("/api/v1/photos/orphanphoto.jpg")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ taken: { location: { country: "nl" } } })
+      .expect(204);
+    const after = await postGlobal(token);
+    expect(after.body.byCategory.country.fi).toBeUndefined();
+    expect(after.body.byCategory.country.nl).toBe(2); // gallery12photo + orphanphoto
+  });
+});
+
 describe("unknown bucket", () => {
   test("photos with empty fields bucket under 'unknown'", async () => {
     const token = await loginUser(api, "admin");


### PR DESCRIPTION
## Summary

Sets up the cross-gallery path that `GlobalStats` will migrate to in slice 6b — unblocking the deletion of the client-side photo walk. Server extracts the pure compute logic so both gallery-scoped and global flavours share it.

## Refactor

- **`lib/stats-compute.ts`** — pure functions lifted out of `models/stats.ts`. `computeStats(photos, filter)`, the bucket builders, the response shape types, `UNKNOWN_BUCKET`, and `isUnfilteredBase` all move here. No DB or cache imports.
- **`models/stats.ts`** collapses to two thin orchestration calls: `getGalleryStats(galleryId, filter?, lang?)` and the new `getGlobalStats(filter?, lang?)`. Both wrap the same compute with a per-flavour cache key.

## New endpoint

```
POST /api/v1/stats
```

Admin-only, `requireUnscoped` (rejects on hostname-bound instances — matches the other cross-gallery admin routes). Body shape identical to the gallery-scoped endpoint so the client can reuse the same wire types.

## Cache

- Dedicated `:global` / `:global:<lang>` namespace prefix. Slug-shaped gallery ids can't start with `:`, so collisions are impossible.
- `invalidateGlobal()` exported alongside `invalidateGallery`.
- **Drive-by fix**: `invalidateGallery` now drops every `<id>` / `<id>:<lang>` entry. Previously only the bare `<id>` was dropped, leaving localised variants stale until TTL.
- Photo writes (`createPhoto`, `updatePhoto`, `deletePhoto`, regeocode via `invalidateStatsForPhoto`) all drop the global cache. Gallery-photo link / unlink doesn't — the catalogue set is unchanged, only the per-gallery membership view shifted.

## Client service

`statsService.getGlobalStats(filter, lang)` matches `getGalleryStats`'s signature minus the gallery id. No consumer yet.

## Test plan

5 new integration tests:
- Admin sees the cross-gallery total (fixture: 5 photos, jp + nl + fi).
- Guest blocked (403).
- Non-admin blocked (403).
- Filter narrows across galleries.
- Photo update invalidates the global cache; next call sees the new country bucket.

`npm test` — 32 files / 828 tests pass.

## Next (slice 6b)

Frontend: `Stats` gets a `globalScope` prop; `GlobalStats` uses it instead of the in-memory `stats.generate(photos)` path; the dead client-side `collectStatistics` + `initializeStats` + `populateDistributions` + `calculateNumberOfDays` finally gets deleted. Closes #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)