### PR TITLE
react-app: Month view consumes /query endpoint (#406, slice 3)

### DIFF
--- a/react-app/src/components/Gallery/Month/Content.tsx
+++ b/react-app/src/components/Gallery/Month/Content.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 import EpochAge from "../EpochAge";
 import EpochDayIndex from "../EpochDayIndex";
@@ -9,6 +10,12 @@ import Thumbnails from "../Thumbnails";
 import Link from "../Link";
 
 import calendar from "../../../lib/calendar";
+import filter from "../../../lib/filter";
+import galleryPhotosService from "../../../services/gallery-photos";
+import PhotoModel, {
+  type Photo as PhotoT,
+} from "../../../models/PhotoModel";
+import { useFiltersStore } from "../../../stores";
 
 import type { Gallery } from "../../../models/GalleryModel";
 
@@ -85,6 +92,51 @@ const Content = ({
   modalActive,
 }: Props): React.ReactElement => {
   const { t } = useTranslation();
+
+  // Per-view fetch (#406): server returns the month's photos
+  // already filter-narrowed, so we group them by day client-side
+  // and skip the in-memory gallery.photos walk.
+  const filters = useFiltersStore((s) => s.filters);
+  const serverFilters = React.useMemo(
+    () => filter.toServerFilters(filters),
+    [filters]
+  );
+  const { data: photosRaw } = useQuery({
+    queryKey: [
+      "gallery-photos-month",
+      gallery.id(),
+      year,
+      month,
+      serverFilters,
+      lang,
+    ],
+    queryFn: () =>
+      galleryPhotosService.query(gallery.id(), {
+        filter: serverFilters,
+        year,
+        month,
+        lang,
+      }),
+    placeholderData: keepPreviousData,
+  });
+  const photosByDay = React.useMemo(() => {
+    const out: Record<number, PhotoT[]> = {};
+    for (const raw of (photosRaw ?? []) as Array<Record<string, unknown>>) {
+      const photo = PhotoModel(raw);
+      if (!photo) continue;
+      const d = photo.day();
+      if (!out[d]) out[d] = [];
+      out[d].push(photo);
+    }
+    return out;
+  }, [photosRaw]);
+  const daysWithPhotos = React.useMemo(
+    () =>
+      Object.keys(photosByDay)
+        .map(Number)
+        .sort((a, b) => a - b),
+    [photosByDay]
+  );
 
   // RAF defers past ScrollToPosition's setTimeout(0) — without that delay
   // the parent's scroll restore fires last and undoes this jump. While
@@ -164,7 +216,7 @@ const Content = ({
       <Thumbnails
         key={"" + year + month + d}
         gallery={gallery}
-        photos={gallery.photos(year, month, d)}
+        photos={photosByDay[d] ?? []}
         lang={lang}
         countryData={countryData}
         highlighted={isHighlighted}
@@ -191,7 +243,7 @@ const Content = ({
   return (
     <>
       {children}
-      <Root>{gallery.mapDays(year, month, renderDay)}</Root>
+      <Root>{daysWithPhotos.map(renderDay)}</Root>
     </>
   );
 };


### PR DESCRIPTION
## Summary

Migrates the Month view off the in-memory `gallery.photos(year, month, day)` walk to the per-view server fetch.

`Month/Content.tsx`:
- New `useQuery` against `POST /api/v1/gallery-photos/:id/query` with `{filter, year, month, lang}`. `keepPreviousData` so a chip toggle or month switch updates in place — same UX trick the Year view + Stats use.
- Returned photos run through `PhotoModel(raw)` (matches the gallery model's photo shape) and grouped into `photosByDay`.
- Day iteration walks `daysWithPhotos` (sorted keys of `photosByDay`) instead of `gallery.mapDays(year, month, ...)`.
- Per-day thumbnail source switches from `gallery.photos(year, month, d)` to `photosByDay[d]`.

`gallery.includesMonth` and the other gallery-level helpers (`firstMonth`, `lastMonth`, `path`, EpochAge / EpochDayIndex) still consult the gallery model — they're cheap, gallery-scoped, and don't filter, so they stay on the existing path. Slice 5 retires the underlying `photosByYmd` index once Photo modal also migrates and the in-memory `gallery.withPhotos()` filter is gone.

There's no separate Day view to migrate — Day merged into Month in 0.10. Clicking a day deep-links into Month with a `day` param + scroll-into-view. That path is unchanged.

## Test plan

- [x] `npm run typecheck` + `npm run lint` clean.
- [x] `npm test` — 20 files / 983 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)