### PR TITLE
Driver-interface refactor: push FilterShape into db.*

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1,4 +1,5 @@
 import config from "../lib/config/index.js";
+import type { FilterShape } from "../lib/photo-filter-eval.js";
 import type {
   Gallery,
   GalleryInput,
@@ -11,6 +12,30 @@ import type {
   User,
   UserGalleryRow,
 } from "./sqlite3/schema.js";
+
+export interface QueryFilteredOpts {
+  filter?: FilterShape;
+  year?: number;
+  month?: number;
+  day?: number;
+  lang?: string;
+}
+export interface CountsFilteredOpts {
+  filter?: FilterShape;
+  year?: number;
+}
+export interface NeighborsFilteredOpts {
+  filter?: FilterShape;
+  lang?: string;
+}
+export interface NeighborsResult {
+  previous?: Photo;
+  next?: Photo;
+  first?: Photo;
+  last?: Photo;
+  position?: number;
+  total: number;
+}
 
 const drivers = {
   sqlite3: () => import("./sqlite3/index.js"),
@@ -197,6 +222,32 @@ export default {
 
   loadGalleryPhotos: async (galleryId: string, lang?: string) => {
     return await db.loadGalleryPhotos(galleryId, lang);
+  },
+  queryFilteredPhotos: async (
+    galleryId: string,
+    opts: QueryFilteredOpts = {}
+  ): Promise<Photo[]> => {
+    return (await db.queryFilteredPhotos(galleryId, opts)) as Photo[];
+  },
+  queryFilteredPhotoCounts: async (
+    galleryId: string,
+    opts: CountsFilteredOpts = {}
+  ): Promise<Record<string, number>> => {
+    return (await db.queryFilteredPhotoCounts(
+      galleryId,
+      opts
+    )) as Record<string, number>;
+  },
+  queryFilteredPhotoNeighbors: async (
+    galleryId: string,
+    photoId: string,
+    opts: NeighborsFilteredOpts = {}
+  ): Promise<NeighborsResult> => {
+    return (await db.queryFilteredPhotoNeighbors(
+      galleryId,
+      photoId,
+      opts
+    )) as NeighborsResult;
   },
   linkGalleryPhoto: async (galleryIds: string[], photoIds: string[]) => {
     return await db.linkGalleryPhoto(galleryIds, photoIds);

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -5,6 +5,10 @@ import { NotFoundError } from "../../lib/errors.js";
 import config from "../../lib/config/index.js";
 import logger from "../../lib/logger.js";
 import { acceptLocalizedCity } from "../../lib/localized-script.js";
+import {
+  matchesFilter,
+  type FilterShape,
+} from "../../lib/photo-filter-eval.js";
 import { migrate } from "./migrate.js";
 
 import schemaFactory, {
@@ -16,6 +20,7 @@ import schemaFactory, {
   type GroupGalleryRow,
   type GroupRow,
   type MetaRow,
+  type Photo,
   type PhotoInput,
   type PhotoLocalizedRow,
   type PhotoRow,
@@ -73,6 +78,9 @@ export default () => {
     deleteGallery,
 
     loadGalleryPhotos,
+    queryFilteredPhotos,
+    queryFilteredPhotoCounts,
+    queryFilteredPhotoNeighbors,
     linkGalleryPhoto,
     unlinkGalleryPhoto,
     unlinkAllPhotos,
@@ -500,6 +508,110 @@ const loadAllGalleryPhotoLinks = async (): Promise<
     .all() as Array<{ gallery_id: string; photo_id: string }>;
   return rows.map((r) => ({ galleryId: r.gallery_id, photoId: r.photo_id }));
 };
+interface QueryFilteredOpts {
+  filter?: FilterShape;
+  year?: number;
+  month?: number;
+  day?: number;
+  lang?: string;
+}
+const matchesScope = (
+  photo: Photo,
+  year?: number,
+  month?: number,
+  day?: number
+): boolean => {
+  const instant = photo.taken.instant;
+  if (year !== undefined && instant.year !== year) return false;
+  if (month !== undefined && instant.month !== month) return false;
+  if (day !== undefined && instant.day !== day) return false;
+  return true;
+};
+// Load the gallery's photos via the same SQL path as
+// `loadGalleryPhotos`, then evaluate FilterShape + (year, month,
+// day) scope in JS. For SQLite the round-trip is free, so load-all-
+// and-filter is the right shape; the boundary moves here so the
+// model layer doesn't have to know which is which. A Postgres
+// driver can replace this body with a parameterised WHERE.
+const queryFilteredPhotos = async (
+  galleryId: string,
+  opts: QueryFilteredOpts = {}
+): Promise<Photo[]> => {
+  const photos = (await loadGalleryPhotos(galleryId, opts.lang)) as Photo[];
+  return photos.filter(
+    (photo) =>
+      matchesScope(photo, opts.year, opts.month, opts.day) &&
+      matchesFilter(opts.filter, photo)
+  );
+};
+
+interface CountsFilteredOpts {
+  filter?: FilterShape;
+  year?: number;
+}
+const queryFilteredPhotoCounts = async (
+  galleryId: string,
+  opts: CountsFilteredOpts = {}
+): Promise<Record<string, number>> => {
+  const photos = (await loadGalleryPhotos(galleryId)) as Photo[];
+  const out: Record<string, number> = {};
+  for (const photo of photos) {
+    const instant = photo.taken.instant;
+    if (opts.year !== undefined && instant.year !== opts.year) continue;
+    if (!matchesFilter(opts.filter, photo)) continue;
+    const key = `${instant.year}-${String(instant.month).padStart(
+      2,
+      "0"
+    )}-${String(instant.day).padStart(2, "0")}`;
+    out[key] = (out[key] ?? 0) + 1;
+  }
+  return out;
+};
+
+interface NeighborsFilteredOpts {
+  filter?: FilterShape;
+  lang?: string;
+}
+interface NeighborsResult {
+  previous?: Photo;
+  next?: Photo;
+  first?: Photo;
+  last?: Photo;
+  position?: number;
+  total: number;
+}
+const queryFilteredPhotoNeighbors = async (
+  galleryId: string,
+  photoId: string,
+  opts: NeighborsFilteredOpts = {}
+): Promise<NeighborsResult> => {
+  const all = (await loadGalleryPhotos(galleryId, opts.lang)) as Photo[];
+  const filtered = all
+    .filter((p) => matchesFilter(opts.filter, p))
+    .sort((a, b) =>
+      a.taken.instant.timestamp.localeCompare(b.taken.instant.timestamp)
+    );
+  if (filtered.length === 0) return { total: 0 };
+  const first = filtered[0];
+  const last = filtered[filtered.length - 1];
+  const index = filtered.findIndex((p) => p.id === photoId);
+  if (index < 0) {
+    // Current photo not in filtered set — first / last still
+    // useful; previous / next undefined; position omitted.
+    return { first, last, total: filtered.length };
+  }
+  const previous = index > 0 ? filtered[index - 1] : undefined;
+  const next = index < filtered.length - 1 ? filtered[index + 1] : undefined;
+  return {
+    previous,
+    next,
+    first,
+    last,
+    position: index + 1,
+    total: filtered.length,
+  };
+};
+
 const loadGalleryPhoto = async (
   galleryId: string,
   photoId: string,

--- a/server/models/gallery-photo.ts
+++ b/server/models/gallery-photo.ts
@@ -1,10 +1,6 @@
 import logger from "../lib/logger.js";
 import db from "../db/index.js";
-import {
-  matchesFilter,
-  type FilterShape,
-} from "../lib/photo-filter-eval.js";
-import type { Photo } from "../db/sqlite3/schema.js";
+import type { FilterShape } from "../lib/photo-filter-eval.js";
 import { invalidateGallery } from "../lib/stats-cache.js";
 
 export default () => {
@@ -29,11 +25,9 @@ const getGalleryPhotos = async (galleryId: string, lang?: string) => {
   return await db.loadGalleryPhotos(galleryId, lang);
 };
 
-// View-scoped + filtered fetch — backs the per-view fetch path
-// the public gallery viewer migrates to in #406. Server loads the
-// gallery's photos via the same SQL path as `getGalleryPhotos`,
-// then applies the filter evaluator and an optional year/month/day
-// scope on the result. Same auth context as the unfiltered fetch.
+// View-scoped + filtered fetch — backs the per-view fetch path the
+// public gallery viewer migrates to in #406. Filter + scope eval
+// lives in the driver (#529) so this stays a thin wrapper.
 interface QueryOpts {
   filter?: FilterShape;
   year?: number;
@@ -41,82 +35,30 @@ interface QueryOpts {
   day?: number;
   lang?: string;
 }
-const matchesScope = (photo: Photo, opts: QueryOpts): boolean => {
-  const instant = photo.taken.instant;
-  if (opts.year !== undefined && instant.year !== opts.year) return false;
-  if (opts.month !== undefined && instant.month !== opts.month) return false;
-  if (opts.day !== undefined && instant.day !== opts.day) return false;
-  return true;
-};
-const queryGalleryPhotos = async (
-  galleryId: string,
-  opts: QueryOpts = {}
-): Promise<Photo[]> => {
+const queryGalleryPhotos = async (galleryId: string, opts: QueryOpts = {}) => {
   logger.debug("Querying photos from gallery", { galleryId, opts });
-  const photos = (await db.loadGalleryPhotos(galleryId, opts.lang)) as Photo[];
-  return photos.filter(
-    (photo) => matchesScope(photo, opts) && matchesFilter(opts.filter, photo)
-  );
+  return await db.queryFilteredPhotos(galleryId, opts);
 };
 
 // Adjacent + boundary photos for the Photo modal's carousel +
-// keyboard nav (#406). Loads the gallery's photos via the same
-// SQL path, filters with the wire-shape evaluator, sorts by
-// timestamp, and returns the photo objects the modal needs to
-// render its prev / current / next slides plus the first / last
-// jumps. All four fields optional — empty filter set, photo at
-// boundary, or photo not in the filtered set each surface as a
-// missing field rather than an error.
+// keyboard nav (#406). Driver does the filter + sort + index walk
+// (#529) and returns the response shape the controller serializes.
 interface NeighborsOpts {
   filter?: FilterShape;
   lang?: string;
-}
-interface NeighborsResult {
-  previous?: Photo;
-  next?: Photo;
-  first?: Photo;
-  last?: Photo;
-  position?: number;
-  total: number;
 }
 const getGalleryPhotoNeighbors = async (
   galleryId: string,
   photoId: string,
   opts: NeighborsOpts = {}
-): Promise<NeighborsResult> => {
+) => {
   logger.debug("Getting gallery photo neighbors", { galleryId, photoId });
-  const all = (await db.loadGalleryPhotos(galleryId, opts.lang)) as Photo[];
-  const filtered = all
-    .filter((p) => matchesFilter(opts.filter, p))
-    .sort((a, b) =>
-      a.taken.instant.timestamp.localeCompare(b.taken.instant.timestamp)
-    );
-  if (filtered.length === 0) return { total: 0 };
-  const first = filtered[0];
-  const last = filtered[filtered.length - 1];
-  const index = filtered.findIndex((p) => p.id === photoId);
-  if (index < 0) {
-    // Current photo not in filtered set — first / last still
-    // useful; previous / next undefined; position omitted.
-    return { first, last, total: filtered.length };
-  }
-  const previous = index > 0 ? filtered[index - 1] : undefined;
-  const next = index < filtered.length - 1 ? filtered[index + 1] : undefined;
-  return {
-    previous,
-    next,
-    first,
-    last,
-    position: index + 1,
-    total: filtered.length,
-  };
+  return await db.queryFilteredPhotoNeighbors(galleryId, photoId, opts);
 };
 
 // Per-day photo counts for the Year heatmap. Returns
 // `{ "YYYY-MM-DD": count }` over the filtered + (optionally
-// year-scoped) photo set. Same auth as the unfiltered fetch;
-// the caller is just asking for a histogram instead of the rows
-// themselves.
+// year-scoped) photo set. Driver owns the aggregation (#529).
 interface CountsOpts {
   filter?: FilterShape;
   year?: number;
@@ -124,21 +66,9 @@ interface CountsOpts {
 const queryGalleryPhotoCounts = async (
   galleryId: string,
   opts: CountsOpts = {}
-): Promise<Record<string, number>> => {
+) => {
   logger.debug("Querying photo counts from gallery", { galleryId, opts });
-  const photos = (await db.loadGalleryPhotos(galleryId)) as Photo[];
-  const out: Record<string, number> = {};
-  for (const photo of photos) {
-    const instant = photo.taken.instant;
-    if (opts.year !== undefined && instant.year !== opts.year) continue;
-    if (!matchesFilter(opts.filter, photo)) continue;
-    const key = `${instant.year}-${String(instant.month).padStart(
-      2,
-      "0"
-    )}-${String(instant.day).padStart(2, "0")}`;
-    out[key] = (out[key] ?? 0) + 1;
-  }
-  return out;
+  return await db.queryFilteredPhotoCounts(galleryId, opts);
 };
 const getGalleryPhoto = async (
   galleryId: string,


### PR DESCRIPTION
## Summary

Closes #529. After #406, three model methods in `gallery-photo.ts` followed the same shape — `db.loadGalleryPhotos(galleryId, lang)` followed by a JS filter+aggregate pass. That shape is implicitly SQLite-shaped (same-process round-trip is free), but defeats a Postgres driver and tangles a virtual-gallery / saved-filter resolver.

Boundary moves one level down. Three new driver methods on `db.*`:

- `queryFilteredPhotos(galleryId, { filter, year?, month?, day?, lang? }) → Photo[]`
- `queryFilteredPhotoCounts(galleryId, { filter, year? }) → Record<YYYY-MM-DD, number>`
- `queryFilteredPhotoNeighbors(galleryId, photoId, { filter, lang? }) → { previous?, next?, first?, last?, position?, total }`

The SQLite driver's impl is the model code transplanted — load-all-and-filter via the existing `photo-filter-eval.ts` evaluator. No behavioural diff on this PR: same SQLite path, just owned by the layer that decides which path is right.

Model methods in `gallery-photo.ts` become passthroughs that log + delegate. `matchesFilter` and `matchesScope` no longer appear in the model layer; only the driver imports the evaluator. `NeighborsResult` shape moves to the driver dispatcher so it's declared once.

## Stats path

Intentionally untouched. `stats.ts` → `computeStats` (in `stats-compute.ts`) needs both the filtered set (for the aggregations) AND the unfiltered set (for `categoryValues` — the filter UI universe), so the current load-once-then-filter shape inside `computeStats` is already at the right boundary. Postgres can revisit stats separately if/when that becomes a hot path.

## Why this matters

- #265 (Postgres driver) lands native SQL impls against this boundary instead of either pulling all rows or growing a parallel evaluator inline with every model method.
- #22 / #285 (virtual gallery / saved filter resolution) can compose at the driver layer — a virtual gallery's photo set is a driver concern, not a model concern.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 844 / 844 pass
- [x] `npm run lint` clean
- [x] No converter / bin script references the migrated methods (grepped — none found)