### PR TITLE
Photo modal: prime per-id cache from /neighbors to kill prev/next loading flash

### DIFF
--- a/react-app/src/components/Gallery/Photo/index.tsx
+++ b/react-app/src/components/Gallery/Photo/index.tsx
@@ -11,7 +11,11 @@ import {
   BsXLg,
 } from "react-icons/bs";
 import { motion, useAnimationControls, type PanInfo } from "framer-motion";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import Navigation from "./Navigation";
 import Content from "./Content";
@@ -292,6 +296,30 @@ const Photo = ({
       }),
     placeholderData: keepPreviousData,
   });
+  // Prime the per-id query cache (Gallery/index.tsx reads from
+  // `["gallery-photo-by-id", galleryId, photoId, lang]`) with the
+  // neighbor photo objects, so prev/next navigation finds the new
+  // photo in cache the moment the URL changes. Without this the
+  // route re-render hits `isLoading` and renders a bare "Loading"
+  // text on the page background — a brief bright-white flash
+  // between modal frames.
+  const queryClient = useQueryClient();
+  React.useEffect(() => {
+    if (!neighbors) return;
+    const prime = (raw: unknown): void => {
+      if (!raw || typeof raw !== "object") return;
+      const id = (raw as { id?: unknown }).id;
+      if (typeof id !== "string" || !id) return;
+      queryClient.setQueryData(
+        ["gallery-photo-by-id", gallery.id(), id, lang],
+        raw
+      );
+    };
+    prime(neighbors.previous);
+    prime(neighbors.next);
+    prime(neighbors.first);
+    prime(neighbors.last);
+  }, [neighbors, queryClient, gallery, lang]);
   const prevPhoto = React.useMemo(
     () =>
       neighbors?.previous ? PhotoModel(neighbors.previous) : undefined,


### PR DESCRIPTION
## Summary

After #535 moved the modal's current-photo lookup to a dedicated per-id `useQuery`, navigating prev/next in the modal flashed bright-white whenever the next photo wasn't already cached. Root cause: the route re-render hit `photoByIdQuery` in `isLoading` state, and `Gallery/index.tsx`'s render short-circuits to a bare `<div>{t("loading")}</div>` text on the page background.

The `/neighbors` response already carries the full Photo object for prev/next/first/last (the modal carousel needs them to render the adjacent slides). We were dropping that data on the floor for the per-id query. Pushing each into TanStack's cache under the `["gallery-photo-by-id", galleryId, id, lang]` key means the URL change finds cache immediately — `isLoading` never fires for in-modal navigation.

## Scope

- **In-modal navigation (prev/next/first/last)**: fixed. The flash is gone.
- **Cold-open** (first photo modal mount via direct URL or from a thumbnail): unchanged. Neighbors hasn't fired yet so there's nothing to prime from. Out of scope for this fix; would need to restructure `renderContent` to mount the modal chrome with a placeholder while the photo loads instead of replacing the whole content with the loading text. Separate exercise.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 983/983
- [x] `npm run lint` clean
- [x] Live verify: navigating arrow keys / swipe / caret buttons in the Photo modal no longer flashes white between photos
- [x] Live verify: filter toggles still refetch neighbors correctly (cache prime is additive, doesn't block invalidation)