### PR TITLE
Drop in-memory photo filter; map button reads /query (#406, slice 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Server
+
+- Three new `POST` endpoints on `/api/v1/gallery-photos/<id>` — `/query` (filter-narrowed photo list, optionally scoped to year / month / day), `/counts` (per-day `YYYY-MM-DD` → count map for the Year heatmap), and `/neighbors` (previous / next / first / last plus 1-indexed position + total within the active filter, for the Photo modal's carousel and breadcrumb) — share the same FilterShape wire envelope as `/api/v1/stats` and gate on the same gallery-view ACL. (closes #406)
+
+### Frontend
+
+- Public gallery views fetch only what they render: Year consumes `/counts` for the heatmap, Month consumes `/query` for the day thumbnails, the Photo modal pulls prev / next / first / last + position / total from `/neighbors`, and the Title bar's map button fetches its in-scope pins from `/query` — all with the active filter applied server-side and `keepPreviousData` smoothing refetches across filter toggles. The legacy `gallery.withPhotos(filteredPhotos)` in-memory filter walk in `Gallery/index.tsx` is gone; filter changes no longer rebuild the whole gallery model. (closes #406)
+
 ## [0.14.0] - 2026-06-07
 
 ### Server

--- a/react-app/src/components/Gallery/Month/Navigation.tsx
+++ b/react-app/src/components/Gallery/Month/Navigation.tsx
@@ -12,6 +12,7 @@ import {
 import Root, { UpButton } from "../Navigation";
 import Link from "../Link";
 
+import useFilteredCalendar from "../../../lib/useFilteredCalendar";
 import type { Gallery } from "../../../models/GalleryModel";
 
 const Group = styled.div`
@@ -53,13 +54,14 @@ const Navigation = ({
   month,
 }: Props): React.ReactElement => {
   const { t } = useTranslation();
-  const prevVisibility = gallery.isFirstMonth(year, month) ? "hidden" : "";
-  const nextVisibility = gallery.isLastMonth(year, month) ? "hidden" : "";
+  const cal = useFilteredCalendar(gallery.id());
+  const prevVisibility = cal.isFirstMonth(year, month) ? "hidden" : "";
+  const nextVisibility = cal.isLastMonth(year, month) ? "hidden" : "";
 
-  const [firstYear, firstMonth] = gallery.firstMonth();
-  const [previousYear, previousMonth] = gallery.previousMonth(year, month);
-  const [nextYear, nextMonth] = gallery.nextMonth(year, month);
-  const [lastYear, lastMonth] = gallery.lastMonth();
+  const [firstYear, firstMonth] = cal.firstMonth();
+  const [previousYear, previousMonth] = cal.previousMonth(year, month);
+  const [nextYear, nextMonth] = cal.nextMonth(year, month);
+  const [lastYear, lastMonth] = cal.lastMonth();
   return (
     <Root>
       <UpButton

--- a/react-app/src/components/Gallery/Month/index.tsx
+++ b/react-app/src/components/Gallery/Month/index.tsx
@@ -9,6 +9,7 @@ import Navigation from "./Navigation";
 import Content from "./Content";
 
 import useKeyPress from "../../../lib/keypress";
+import useFilteredCalendar from "../../../lib/useFilteredCalendar";
 
 import type { Gallery } from "../../../models/GalleryModel";
 
@@ -43,25 +44,30 @@ const Month = ({
   const navigate = useNavigate();
 
   const { t } = useTranslation();
+  const cal = useFilteredCalendar(gallery.id());
 
   const handlMoveToFirst = () => {
-    if (!gallery.isFirstMonth(year, month)) {
-      navigate(gallery.path(...gallery.firstMonth()));
+    const [y, m] = cal.firstMonth();
+    if (y !== undefined && m !== undefined && !cal.isFirstMonth(year, month)) {
+      navigate(gallery.path(y, m));
     }
   };
   const handlMoveToPrevious = () => {
-    if (!gallery.isFirstMonth(year, month)) {
-      navigate(gallery.path(...gallery.previousMonth(year, month)));
+    const [y, m] = cal.previousMonth(year, month);
+    if (y !== undefined && m !== undefined) {
+      navigate(gallery.path(y, m));
     }
   };
   const handlMoveToNext = () => {
-    if (!gallery.isLastMonth(year, month)) {
-      navigate(gallery.path(...gallery.nextMonth(year, month)));
+    const [y, m] = cal.nextMonth(year, month);
+    if (y !== undefined && m !== undefined) {
+      navigate(gallery.path(y, m));
     }
   };
   const handlMoveToLast = () => {
-    if (!gallery.isLastMonth(year, month)) {
-      navigate(gallery.path(...gallery.lastMonth()));
+    const [y, m] = cal.lastMonth();
+    if (y !== undefined && m !== undefined && !cal.isLastMonth(year, month)) {
+      navigate(gallery.path(y, m));
     }
   };
 

--- a/react-app/src/components/Gallery/Title.tsx
+++ b/react-app/src/components/Gallery/Title.tsx
@@ -17,7 +17,7 @@ import {
   useUserStore,
 } from "../../stores";
 import type { Gallery } from "../../models/GalleryModel";
-import type { Photo } from "../../models/PhotoModel";
+import PhotoModel, { type Photo } from "../../models/PhotoModel";
 
 const Root = styled.div`
   display: flex;
@@ -242,30 +242,39 @@ const Title = ({
 
   // Map scope: month if URL identifies a month (or a photo within one),
   // year if only year, whole gallery on Statistics. Empty array hides
-  // the button (also when the per-gallery hideMap flag is set).
-  const mapPhotos = React.useMemo(() => {
-    if (gallery.hideMap()) {
-      return [];
-    }
+  // the button (also when the per-gallery hideMap flag is set). The
+  // /query fetch returns photos that pass the active filter + scope;
+  // we then keep only the ones with coordinates for the map pins.
+  const mapScopeEnabled =
+    !gallery.hideMap() &&
+    (year !== undefined ||
+      (context === "stats" && year === undefined && month === undefined));
+  const mapScopeBody = React.useMemo(() => {
     if (year !== undefined && month !== undefined) {
-      return gallery
-        .flatMapDays(year, month, (d) => gallery.photos(year, month, d))
-        .filter(Boolean)
-        .filter((p) => p.hasCoordinates());
+      return { filter: serverFilters, year, month };
     }
     if (year !== undefined) {
-      return gallery
-        .flatMapMonths(year, (m) =>
-          gallery.flatMapDays(year, m, (d) => gallery.photos(year, m, d))
-        )
-        .filter(Boolean)
-        .filter((p) => p.hasCoordinates());
+      return { filter: serverFilters, year };
     }
-    if (context === "stats") {
-      return gallery.photos().filter((p) => p.hasCoordinates());
-    }
-    return [];
-  }, [gallery, year, month, context]);
+    return { filter: serverFilters };
+  }, [serverFilters, year, month]);
+  const { data: mapPhotosRaw } = useQuery({
+    queryKey: [
+      "gallery-photos-map",
+      gallery.id(),
+      mapScopeBody,
+    ],
+    queryFn: () => galleryPhotosService.query(gallery.id(), mapScopeBody),
+    enabled: mapScopeEnabled,
+    placeholderData: keepPreviousData,
+  });
+  const mapPhotos = React.useMemo(() => {
+    if (!mapScopeEnabled) return [];
+    return ((mapPhotosRaw ?? []) as Array<Record<string, unknown>>)
+      .map((raw) => PhotoModel(raw))
+      .filter((p): p is Photo => !!p)
+      .filter((p) => p.hasCoordinates());
+  }, [mapPhotosRaw, mapScopeEnabled]);
 
   const getRedirectPath = (gallery: Gallery, context: string): string => {
     switch (context) {

--- a/react-app/src/components/Gallery/Year/Month.tsx
+++ b/react-app/src/components/Gallery/Year/Month.tsx
@@ -7,6 +7,7 @@ import DayCell from "./DayCell";
 import Link from "../Link";
 
 import calendar from "../../../lib/calendar";
+import useFilteredCalendar from "../../../lib/useFilteredCalendar";
 
 import type { Gallery } from "../../../models/GalleryModel";
 
@@ -87,6 +88,7 @@ const Month = ({
   theme,
 }: Props): React.ReactElement => {
   const { t } = useTranslation();
+  const cal = useFilteredCalendar(gallery.id());
 
   const tile = (
     <Root>
@@ -122,7 +124,7 @@ const Month = ({
     </Root>
   );
 
-  if (gallery.includesMonth(year, month)) {
+  if (cal.has(year, month)) {
     return (
       <MonthLink gallery={gallery} year={year} month={month}>
         {tile}

--- a/react-app/src/components/Gallery/Year/Navigation.tsx
+++ b/react-app/src/components/Gallery/Year/Navigation.tsx
@@ -13,6 +13,7 @@ import Root, { UpButton } from "../Navigation";
 import Link from "../Link";
 import FormatDate from "../../FormatDate";
 
+import useFilteredCalendar from "../../../lib/useFilteredCalendar";
 import type { Gallery } from "../../../models/GalleryModel";
 
 const Group = styled.div`
@@ -47,13 +48,14 @@ interface Props {
 
 const Navigation = ({ gallery, year }: Props): React.ReactElement => {
   const { t } = useTranslation();
-  const prevVisibility = gallery.isFirstYear(year) ? "hidden" : "";
-  const nextVisibility = gallery.isLastYear(year) ? "hidden" : "";
+  const cal = useFilteredCalendar(gallery.id());
+  const prevVisibility = cal.isFirstYear(year) ? "hidden" : "";
+  const nextVisibility = cal.isLastYear(year) ? "hidden" : "";
 
-  const firstYear = gallery.firstYear();
-  const previousYear = gallery.previousYear(year);
-  const nextYear = gallery.nextYear(year);
-  const lastYear = gallery.lastYear();
+  const firstYear = cal.firstYear();
+  const previousYear = cal.previousYear(year);
+  const nextYear = cal.nextYear(year);
+  const lastYear = cal.lastYear();
   return (
     <Root>
       <UpButton

--- a/react-app/src/components/Gallery/Year/index.tsx
+++ b/react-app/src/components/Gallery/Year/index.tsx
@@ -9,6 +9,7 @@ import Navigation from "./Navigation";
 import Content from "./Content";
 
 import useKeyPress from "../../../lib/keypress";
+import useFilteredCalendar from "../../../lib/useFilteredCalendar";
 
 import type { Gallery } from "../../../models/GalleryModel";
 
@@ -30,28 +31,29 @@ const Year = ({
   const navigate = useNavigate();
 
   const { t } = useTranslation();
+  const cal = useFilteredCalendar(gallery.id());
 
   const handlMoveToFirst = () => {
-    const firstYear = gallery.firstYear();
-    if (!gallery.isFirstYear(year) && firstYear) {
+    const firstYear = cal.firstYear();
+    if (!cal.isFirstYear(year) && firstYear !== undefined) {
       navigate(gallery.path(firstYear));
     }
   };
   const handlMoveToPrevious = () => {
-    const previousYear = gallery.previousYear(year);
-    if (!gallery.isFirstYear(year) && previousYear) {
+    const previousYear = cal.previousYear(year);
+    if (previousYear !== undefined) {
       navigate(gallery.path(previousYear));
     }
   };
   const handlMoveToNext = () => {
-    const nextYear = gallery.nextYear(year);
-    if (!gallery.isLastYear(year) && nextYear) {
+    const nextYear = cal.nextYear(year);
+    if (nextYear !== undefined) {
       navigate(gallery.path(nextYear));
     }
   };
   const handlMoveToLast = () => {
-    const lastYear = gallery.lastYear();
-    if (!gallery.isLastYear(year) && lastYear) {
+    const lastYear = cal.lastYear();
+    if (!cal.isLastYear(year) && lastYear !== undefined) {
       navigate(gallery.path(lastYear));
     }
   };

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -167,19 +167,8 @@ const Gallery = ({
 
   const gallery = React.useMemo<GalleryT | undefined>(() => {
     if (!selectedGallery || !photos) return undefined;
-    const filteredPhotos = photos.filter((photo) =>
-      Object.values(filters).every(
-        (topicFilters) =>
-          !Object.keys(topicFilters).length ||
-          Object.values(topicFilters).every(
-            (categoryFilters) =>
-              !Object.keys(categoryFilters).length ||
-              Object.values(categoryFilters).some((filter) => filter(photo))
-          )
-      )
-    );
-    return selectedGallery.withPhotos(filteredPhotos);
-  }, [selectedGallery, photos, filters]);
+    return selectedGallery.withPhotos(photos);
+  }, [selectedGallery, photos]);
 
   // Load the persisted user preference once, against the current
   // manifest so a stale localStorage entry can't survive a theme

--- a/react-app/src/lib/useFilteredCalendar.ts
+++ b/react-app/src/lib/useFilteredCalendar.ts
@@ -1,0 +1,165 @@
+import React from "react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import filter from "./filter";
+import galleryPhotosService from "../services/gallery-photos";
+import { useFiltersStore } from "../stores";
+
+export interface FilteredCalendar {
+  ready: boolean;
+  has(year: number, month?: number, day?: number): boolean;
+  firstYear(): number | undefined;
+  lastYear(): number | undefined;
+  isFirstYear(year: number): boolean;
+  isLastYear(year: number): boolean;
+  previousYear(year: number): number | undefined;
+  nextYear(year: number): number | undefined;
+  firstMonth(): [number, number] | [undefined, undefined];
+  lastMonth(): [number, number] | [undefined, undefined];
+  isFirstMonth(year: number, month: number): boolean;
+  isLastMonth(year: number, month: number): boolean;
+  previousMonth(
+    year: number,
+    month: number
+  ): [number, number] | [undefined, undefined];
+  nextMonth(
+    year: number,
+    month: number
+  ): [number, number] | [undefined, undefined];
+}
+
+const ymKey = (y: number, m: number): string =>
+  `${y}-${String(m).padStart(2, "0")}`;
+
+// Reads /counts (gallery-wide, filter-applied, no year scope) and
+// derives the navigation primitives the gallery model used to compute
+// in-memory from the filtered photo array. One query per (gallery,
+// filter) tuple — shared via TanStack across every component that
+// needs it. Loaded state ("ready=false") collapses every navigation
+// helper to "empty" so the UI hides the prev/next chrome instead of
+// flashing wrong links from stale gallery data.
+const useFilteredCalendar = (galleryId: string): FilteredCalendar => {
+  const filters = useFiltersStore((s) => s.filters);
+  const serverFilters = React.useMemo(
+    () => filter.toServerFilters(filters),
+    [filters]
+  );
+  const { data: counts } = useQuery({
+    queryKey: ["gallery-photo-counts", galleryId, undefined, serverFilters],
+    queryFn: () =>
+      galleryPhotosService.getCounts(galleryId, { filter: serverFilters }),
+    placeholderData: keepPreviousData,
+  });
+  return React.useMemo<FilteredCalendar>(() => {
+    if (!counts) {
+      return {
+        ready: false,
+        has: () => false,
+        firstYear: () => undefined,
+        lastYear: () => undefined,
+        isFirstYear: () => false,
+        isLastYear: () => false,
+        previousYear: () => undefined,
+        nextYear: () => undefined,
+        firstMonth: () => [undefined, undefined],
+        lastMonth: () => [undefined, undefined],
+        isFirstMonth: () => false,
+        isLastMonth: () => false,
+        previousMonth: () => [undefined, undefined],
+        nextMonth: () => [undefined, undefined],
+      };
+    }
+    const yearSet = new Set<number>();
+    const monthSet = new Set<string>();
+    const daySet = new Set<string>();
+    for (const key of Object.keys(counts)) {
+      const [ys, ms, ds] = key.split("-");
+      const y = Number(ys);
+      const m = Number(ms);
+      yearSet.add(y);
+      monthSet.add(ymKey(y, m));
+      daySet.add(`${ymKey(y, m)}-${ds}`);
+    }
+    const years = [...yearSet].sort((a, b) => a - b);
+    const months = [...monthSet].sort();
+    const ymToIdx = new Map(months.map((k, i) => [k, i]));
+    return {
+      ready: true,
+      has: (year, month, day) => {
+        if (day !== undefined && month !== undefined) {
+          return daySet.has(
+            `${ymKey(year, month)}-${String(day).padStart(2, "0")}`
+          );
+        }
+        if (month !== undefined) return monthSet.has(ymKey(year, month));
+        return yearSet.has(year);
+      },
+      firstYear: () => (years.length ? years[0] : undefined),
+      lastYear: () => (years.length ? years[years.length - 1] : undefined),
+      isFirstYear: (year) => years.length > 0 && year <= years[0],
+      isLastYear: (year) => years.length > 0 && year >= years[years.length - 1],
+      previousYear: (year) => {
+        for (let i = years.length - 1; i >= 0; i--) {
+          if (years[i] < year) return years[i];
+        }
+        return undefined;
+      },
+      nextYear: (year) => {
+        for (let i = 0; i < years.length; i++) {
+          if (years[i] > year) return years[i];
+        }
+        return undefined;
+      },
+      firstMonth: () => {
+        if (!months.length) return [undefined, undefined];
+        const [y, m] = months[0].split("-").map(Number);
+        return [y, m];
+      },
+      lastMonth: () => {
+        if (!months.length) return [undefined, undefined];
+        const [y, m] = months[months.length - 1].split("-").map(Number);
+        return [y, m];
+      },
+      isFirstMonth: (year, month) =>
+        months.length > 0 && ymKey(year, month) <= months[0],
+      isLastMonth: (year, month) =>
+        months.length > 0 && ymKey(year, month) >= months[months.length - 1],
+      previousMonth: (year, month) => {
+        const idx = ymToIdx.get(ymKey(year, month));
+        if (idx === undefined) {
+          // Current view is on an empty month — find the largest key
+          // strictly before it.
+          const key = ymKey(year, month);
+          for (let i = months.length - 1; i >= 0; i--) {
+            if (months[i] < key) {
+              const [y, m] = months[i].split("-").map(Number);
+              return [y, m];
+            }
+          }
+          return [undefined, undefined];
+        }
+        if (idx === 0) return [undefined, undefined];
+        const [y, m] = months[idx - 1].split("-").map(Number);
+        return [y, m];
+      },
+      nextMonth: (year, month) => {
+        const idx = ymToIdx.get(ymKey(year, month));
+        if (idx === undefined) {
+          const key = ymKey(year, month);
+          for (let i = 0; i < months.length; i++) {
+            if (months[i] > key) {
+              const [y, m] = months[i].split("-").map(Number);
+              return [y, m];
+            }
+          }
+          return [undefined, undefined];
+        }
+        if (idx === months.length - 1) return [undefined, undefined];
+        const [y, m] = months[idx + 1].split("-").map(Number);
+        return [y, m];
+      },
+    };
+  }, [counts]);
+};
+
+export default useFilteredCalendar;


### PR DESCRIPTION
## Summary

Closing slice of #406. Year heatmap, Month thumbnails, and Photo modal navigation are all already reading filter-narrowed data from the new server endpoints (slices 2–4); this slice removes the last two in-memory filter walks — the inline `photos.filter(...)` loop in `Gallery/index.tsx` (which produced the `gallery.withPhotos(filteredPhotos)` clone every filter render touched), and the `gallery.flatMapDays(...).filter(p.hasCoordinates())` chain in `Title.tsx` that fed the map button. Both now go through `/query`.

`gallery.photos()` and the calendar-boundary helpers (`firstDay`, `lastDay`, `includesMonth`, `lastPath`, …) operate on the unfiltered set going forward, which is the right semantic: those are calendar facts about the gallery, not facts about the active filter. The Filters sidebar UI still flows through `useFiltersStore` → `<Filters>` unchanged; the filter just doesn't *also* loop the photos in JS anymore.

## Title bar map button

The map's pin set is the only remaining filter-respecting full-photo walk. Reuses `/query` with the active filter + (year, month?) scope, then client-side `.hasCoordinates()` filter narrows to map pins. `keepPreviousData` keeps the button visible while a filter toggle's refetch is in flight, matching the smoothing pattern used in Year / Month / Photo since slice 2. The queryKey is intentionally distinct from Month's `gallery-photos-month` key (different lifetime / lang requirements); the cost is one extra round-trip per view change, not per render.

## Direct photo URLs outside the filter

`gallery.photo(year, month, day, photoId)` no longer applies the in-memory filter, so a direct photo URL outside the active filter resolves and the modal mounts. `/neighbors` already handles this gracefully — when the current photo isn't in the filtered set it returns `first / last / total` only (no `position`, no `previous`, no `next`), so the carets hide, the skip-back/skip-forward buttons let you jump back into the filtered set, and the breadcrumb's `#N` crumb stays empty. This is a small UX improvement over the prior behavior (where a filtered-out URL silently redirected to month) and the natural shape now that filtering is server-driven.

## Test plan

- [x] `npm run typecheck` + `npm test` + `npm run lint` clean in react-app
- [ ] Verify on a live filtered Year view: filter pills toggle smoothly, heatmap counts update, the breadcrumb stays put
- [ ] Verify on a live filtered Month view: thumbnails narrow, the map button reflects pins from the active filter (not all-coords)
- [ ] Verify Photo modal under a filter: position / total reads from the filtered set (regression fix from #527), prev/next walk the filter, first/last jump to filter boundaries
- [ ] Verify a direct URL to a filter-excluded photo: modal mounts, breadcrumb's #N is empty, skip-back/skip-forward land at the filter's first/last