### PR TITLE
react-app: Year view consumes server counts endpoint (#406, slice 2)

### DIFF
--- a/react-app/src/components/Gallery/Year/Content.tsx
+++ b/react-app/src/components/Gallery/Year/Content.tsx
@@ -1,9 +1,13 @@
 import React from "react";
 import styled from "@emotion/styled";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 import Month from "./Month";
 
 import calendar from "../../../lib/calendar";
+import filter from "../../../lib/filter";
+import galleryPhotosService from "../../../services/gallery-photos";
+import { useFiltersStore } from "../../../stores";
 
 import type { Gallery } from "../../../models/GalleryModel";
 
@@ -30,13 +34,38 @@ interface Props {
   theme: ActiveTheme;
 }
 
+const EMPTY_COUNTS: Record<string, number> = {};
+
 const Content = ({
   children,
   gallery,
   year,
   theme,
 }: Props): React.ReactElement => {
-  const maxCount = gallery.maxDayCount(year);
+  const filters = useFiltersStore((s) => s.filters);
+  const serverFilters = React.useMemo(
+    () => filter.toServerFilters(filters),
+    [filters]
+  );
+  // Per-day counts fetched from the server (#406). `keepPreviousData`
+  // keeps the heatmap painted while a year / filter change refetches —
+  // a chip toggle gets an in-place update, not a loader flash.
+  const { data: counts = EMPTY_COUNTS } = useQuery({
+    queryKey: ["gallery-photo-counts", gallery.id(), year, serverFilters],
+    queryFn: () =>
+      galleryPhotosService.getCounts(gallery.id(), {
+        filter: serverFilters,
+        year,
+      }),
+    placeholderData: keepPreviousData,
+  });
+  const maxCount = React.useMemo(() => {
+    let max = 0;
+    for (const value of Object.values(counts)) {
+      if (value > max) max = value;
+    }
+    return max;
+  }, [counts]);
   return (
     <>
       {children}
@@ -50,6 +79,7 @@ const Content = ({
                 gallery={gallery}
                 year={year}
                 month={month}
+                counts={counts}
                 maxCount={maxCount}
                 theme={theme}
               />

--- a/react-app/src/components/Gallery/Year/Day.tsx
+++ b/react-app/src/components/Gallery/Year/Day.tsx
@@ -7,8 +7,6 @@ import DayCell from "./DayCell";
 import color from "../../../lib/color";
 import format from "../../../lib/format";
 
-import type { Gallery } from "../../../models/GalleryModel";
-
 type ActiveTheme = { get: (name: string) => string };
 
 const Some = styled(DayCell)``;
@@ -42,19 +40,19 @@ const getHeatColors = (theme: ActiveTheme): string[] => {
 };
 
 interface Props {
-  gallery: Gallery;
   year: number;
   month: number;
   day: number;
+  counts: Record<string, number>;
   maxCount: number;
   theme: ActiveTheme;
 }
 
 const Day = ({
-  gallery,
   year,
   month,
   day,
+  counts,
   maxCount,
   theme,
 }: Props): React.ReactElement => {
@@ -69,8 +67,12 @@ const Day = ({
     return day;
   };
 
-  const photoCount = gallery.countPhotos(year, month, day);
-  const heatColor = heatColors[Math.round((photoCount * 10) / maxCount)];
+  const key = `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+  const photoCount = counts[key] ?? 0;
+  const heatColor =
+    maxCount === 0
+      ? heatColors[0]
+      : heatColors[Math.round((photoCount * 10) / maxCount)];
   const style = {
     backgroundColor: heatColor,
   };

--- a/react-app/src/components/Gallery/Year/Month.tsx
+++ b/react-app/src/components/Gallery/Year/Month.tsx
@@ -73,6 +73,7 @@ interface Props {
   gallery: Gallery;
   year: number;
   month: number;
+  counts: Record<string, number>;
   maxCount: number;
   theme: ActiveTheme;
 }
@@ -81,6 +82,7 @@ const Month = ({
   gallery,
   year,
   month,
+  counts,
   maxCount,
   theme,
 }: Props): React.ReactElement => {
@@ -104,10 +106,10 @@ const Month = ({
                 {row.map((day, cellIndex) => (
                   <Day
                     key={cellIndex}
-                    gallery={gallery}
                     year={year}
                     month={month}
                     day={day}
+                    counts={counts}
                     maxCount={maxCount}
                     theme={theme}
                   />

--- a/react-app/src/services/gallery-photos.ts
+++ b/react-app/src/services/gallery-photos.ts
@@ -1,9 +1,40 @@
 import api, { unwrap } from "../lib/api";
 
+import type { ServerFilters } from "../lib/filter";
+
 const get = async (galleryId: string, lang?: string) =>
   unwrap(
     api.GET("/api/v1/gallery-photos/{galleryId}", {
       params: { path: { galleryId }, query: lang ? { lang } : undefined },
+    })
+  );
+
+interface QueryOpts {
+  filter?: ServerFilters;
+  year?: number;
+  month?: number;
+  day?: number;
+  lang?: string;
+}
+// Per-view + filtered fetch (#406). Backs the view-scoped photo
+// list for Month / Day; same wire shape as the unfiltered `get`.
+const query = async (galleryId: string, opts: QueryOpts = {}) =>
+  unwrap(
+    api.POST("/api/v1/gallery-photos/{galleryId}/query", {
+      params: { path: { galleryId } },
+      body: opts,
+    })
+  );
+
+// Per-day photo counts for the Year heatmap (#406).
+const getCounts = async (
+  galleryId: string,
+  opts: { filter?: ServerFilters; year?: number } = {}
+): Promise<Record<string, number>> =>
+  unwrap(
+    api.POST("/api/v1/gallery-photos/{galleryId}/counts", {
+      params: { path: { galleryId } },
+      body: opts,
     })
   );
 
@@ -23,4 +54,4 @@ const unlink = async (galleryId: string, photoId: string): Promise<void> => {
   );
 };
 
-export default { get, link, unlink };
+export default { get, query, getCounts, link, unlink };


### PR DESCRIPTION
## Summary

First view migration off the in-memory `gallery.photos()` array. The Year heatmap was the cleanest swap: it only needs per-day counts, no photo objects.

## Changes

**`Year/Content.tsx`**
- New `useQuery` against `POST /api/v1/gallery-photos/:id/counts` with `keepPreviousData` so a filter chip toggle or year switch updates the heatmap in place (no loader flash).
- Filter state read from `useFiltersStore` and serialised via the existing `toServerFilters`.
- `maxCount` derived from the returned counts map (was `gallery.maxDayCount(year)` walking the in-memory array).

**`Year/Month.tsx`** + **`Year/Day.tsx`**
- Receive the counts map as a prop; Day looks up `counts["YYYY-MM-DD"]` instead of calling `gallery.countPhotos(year, month, day)`.
- Day no longer needs the `gallery` prop (it was only there for the count lookup); dropped from the type + destructure.

**`services/gallery-photos.ts`**
- Adds `getCounts(galleryId, { filter?, year? })` and `query(galleryId, { filter?, year?, month?, day?, lang? })`. Both wrap the new endpoints from #524. `query` not consumed yet — slice 3 wires it into Month / Day.

## What still runs on the in-memory path

The `gallery.withPhotos(filteredPhotos)` filter in `Gallery/index.tsx` stays — Month / Day / Photo views haven't migrated yet. Year is now independent of that path; refetches via the server when filters change. `gallery.maxDayCount` / `gallery.countPhotos` stay on the model for now; slice 5 retires them along with the in-memory filter once every view consumes its own server fetch.

## Test plan

- [x] `npm run typecheck` + `npm run lint` clean.
- [x] `npm test` — 20 files / 983 tests pass (no test changes; the components weren't unit-tested at the level the migration touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)