### PR TITLE
Filter pill universe: dedicated /filter-values endpoint (#532, phase 1)

### DIFF
--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -142,14 +142,25 @@ const Gallery = ({
     },
     enabled: galleryInList,
   });
+  // Filter pill universe (#532). Tiny payload, server-cached. Lives
+  // alongside the photos query for now — once the gallery shape
+  // helpers (firstDay / lastDay / includesPhotos / lastPath) move
+  // off `photosByYmd` too, the full photos fetch can go.
+  const filterValuesQuery = useQuery({
+    queryKey: ["gallery-filter-values", galleryId, user?.id ?? null, lang],
+    queryFn: () => galleryPhotosService.getFilterValues(galleryId as string, lang),
+    enabled: galleryInList,
+  });
 
   const meta = metaQuery.data as Meta | undefined;
   const galleries = galleriesQuery.data;
   const photos = photosQuery.data;
+  const filterValues = filterValuesQuery.data;
   const error =
     metaQuery.error?.message ||
     galleriesQuery.error?.message ||
     photosQuery.error?.message ||
+    filterValuesQuery.error?.message ||
     "";
 
   // The meta-to-config side-effect now lives in App.tsx so the
@@ -161,9 +172,9 @@ const Gallery = ({
 
   // Recomputes on language change too — display values are localised.
   const uniqueValues = React.useMemo<UniqueValues | undefined>(() => {
-    if (!photos || !countryData) return undefined;
-    return buildUniqueValues(photos, lang, t, countryData);
-  }, [photos, lang, t, countryData]);
+    if (!filterValues || !countryData) return undefined;
+    return buildUniqueValues(filterValues, lang, t, countryData);
+  }, [filterValues, lang, t, countryData]);
 
   const gallery = React.useMemo<GalleryT | undefined>(() => {
     if (!selectedGallery || !photos) return undefined;

--- a/react-app/src/components/GlobalStats/index.tsx
+++ b/react-app/src/components/GlobalStats/index.tsx
@@ -14,7 +14,7 @@ import galleriesService from "../../services/galleries";
 import metaService from "../../services/meta";
 import theme from "../../lib/theme";
 import { type UniqueValues } from "../../lib/stats";
-import { buildUniqueValues } from "../../lib/uniqueValues";
+import { buildUniqueValuesFromPhotos } from "../../lib/uniqueValues";
 import config from "../../lib/config";
 import { useHostScope } from "../../lib/use-host-scope";
 import {
@@ -107,7 +107,7 @@ const GlobalStats = (): React.ReactElement => {
   const galleries = galleriesQuery.data ?? [];
   const uniqueValues = React.useMemo<UniqueValues | undefined>(() => {
     if (!photos || !countryData) return undefined;
-    return buildUniqueValues(photos, lang, t, countryData);
+    return buildUniqueValuesFromPhotos(photos, lang, t, countryData);
   }, [photos, lang, t, countryData]);
 
   const frame = (body: React.ReactNode): React.ReactElement => (

--- a/react-app/src/lib/api-schema.ts
+++ b/react-app/src/lib/api-schema.ts
@@ -1359,6 +1359,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/gallery-photos/{galleryId}/filter-values": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Filter pill universe (per-category value set) */
+        get: {
+            parameters: {
+                query?: {
+                    lang?: string;
+                };
+                header?: never;
+                path: {
+                    galleryId: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            categoryValues: {
+                                [key: string]: string[];
+                            };
+                            byCityLocalized: {
+                                [key: string]: string;
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/gallery-photos/{galleryId}/{photoId}": {
         parameters: {
             query?: never;

--- a/react-app/src/lib/uniqueValues.ts
+++ b/react-app/src/lib/uniqueValues.ts
@@ -13,12 +13,132 @@ interface CountryData {
   getName(code: string, lang: string): string | undefined;
 }
 
-// Build the per-topic / per-category UniqueValues bag the stats UI
-// consumes. Pure transform: in → photos, lang, t, countryData;
-// out → UniqueValues. The per-gallery `/g/<id>/...` and the global
-// `/s` view both build the same shape over their respective photo
-// arrays, so the logic stays in one place.
+// Topic → categories mapping. Mirrors PhotoModel.uniqueValues(): the
+// filter UI groups categories under topics ("general" / "time" /
+// "gear" / "exposure"). The server returns a flat
+// `Record<category, string[]>` from /filter-values (#532); this
+// shape is the only place that knows where each category lives.
+const TOPICS: Record<string, string[]> = {
+  general: ["author", "country", "state", "city", "geotagged"],
+  time: ["year", "year-month", "month", "weekday", "hour"],
+  gear: ["camera-make", "camera", "lens", "camera-lens"],
+  exposure: [
+    "focal-length",
+    "focal-length-eq",
+    "aperture",
+    "exposure-time",
+    "iso",
+    "ev",
+    "lv",
+    "resolution",
+    "orientation",
+    "aspect-ratio",
+  ],
+};
+
+// Categories that should be presented as numbers in the filter UI
+// (sorter + formatter pick the right path). Mirrors PhotoModel's
+// uniqueValues() Set entry types — anything not listed here is
+// treated as a string key.
+const NUMERIC_CATEGORIES = new Set([
+  "year",
+  "month",
+  "weekday",
+  "hour",
+  "focal-length",
+  "focal-length-eq",
+  "aperture",
+  "exposure-time",
+  "iso",
+  "ev",
+  "lv",
+]);
+
+// Server response shape from /filter-values. The keys are kebab-case
+// category names matching the filter wire format; values are the
+// distinct keys present in the unfiltered photo set (`null` would
+// indicate the "unknown" bucket, but the server emits empty string
+// for that — both get normalized to `stats.UNKNOWN` here).
+export interface FilterValuesPayload {
+  categoryValues: Record<string, string[]>;
+  byCityLocalized: Record<string, string>;
+}
+
+const buildCityLabels = (
+  cityKeys: string[],
+  lang: string,
+  countryData: CountryData,
+  cityLocalizedByKey: Record<string, string>
+): Record<string, string> => {
+  const formatCountryName = format.countryName(lang, countryData);
+  return format.buildCityLabels(
+    cityKeys.filter((v): v is string => typeof v === "string" && !!v),
+    lang,
+    formatCountryName,
+    cityLocalizedByKey
+  );
+};
+
+// Build the per-topic / per-category UniqueValues bag the filter UI
+// consumes from the server's /filter-values payload (#532). The
+// server returns the universe of keys per category (already
+// deduplicated + sorted); this layer maps them to the topic-nested
+// shape, applies localization for country/city labels + numeric
+// formatting for numeric categories, then sorts each category in
+// its natural order.
 export const buildUniqueValues = (
+  payload: FilterValuesPayload,
+  lang: string,
+  t: TFunction,
+  countryData: CountryData
+): UniqueValues => {
+  const { categoryValues, byCityLocalized } = payload;
+  const categoryValueFormatter = format.categoryValue(lang, t, countryData);
+  const out: UniqueValues = {} as UniqueValues;
+  for (const [topic, categories] of Object.entries(TOPICS)) {
+    const topicBag: Record<string, UniqueValueEntry[]> = {};
+    for (const category of categories) {
+      const rawKeys = categoryValues[category] ?? [];
+      const cityLabels =
+        category === "city"
+          ? buildCityLabels(rawKeys, lang, countryData, byCityLocalized)
+          : null;
+      const isNumeric = NUMERIC_CATEGORIES.has(category);
+      const entries = rawKeys.map((raw): UniqueValueEntry => {
+        if (raw === "" || raw === null || raw === undefined) {
+          return {
+            key: stats.UNKNOWN,
+            value: String(t("stats-unknown")),
+          };
+        }
+        if (cityLabels) {
+          return {
+            key: raw,
+            value: cityLabels[raw] ?? String(raw),
+          };
+        }
+        const typedKey: string | number = isNumeric ? Number(raw) : raw;
+        return {
+          key: typedKey,
+          value: categoryValueFormatter(category)(typedKey),
+        };
+      });
+      topicBag[category] = entries.sort(
+        format.categorySorter("key", "value")(category)
+      );
+    }
+    (out as Record<string, Record<string, UniqueValueEntry[]>>)[topic] =
+      topicBag;
+  }
+  return out;
+};
+
+// Legacy photo-walking variant. Kept alive for the global stats
+// page (admin), which still fetches the cross-gallery photo array
+// and derives the universe client-side. A follow-up will swap this
+// out for a global-flavour /filter-values endpoint and delete this
+// function.
+export const buildUniqueValuesFromPhotos = (
   photos: PhotoT[],
   lang: string,
   t: TFunction,

--- a/react-app/src/services/gallery-photos.ts
+++ b/react-app/src/services/gallery-photos.ts
@@ -52,6 +52,18 @@ const getNeighbors = async (
     })
   );
 
+// Filter pill universe (#532). Returns categoryValues + city
+// localized-label map; shares the stats cache server-side, so a
+// warm cache costs nothing extra. Lets the gallery viewer skip the
+// full unfiltered photo fetch it previously did just to derive
+// these values client-side.
+const getFilterValues = async (galleryId: string, lang?: string) =>
+  unwrap(
+    api.GET("/api/v1/gallery-photos/{galleryId}/filter-values", {
+      params: { path: { galleryId }, query: lang ? { lang } : undefined },
+    })
+  );
+
 const link = async (galleryId: string, photoId: string): Promise<void> => {
   await unwrap(
     api.PUT("/api/v1/gallery-photos/{galleryId}/{photoId}", {
@@ -68,4 +80,12 @@ const unlink = async (galleryId: string, photoId: string): Promise<void> => {
   );
 };
 
-export default { get, query, getCounts, getNeighbors, link, unlink };
+export default {
+  get,
+  query,
+  getCounts,
+  getNeighbors,
+  getFilterValues,
+  link,
+  unlink,
+};

--- a/server/controllers/gallery-photos-v1.ts
+++ b/server/controllers/gallery-photos-v1.ts
@@ -6,9 +6,11 @@ import { AccessError, NotFoundError } from "../lib/errors.js";
 import { requireScopeMatches } from "../lib/host-scope.js";
 import { shouldHideMap, maskCoordinates } from "../lib/privacy.js";
 import modelFactory from "../models/gallery-photo.js";
+import statsFactory from "../models/stats.js";
 
 const authorizer = authorizerFactory();
 const model = modelFactory();
+const stats = statsFactory();
 
 const init = async () => {
   await model.init();
@@ -68,6 +70,10 @@ const NeighborsResponse = Type.Object({
   last: Type.Optional(PhotoItem),
   position: Type.Optional(Type.Integer({ minimum: 1 })),
   total: Type.Integer({ minimum: 0 }),
+});
+const FilterValuesResponse = Type.Object({
+  categoryValues: Type.Record(Type.String(), Type.Array(Type.String())),
+  byCityLocalized: Type.Record(Type.String(), Type.String()),
 });
 
 const TAGS = ["gallery-photos"];
@@ -237,6 +243,44 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       } catch (error) {
         if (error instanceof AccessError || error instanceof NotFoundError) {
           return { total: 0 };
+        }
+        throw error;
+      }
+    }
+  );
+
+  /**
+   * Filter pill universe (#532): the gallery's per-category value
+   * set, plus the city localized-label map. Subset of `/stats` —
+   * shares the stats cache, same invalidation hooks. Drives the
+   * Filters sidebar in the gallery viewer without the client having
+   * to fetch the gallery's full photo array.
+   */
+  fastify.get(
+    "/:galleryId/filter-values",
+    {
+      schema: {
+        tags: TAGS,
+        summary: "Filter pill universe (per-category value set)",
+        params: GalleryIdParam,
+        querystring: LangQuery,
+        response: { 200: FilterValuesResponse },
+      },
+    },
+    async (request) => {
+      try {
+        requireScopeMatches(request, request.params.galleryId);
+        await authorizer.authorizeGalleryView(
+          request.user.id,
+          request.params.galleryId
+        );
+        return await stats.getGalleryFilterValues(
+          request.params.galleryId,
+          request.query.lang
+        );
+      } catch (error) {
+        if (error instanceof AccessError || error instanceof NotFoundError) {
+          return { categoryValues: {}, byCityLocalized: {} };
         }
         throw error;
       }

--- a/server/models/stats.ts
+++ b/server/models/stats.ts
@@ -26,6 +26,7 @@ import type { FilterShape } from "../lib/photo-filter-eval.js";
 export default () => ({
   getGalleryStats,
   getGlobalStats,
+  getGalleryFilterValues,
 });
 
 // Re-export the response shape + types so controllers and tests
@@ -66,6 +67,69 @@ const getGalleryStats = async (
   const stats = computeStats(photos, filter);
   if (cacheable) cacheSet(key, stats);
   return stats;
+};
+
+// Subset of the gallery's unfiltered stats — the universe the filter
+// pill UI needs to render every selectable value (#532). Projection
+// off `getGalleryStats` so the existing stats cache + invalidation
+// hooks naturally apply; a cold gallery mount pays one stats compute
+// then every subsequent visit serves out of cache. Filter pills want
+// the universe across the unfiltered set, never the active filter's
+// narrowed view, so this never takes a filter arg.
+//
+// Stats internally buckets by camelCase category names; the filter
+// pill UI + FilterShape wire format use kebab-case (see
+// PhotoModel.uniqueValues() and photo-filter-eval.ts). This method
+// maps to the kebab-case shape the filter side expects, and adds the
+// two categories stats doesn't bucket but the pills want — `year-
+// month` (derived from `byYearMonth`'s keys) and `geotagged` (binary;
+// surfaces both yes/no so the pill is always selectable).
+export interface FilterValuesResponse {
+  categoryValues: Record<string, string[]>;
+  byCityLocalized: Record<string, string>;
+}
+const getGalleryFilterValues = async (
+  galleryId: string,
+  lang?: string
+): Promise<FilterValuesResponse> => {
+  const stats = await getGalleryStats(galleryId, undefined, lang);
+  const cv = stats.categoryValues;
+  const yearMonths: string[] = [];
+  for (const [year, months] of Object.entries(stats.byYearMonth ?? {})) {
+    for (const month of Object.keys(months)) {
+      yearMonths.push(`${year}-${month}`);
+    }
+  }
+  yearMonths.sort();
+  return {
+    categoryValues: {
+      author: cv.author ?? [],
+      country: cv.country ?? [],
+      state: cv.state ?? [],
+      city: cv.city ?? [],
+      geotagged: ["yes", "no"],
+      year: cv.year ?? [],
+      "year-month": yearMonths,
+      month: cv.month ?? [],
+      weekday: cv.weekday ?? [],
+      hour: cv.hour ?? [],
+      "camera-make": cv.cameraMake ?? [],
+      camera: cv.camera ?? [],
+      lens: cv.lens ?? [],
+      "camera-lens": cv.cameraLens ?? [],
+      "focal-length": cv.focalLength ?? [],
+      "focal-length-eq": cv.focalLength35mmEquiv ?? [],
+      aperture: cv.aperture ?? [],
+      "exposure-time": cv.exposureTime ?? [],
+      iso: cv.iso ?? [],
+      ev: cv.ev ?? [],
+      lv: cv.lv ?? [],
+      resolution: cv.resolution ?? [],
+      orientation: cv.orientation ?? [],
+      "aspect-ratio": cv.aspectRatio ?? [],
+    },
+    byCityLocalized: stats.byCityLocalized,
+  };
 };
 
 const getGlobalStats = async (

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -2327,6 +2327,65 @@
         }
       }
     },
+    "/api/v1/gallery-photos/{galleryId}/filter-values": {
+      "get": {
+        "summary": "Filter pill universe (per-category value set)",
+        "tags": [
+          "gallery-photos"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "lang",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "galleryId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "categoryValues",
+                    "byCityLocalized"
+                  ],
+                  "properties": {
+                    "categoryValues": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "byCityLocalized": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/gallery-photos/{galleryId}/{photoId}": {
       "get": {
         "summary": "Get one photo's metadata in a gallery's context",

--- a/server/tests/api/gallery-photos.test.ts
+++ b/server/tests/api/gallery-photos.test.ts
@@ -904,3 +904,36 @@ describe("POST /:galleryId/neighbors (photo modal navigation)", () => {
     expect(res.body).toEqual({ total: 0 });
   });
 });
+
+describe("GET /:galleryId/filter-values (filter pill universe)", () => {
+  const getFilterValues = (
+    token: string | undefined,
+    galleryId: string,
+    lang?: string,
+    status = 200
+  ) => {
+    const url =
+      `/api/v1/gallery-photos/${galleryId}/filter-values` +
+      (lang ? `?lang=${lang}` : "");
+    const req = api.get(url);
+    if (token) req.set("Authorization", `Bearer ${token}`);
+    return req.expect(status);
+  };
+
+  test("admin: returns categoryValues + byCityLocalized", async () => {
+    const token = await loginUser(api, "admin");
+    const res = await getFilterValues(token, "gallery1");
+    expect(res.body.categoryValues).toBeDefined();
+    expect(res.body.byCityLocalized).toBeDefined();
+    // gallery1 has photos with countries jp + nl — both should
+    // surface in the unfiltered universe.
+    expect(res.body.categoryValues.country).toEqual(
+      expect.arrayContaining(["jp", "nl"])
+    );
+  });
+
+  test("guest blocked from gallery1 → empty universe (privacy collapse)", async () => {
+    const res = await getFilterValues(undefined, "gallery1");
+    expect(res.body).toEqual({ categoryValues: {}, byCityLocalized: {} });
+  });
+});


### PR DESCRIPTION
## Summary

`Gallery/index.tsx` was fetching the full unfiltered photo array at mount and walking it client-side via `buildUniqueValues` just to extract the per-category universe the Filters sidebar pills need. For an N-photo gallery that's an O(N) response when the actual need is O(unique values).

New thin endpoint:

```
GET /api/v1/gallery-photos/<id>/filter-values?lang=...
  → {
      categoryValues: Record<category, string[]>,
      byCityLocalized: Record<key, label>,
    }
```

Implemented as a projection off `getGalleryStats` so the existing stats cache + invalidation hooks naturally apply — a cold gallery mount pays one stats compute, every subsequent visit serves cached. Maps stats's internal camelCase category names to the kebab-case shape the filter UI + `FilterShape` wire format expect (see `PhotoModel.uniqueValues()` and `photo-filter-eval.ts`), and adds the two categories stats doesn't bucket but the pills want — `year-month` (derived from `byYearMonth`'s keys) and `geotagged` (always both yes/no so the pill stays selectable).

Client `buildUniqueValues` rewires to consume the server response. Still does the localization / format / sort pass, just over the small key set instead of an N-photo walk. The old photo-walking implementation lives on as `buildUniqueValuesFromPhotos` for `GlobalStats` (admin cross-gallery surface still fetches the cross-gallery photo array — a follow-up adds a global-flavour `/filter-values` and deletes the fallback).

## Why this is phase 1 of #532

The full unfiltered photo fetch at gallery mount stays for now — it still drives `gallery.firstDay / lastDay / includesPhotos / lastPath / photo(...)` via `selectedGallery.withPhotos(photos)`. Phase 2 of #532 migrates those off `photosByYmd` (mostly to `/counts`-derived helpers, mirroring `useFilteredCalendar` from #528) and finally drops the full fetch. No perf win until phase 2 lands, but this PR builds the endpoint and migrates one consumer so phase 2 is a smaller, more targeted change.

## Test plan

- [x] `npm run typecheck` clean (server + react-app)
- [x] `npm test` — 155 / 155 gallery-photos, 983 / 983 react-app
- [x] `npm run lint` clean
- [ ] Verify on a live gallery: Filters sidebar shows the same pill universe it did before; toggling pills behaves the same (server-narrowed `/query` / `/counts` / `/neighbors` already drives the views)

Closes phase 1 of #532.