### PR TITLE
filter-values: move compute into the driver layer

### DIFF
--- a/server/controllers/gallery-photos-v1.ts
+++ b/server/controllers/gallery-photos-v1.ts
@@ -6,11 +6,9 @@ import { AccessError, NotFoundError } from "../lib/errors.js";
 import { requireScopeMatches } from "../lib/host-scope.js";
 import { shouldHideMap, maskCoordinates } from "../lib/privacy.js";
 import modelFactory from "../models/gallery-photo.js";
-import statsFactory from "../models/stats.js";
 
 const authorizer = authorizerFactory();
 const model = modelFactory();
-const stats = statsFactory();
 
 const init = async () => {
   await model.init();
@@ -278,7 +276,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
           request.user.id,
           request.params.galleryId
         );
-        return await stats.getGalleryFilterValues(
+        return await model.getGalleryFilterValues(
           request.params.galleryId,
           request.query.lang
         );

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -36,6 +36,10 @@ export interface NeighborsResult {
   position?: number;
   total: number;
 }
+export interface FilterValuesResult {
+  categoryValues: Record<string, string[]>;
+  byCityLocalized: Record<string, string>;
+}
 
 const drivers = {
   sqlite3: () => import("./sqlite3/index.js"),
@@ -248,6 +252,15 @@ export default {
       photoId,
       opts
     )) as NeighborsResult;
+  },
+  queryGalleryFilterValues: async (
+    galleryId: string,
+    lang?: string
+  ): Promise<FilterValuesResult> => {
+    return (await db.queryGalleryFilterValues(
+      galleryId,
+      lang
+    )) as FilterValuesResult;
   },
   linkGalleryPhoto: async (galleryIds: string[], photoIds: string[]) => {
     return await db.linkGalleryPhoto(galleryIds, photoIds);

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -9,6 +9,10 @@ import {
   matchesFilter,
   type FilterShape,
 } from "../../lib/photo-filter-eval.js";
+import {
+  buildAnnotations,
+  buildCategoryValues,
+} from "../../lib/stats-compute.js";
 import { migrate } from "./migrate.js";
 
 import schemaFactory, {
@@ -81,6 +85,7 @@ export default () => {
     queryFilteredPhotos,
     queryFilteredPhotoCounts,
     queryFilteredPhotoNeighbors,
+    queryGalleryFilterValues,
     linkGalleryPhoto,
     unlinkGalleryPhoto,
     unlinkAllPhotos,
@@ -610,6 +615,62 @@ const queryFilteredPhotoNeighbors = async (
     last,
     position: index + 1,
     total: filtered.length,
+  };
+};
+
+// Filter pill universe + city localized-label map for a gallery
+// (#534). Loads the gallery's photos and projects per-category
+// distinct values via the shared `buildCategoryValues`, then maps
+// stats's camelCase category names to the kebab-case shape the
+// FilterShape wire format + the client filter UI both use. Adds
+// the two categories `buildByCategory` doesn't bucket but the
+// pills want — `year-month` (derived from photo instants) and
+// `geotagged` (constant yes/no so the pill stays selectable).
+interface FilterValuesResult {
+  categoryValues: Record<string, string[]>;
+  byCityLocalized: Record<string, string>;
+}
+const queryGalleryFilterValues = async (
+  galleryId: string,
+  lang?: string
+): Promise<FilterValuesResult> => {
+  const photos = (await loadGalleryPhotos(galleryId, lang)) as Photo[];
+  const cv = buildCategoryValues(photos);
+  const annotations = buildAnnotations(photos);
+  const yearMonthSet = new Set<string>();
+  for (const p of photos) {
+    const i = p.taken.instant;
+    yearMonthSet.add(`${i.year}-${String(i.month).padStart(2, "0")}`);
+  }
+  const yearMonths = [...yearMonthSet].sort();
+  return {
+    categoryValues: {
+      author: cv.author ?? [],
+      country: cv.country ?? [],
+      state: cv.state ?? [],
+      city: cv.city ?? [],
+      geotagged: ["yes", "no"],
+      year: cv.year ?? [],
+      "year-month": yearMonths,
+      month: cv.month ?? [],
+      weekday: cv.weekday ?? [],
+      hour: cv.hour ?? [],
+      "camera-make": cv.cameraMake ?? [],
+      camera: cv.camera ?? [],
+      lens: cv.lens ?? [],
+      "camera-lens": cv.cameraLens ?? [],
+      "focal-length": cv.focalLength ?? [],
+      "focal-length-eq": cv.focalLength35mmEquiv ?? [],
+      aperture: cv.aperture ?? [],
+      "exposure-time": cv.exposureTime ?? [],
+      iso: cv.iso ?? [],
+      ev: cv.ev ?? [],
+      lv: cv.lv ?? [],
+      resolution: cv.resolution ?? [],
+      orientation: cv.orientation ?? [],
+      "aspect-ratio": cv.aspectRatio ?? [],
+    },
+    byCityLocalized: annotations.byCityLocalized,
   };
 };
 

--- a/server/lib/stats-compute.ts
+++ b/server/lib/stats-compute.ts
@@ -261,7 +261,7 @@ const buildByCategory = (
   ),
 });
 
