### PR TITLE
Virtual galleries: block 'convert source to virtual' path (#22 followup)

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -237,6 +237,9 @@ export default {
   isVirtualGallery: async (galleryId: string): Promise<boolean> => {
     return (await db.isVirtualGallery(galleryId)) as boolean;
   },
+  isReferencedAsSource: async (galleryId: string): Promise<boolean> => {
+    return (await db.isReferencedAsSource(galleryId)) as boolean;
+  },
 
   loadGalleryPhotos: async (galleryId: string, lang?: string) => {
     return await db.loadGalleryPhotos(galleryId, lang);

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -85,6 +85,7 @@ export default () => {
     upsertVirtualGallery,
     deleteVirtualGallery,
     isVirtualGallery,
+    isReferencedAsSource,
 
     loadGalleryPhotos,
     queryFilteredPhotos,
@@ -497,6 +498,19 @@ const isVirtualGallery = async (galleryId: string): Promise<boolean> => {
   const row = db
     .prepare(
       "SELECT 1 FROM virtual_gallery_source WHERE gallery_id = ? LIMIT 1"
+    )
+    .get(galleryId);
+  return row !== undefined;
+};
+// True iff some virtual gallery references this id as a source.
+// Used to block "convert a real gallery to virtual" when it's
+// already in another virtual's source list, preserving the
+// "real galleries only as sources" invariant from #22's design
+// decision #4.
+const isReferencedAsSource = async (galleryId: string): Promise<boolean> => {
+  const row = db
+    .prepare(
+      "SELECT 1 FROM virtual_gallery_source WHERE source_id = ? LIMIT 1"
     )
     .get(galleryId);
   return row !== undefined;

--- a/server/models/gallery.ts
+++ b/server/models/gallery.ts
@@ -82,6 +82,21 @@ const applyVirtualSources = async (
     await db.deleteVirtualGallery(galleryId);
   } else {
     await validateSources(galleryId, sources);
+    // Preserve #22's design decision #4 (no chained virtuals) at
+    // *transition* time, not just at create time: if galleryId is
+    // already referenced as a source by some virtual gallery,
+    // turning it virtual now would silently break that referrer
+    // (resolveGallerySources doesn't recurse, so the referrer
+    // would resolve to an empty photo set). The referrer side is
+    // already protected by validateSources's `isVirtualGallery`
+    // check; this is the converse — block the transition that
+    // would make an existing referrer's source virtual.
+    if (await db.isReferencedAsSource(galleryId)) {
+      throw new ValidationError(
+        "Cannot convert a gallery to virtual while it is a source of another virtual gallery",
+        { galleryId }
+      );
+    }
     await db.upsertVirtualGallery(galleryId, sources);
   }
 };

--- a/server/tests/api/galleries.test.ts
+++ b/server/tests/api/galleries.test.ts
@@ -701,4 +701,17 @@ describe("Virtual galleries", () => {
       .expect(200);
     expect(gallery1.body).not.toEqual([]);
   });
+
+  test("cannot convert a real gallery to virtual while it's a source elsewhere", async () => {
+    // virt_a sources [gallery1]. Now try to make gallery1 virtual
+    // (sourced from gallery2). The check fires because gallery1 is
+    // already referenced as a source — the resulting chain would
+    // silently leave virt_a resolving to an empty photo set.
+    await createVirt(["gallery1"]);
+    await api
+      .put("/api/v1/galleries/gallery1")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ sources: ["gallery2"] })
+      .expect(422);
+  });
 });


### PR DESCRIPTION
## Summary

Followup to #541. #22's locked decision #4 ("real galleries only as sources") sidesteps cycle detection by forbidding chained virtuals. The referring side was already blocked at create/update via `validateSources`'s `isVirtualGallery` check — adding a virtual gallery as someone's source rejects with 422. The converse path was not blocked: a real gallery referenced as a source by an existing virtual could itself be turned virtual, breaking the invariant.

## Symptom

```
1. Create virtual A with sources=[X]  (X is real)
2. Update X with sources=[Y]          (X becomes virtual)
3. A still has source=[X], but X has no `gallery_photo` rows now
4. /api/v1/gallery-photos/A returns []  ← unexpected emptiness
```

`resolveGallerySources` doesn't recurse, so there's no infinite loop — just silent surprise.

## Fix

New driver predicate `isReferencedAsSource(galleryId)`:
`SELECT 1 FROM virtual_gallery_source WHERE source_id = ? LIMIT 1`.

Model's `applyVirtualSources` rejects with 422 when transitioning to a non-empty source set if the gallery is referenced elsewhere. Empty-sources path (converting back to real) doesn't trigger the check — always safe.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 858/858 server (1 new for this check)
- [x] `npm run lint` clean