### PR TITLE
/m/photos: virtual-gallery notice with source-jump links

### DIFF
--- a/react-app/src/components/Manage/Photos.tsx
+++ b/react-app/src/components/Manage/Photos.tsx
@@ -620,12 +620,28 @@ const Photos = (): React.ReactElement => {
   const galleries = React.useMemo(() => {
     const raw =
       (galleriesQuery.data as
-        | Array<{ id: string; title?: string }>
+        | Array<{ id: string; title?: string; sources?: string[] }>
         | undefined) ?? [];
     return raw.slice().sort((a, b) =>
       (a.title || a.id).localeCompare(b.title || b.id)
     );
   }, [galleriesQuery.data]);
+  // Virtual gallery (#22) is a membership-computed concept; the
+  // /m/photos page operates on real `gallery_photo` rows and the
+  // bulk actions (link/unlink/regeocode/delete) all target real
+  // galleries. If the operator's filter narrows to a virtual
+  // gallery we replace the photos body with a notice — the
+  // operator picks a source gallery instead.
+  const filteredVirtuals = React.useMemo(
+    () =>
+      galleries.filter(
+        (g) =>
+          filter.galleryIds?.includes(g.id) &&
+          Array.isArray(g.sources) &&
+          g.sources.length > 0
+      ),
+    [galleries, filter.galleryIds]
+  );
 
   const setSearchParam = (
     name: string,
@@ -922,6 +938,33 @@ const Photos = (): React.ReactElement => {
   };
 
   const renderBody = () => {
+    if (filteredVirtuals.length > 0) {
+      // Virtual gallery in the filter — no real `gallery_photo` rows
+      // to operate on. Offer the operator a way to jump to a source
+      // gallery instead (where bulk actions actually apply).
+      return (
+        <EmptyState>
+          <p>{t("manage-photos-virtual-gallery-notice")}</p>
+          <ul>
+            {filteredVirtuals.flatMap((v) =>
+              (v.sources ?? []).map((sourceId) => (
+                <li key={`${v.id}->${sourceId}`}>
+                  <button
+                    type="button"
+                    onClick={() => setSearchParam("gallery", [sourceId])}
+                  >
+                    {(
+                      galleries.find((g) => g.id === sourceId)?.title ??
+                      sourceId
+                    )}
+                  </button>
+                </li>
+              ))
+            )}
+          </ul>
+        </EmptyState>
+      );
+    }
     if (isLoading) {
       return <EmptyState>{t("loading")}</EmptyState>;
     }

--- a/react-app/src/lib/translations/en.json
+++ b/react-app/src/lib/translations/en.json
@@ -168,6 +168,7 @@
     "manage-photos-result-page": "Page {{page}} / {{pageCount}}",
     "manage-photos-empty": "No photos match this filter.",
     "manage-photos-load-error": "Failed to load photos.",
+    "manage-photos-virtual-gallery-notice": "Virtual galleries can't be managed here — their contents come from source galleries' membership. Pick a source gallery to manage its photos:",
     "manage-photos-bulk-exit": "Clear selection",
     "manage-photos-filters-title": "Filters",
     "manage-photos-filters-open": "Open filters",

--- a/react-app/src/lib/translations/fi.json
+++ b/react-app/src/lib/translations/fi.json
@@ -168,6 +168,7 @@
     "manage-photos-result-page": "Sivu {{page}} / {{pageCount}}",
     "manage-photos-empty": "Suodatin ei vastaa yhtään valokuvaa.",
     "manage-photos-load-error": "Valokuvien lataus epäonnistui.",
+    "manage-photos-virtual-gallery-notice": "Virtuaaligallerioita ei voi hallita täältä — niiden sisältö tulee lähdegallerioiden valokuvista. Valitse lähdegalleria hallitaksesi sen valokuvia:",
     "manage-photos-bulk-exit": "Tyhjennä valinta",
     "manage-photos-filters-title": "Suodattimet",
     "manage-photos-filters-open": "Avaa suodattimet",

--- a/react-app/src/lib/translations/ja.json
+++ b/react-app/src/lib/translations/ja.json
@@ -168,6 +168,7 @@
     "manage-photos-result-page": "ページ {{page}} / {{pageCount}}",
     "manage-photos-empty": "条件に合う写真がありません。",
     "manage-photos-load-error": "写真の読み込みに失敗しました。",
+    "manage-photos-virtual-gallery-notice": "仮想ギャラリーはこの画面では管理できません — 内容はソースギャラリーの写真から構成されます。写真を管理するには、ソースギャラリーを選択してください:",
     "manage-photos-bulk-exit": "選択を解除",
     "manage-photos-filters-title": "フィルター",
     "manage-photos-filters-open": "フィルターを開く",


### PR DESCRIPTION
## Summary

After #541, the admin Photos page would happily filter by a virtual gallery — the photos came up (membership resolves on the server) but bulk actions (link / unlink / delete / regeocode) either no-op or fail on the virtual id, and the filter chips read weird because the virtual gallery isn't a `gallery_photo` row owner.

When the gallery filter contains a virtual gallery, replace the photos body with a notice + one button per source gallery the operator can click to jump there. Sidebar / filter chips stay intact so the operator can clear the filter and return to the unfiltered view.

i18n keys added to en / fi / ja.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 983/983
- [x] `npm run lint` clean
- [ ] Live verify on `/m/photos?gallery=kids` — notice renders, "rikkun" and "lenkun" buttons jump to `/m/photos?gallery=<source>`