-const buildAnnotations = (
+export const buildAnnotations = (
   photos: Photo[]
 ): {
   byStateCountry: Record<string, string>;
@@ -291,7 +291,7 @@ const buildAnnotations = (
 // Universe of bucket keys per category across the unfiltered set.
 // Same buckets `buildByCategory` produces, collapsed to a sorted
 // key list so the wire payload stays small.
-const buildCategoryValues = (
+export const buildCategoryValues = (
   photos: Photo[]
 ): Record<string, string[]> => {
   const all = buildByCategory(photos);

--- a/server/models/gallery-photo.ts
+++ b/server/models/gallery-photo.ts
@@ -1,7 +1,8 @@
 import logger from "../lib/logger.js";
 import db from "../db/index.js";
 import type { FilterShape } from "../lib/photo-filter-eval.js";
-import { invalidateGallery } from "../lib/stats-cache.js";
+import { cacheGet, cacheSet, invalidateGallery } from "../lib/stats-cache.js";
+import type { FilterValuesResult } from "../db/index.js";
 
 export default () => {
   return {
@@ -10,6 +11,7 @@ export default () => {
     queryGalleryPhotos,
     queryGalleryPhotoCounts,
     getGalleryPhotoNeighbors,
+    getGalleryFilterValues,
     getGalleryPhoto,
     getGalleryPhotoByOriginalFilename,
     linkGalleryPhoto,
@@ -71,6 +73,29 @@ const queryGalleryPhotoCounts = async (
   logger.debug("Querying photo counts from gallery", { galleryId, opts });
   return await db.queryFilteredPhotoCounts(galleryId, opts);
 };
+// Filter pill universe + city localized-label map (#534). The
+// driver owns the compute; this layer adds a one-key cache per
+// (gallery, lang) sharing the existing stats-cache machinery
+// (invalidateGallery sweeps `<galleryId>:*`, so the `:fv:`
+// entries get cleaned up on photo writes alongside the stats
+// entries).
+const filterValuesCacheKey = (galleryId: string, lang?: string): string =>
+  !lang || lang === "en"
+    ? `${galleryId}:fv`
+    : `${galleryId}:fv:${lang}`;
+const getGalleryFilterValues = async (
+  galleryId: string,
+  lang?: string
+): Promise<FilterValuesResult> => {
+  const key = filterValuesCacheKey(galleryId, lang);
+  const cached = cacheGet<FilterValuesResult>(key);
+  if (cached) return cached;
+  logger.debug("Computing filter values for gallery", { galleryId, lang });
+  const result = await db.queryGalleryFilterValues(galleryId, lang);
+  cacheSet(key, result);
+  return result;
+};
+
 const getGalleryPhoto = async (
   galleryId: string,
   photoId: string,

--- a/server/models/stats.ts
+++ b/server/models/stats.ts
@@ -26,7 +26,6 @@ import type { FilterShape } from "../lib/photo-filter-eval.js";
 export default () => ({
   getGalleryStats,
   getGlobalStats,
-  getGalleryFilterValues,
 });
 
 // Re-export the response shape + types so controllers and tests
@@ -67,69 +66,6 @@ const getGalleryStats = async (
   const stats = computeStats(photos, filter);
   if (cacheable) cacheSet(key, stats);
   return stats;
-};
-
-// Subset of the gallery's unfiltered stats — the universe the filter
-// pill UI needs to render every selectable value (#532). Projection
-// off `getGalleryStats` so the existing stats cache + invalidation
-// hooks naturally apply; a cold gallery mount pays one stats compute
-// then every subsequent visit serves out of cache. Filter pills want
-// the universe across the unfiltered set, never the active filter's
-// narrowed view, so this never takes a filter arg.
-//
-// Stats internally buckets by camelCase category names; the filter
-// pill UI + FilterShape wire format use kebab-case (see
-// PhotoModel.uniqueValues() and photo-filter-eval.ts). This method
-// maps to the kebab-case shape the filter side expects, and adds the
-// two categories stats doesn't bucket but the pills want — `year-
-// month` (derived from `byYearMonth`'s keys) and `geotagged` (binary;
-// surfaces both yes/no so the pill is always selectable).
-export interface FilterValuesResponse {
-  categoryValues: Record<string, string[]>;
-  byCityLocalized: Record<string, string>;
-}
-const getGalleryFilterValues = async (
-  galleryId: string,
-  lang?: string
-): Promise<FilterValuesResponse> => {
-  const stats = await getGalleryStats(galleryId, undefined, lang);
-  const cv = stats.categoryValues;
-  const yearMonths: string[] = [];
-  for (const [year, months] of Object.entries(stats.byYearMonth ?? {})) {
-    for (const month of Object.keys(months)) {
-      yearMonths.push(`${year}-${month}`);
-    }
-  }
-  yearMonths.sort();
-  return {
-    categoryValues: {
-      author: cv.author ?? [],
-      country: cv.country ?? [],
-      state: cv.state ?? [],
-      city: cv.city ?? [],
-      geotagged: ["yes", "no"],
-      year: cv.year ?? [],
-      "year-month": yearMonths,
-      month: cv.month ?? [],
-      weekday: cv.weekday ?? [],
-      hour: cv.hour ?? [],
-      "camera-make": cv.cameraMake ?? [],
-      camera: cv.camera ?? [],
-      lens: cv.lens ?? [],
-      "camera-lens": cv.cameraLens ?? [],
-      "focal-length": cv.focalLength ?? [],
-      "focal-length-eq": cv.focalLength35mmEquiv ?? [],
-      aperture: cv.aperture ?? [],
-      "exposure-time": cv.exposureTime ?? [],
-      iso: cv.iso ?? [],
-      ev: cv.ev ?? [],
-      lv: cv.lv ?? [],
-      resolution: cv.resolution ?? [],
-      orientation: cv.orientation ?? [],
-      "aspect-ratio": cv.aspectRatio ?? [],
-    },
-    byCityLocalized: stats.byCityLocalized,
-  };
 };
 
 const getGlobalStats = async (


### PR DESCRIPTION
## Summary

Closes #534. #533 introduced `/filter-values` as a projection off the cached `/stats` response — works, but routes the universe through stats's full compute (`peakShape`, `summary` span, `byHour`, every `byCategory`) on cold-miss. The gallery viewer hits `/filter-values` on every mount; `/stats` only when the user navigates to it. Cold-miss was the hot path. The projection also bypassed the driver-interface boundary from #529, blocking the Postgres `SELECT DISTINCT` route.

New driver method, sibling to #529's family:

```ts
db.queryGalleryFilterValues(galleryId, lang?)
  → { categoryValues: Record<kebab-case category, string[]>,
      byCityLocalized: Record<key, label> }
```

SQLite impl loads the gallery's photos once, reuses the now-exported `buildCategoryValues` + `buildAnnotations` from `stats-compute.ts` (same per-category extractors stats uses — no duplication), and maps the result to the kebab-case shape the FilterShape wire format + filter pill UI use. `year-month` comes from a single direct walk of photo instants; `geotagged: ["yes", "no"]` is constant.

Cold-miss cost: one photo walk + two pure transforms instead of a full stats compute. Warm cache: same shape as before.

## Cache

Model layer (`gallery-photo.ts` → `getGalleryFilterValues`) keyed `<galleryId>:fv` / `<galleryId>:fv:<lang>`. Shares the existing `lib/stats-cache.ts` machinery — `invalidateGallery` already sweeps `<galleryId>:*` so the new keys clean up alongside stats entries on any photo write. No new invalidation hooks needed.

## Postgres path

When #265 lands, the Postgres driver implements `queryGalleryFilterValues` with `SELECT DISTINCT camera_make FROM photo WHERE id IN (SELECT photo_id FROM gallery_photo WHERE gallery_id = ?)` (and one such query per category) against this same boundary. The model layer doesn't change.

## Wire shape

Unchanged. The controller route stays at `GET /api/v1/gallery-photos/<id>/filter-values`; it just points at `gallery-photo.model.getGalleryFilterValues` instead of the now-deleted `stats.model.getGalleryFilterValues`. Client untouched.

## Test plan

- [x] `npm run typecheck` clean (server)
- [x] `npm test` — 846/846 server (the existing /filter-values integration test exercises the new path end-to-end)
- [x] `npm run lint` clean
- [ ] Live verify: gallery mount still resolves the filter universe; behaviour identical