### PR TITLE
Year view: full Jan–Dec grid on wide screens

### DIFF
--- a/react-app/src/components/Gallery/Year/Content.tsx
+++ b/react-app/src/components/Gallery/Year/Content.tsx
@@ -68,17 +68,8 @@ const Content = ({
     }
     return max;
   }, [counts]);
-  // Month range (#399). Above the desktop breakpoint the year
-  // grid renders all 12 months so the calendar reads as a stable
-  // Jan–Dec shape regardless of where the active filter's photos
-  // fall; below it clips to the filtered first/last month so the
-  // operator's mobile scroll isn't padded with empty tiles. The
-  // 900px threshold matches the `Calendar` max-width — above that
-  // the full 4-col / 3-row grid fits without forcing a vertical
-  // re-flow. `useFilteredCalendar` gives the filter-aware bounds;
-  // empty bounds (an empty gallery, or one with no photos under
-  // the active filter) collapse to nothing on mobile and a 12-up
-  // empty grid on desktop.
+  // 900px matches the `Calendar` max-width — the full 4-col / 3-row
+  // grid fits without re-flow above it.
   const isWide = useMediaQuery("(min-width: 900px)");
   const cal = useFilteredCalendar(gallery.id());
   const months = React.useMemo(() => {

--- a/react-app/src/components/Gallery/Year/Content.tsx
+++ b/react-app/src/components/Gallery/Year/Content.tsx
@@ -7,6 +7,8 @@ import Month from "./Month";
 import calendar from "../../../lib/calendar";
 import filter from "../../../lib/filter";
 import galleryPhotosService from "../../../services/gallery-photos";
+import useFilteredCalendar from "../../../lib/useFilteredCalendar";
+import useMediaQuery from "../../../lib/useMediaQuery";
 import { useFiltersStore } from "../../../stores";
 
 import type { Gallery } from "../../../models/GalleryModel";
@@ -66,24 +68,41 @@ const Content = ({
     }
     return max;
   }, [counts]);
+  // Month range (#399). Above the desktop breakpoint the year
+  // grid renders all 12 months so the calendar reads as a stable
+  // Jan–Dec shape regardless of where the active filter's photos
+  // fall; below it clips to the filtered first/last month so the
+  // operator's mobile scroll isn't padded with empty tiles. The
+  // 900px threshold matches the `Calendar` max-width — above that
+  // the full 4-col / 3-row grid fits without forcing a vertical
+  // re-flow. `useFilteredCalendar` gives the filter-aware bounds;
+  // empty bounds (an empty gallery, or one with no photos under
+  // the active filter) collapse to nothing on mobile and a 12-up
+  // empty grid on desktop.
+  const isWide = useMediaQuery("(min-width: 900px)");
+  const cal = useFilteredCalendar(gallery.id());
+  const months = React.useMemo(() => {
+    if (isWide) return calendar.months(year);
+    const [firstYear, firstMonth] = cal.firstMonth();
+    const [lastYear, lastMonth] = cal.lastMonth();
+    return calendar.months(year, firstYear, firstMonth, lastYear, lastMonth);
+  }, [isWide, cal, year]);
   return (
     <>
       {children}
       <Root>
         <Calendar>
-          {calendar
-            .months(year, ...gallery.firstMonth(), ...gallery.lastMonth())
-            .map((month) => (
-              <Month
-                key={month}
-                gallery={gallery}
-                year={year}
-                month={month}
-                counts={counts}
-                maxCount={maxCount}
-                theme={theme}
-              />
-            ))}
+          {months.map((month) => (
+            <Month
+              key={month}
+              gallery={gallery}
+              year={year}
+              month={month}
+              counts={counts}
+              maxCount={maxCount}
+              theme={theme}
+            />
+          ))}
         </Calendar>
       </Root>
     </>

--- a/react-app/src/lib/useMediaQuery.ts
+++ b/react-app/src/lib/useMediaQuery.ts
@@ -1,0 +1,23 @@
+import React from "react";
+
+// Subscribe to a CSS media query, returning whether it currently
+// matches. SSR-safe (returns `false` until hydration). Mirrors the
+// shape Web platform offers via `matchMedia` — the hook is just a
+// thin React adapter so component renders stay declarative.
+const useMediaQuery = (query: string): boolean => {
+  const subscribe = React.useCallback(
+    (callback: () => void) => {
+      const mql = window.matchMedia(query);
+      mql.addEventListener("change", callback);
+      return () => mql.removeEventListener("change", callback);
+    },
+    [query]
+  );
+  return React.useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia(query).matches,
+    () => false
+  );
+};
+
+export default useMediaQuery;

--- a/react-app/src/lib/useMediaQuery.ts
+++ b/react-app/src/lib/useMediaQuery.ts
@@ -1,9 +1,5 @@
 import React from "react";
 
-// Subscribe to a CSS media query, returning whether it currently
-// matches. SSR-safe (returns `false` until hydration). Mirrors the
-// shape Web platform offers via `matchMedia` — the hook is just a
-// thin React adapter so component renders stay declarative.
 const useMediaQuery = (query: string): boolean => {
   const subscribe = React.useCallback(
     (callback: () => void) => {


### PR DESCRIPTION
## Summary

Closes #399. Year view was clipping to `[gallery.firstMonth(), gallery.lastMonth()]` — one year started in March, another in January. Fine on mobile (less empty scroll); inconsistent on a wide screen where a stable 12-month grid reads as one recognisable shape per year.

Bonus catch: after #535's drop of `gallery.withPhotos(photos)`, the model's `firstMonth/lastMonth` walk an empty `photosByYmd` and return `[undefined, undefined]`. `calendar.months` treats undefined bounds as "no bounds" → the page was already rendering all 12 months on every device, including mobile — the opposite of the ticket's mobile-clipped intent. Both behaviours were wrong; this commit fixes both.

## Changes

- New `useMediaQuery(query)` hook in `lib/` — a thin `useSyncExternalStore` adapter over `window.matchMedia`. Used here, generalizable.
- `Year/Content` reads filter-aware first/last from `useFilteredCalendar` (same hook the prev/next chrome uses, so the bounds match).
- Above 900px (the `Calendar` `max-width` — above that the 4-col / 3-row grid fits without re-flow), render Jan–Dec bounds-less. Below, clip to the filtered range so the operator's mobile scroll isn't padded with empty tiles.

## Empty months

The existing tile shell renders fine for empty months — border + month name + calendar grid with no heat colors. Quiet, not blank; no separate "no photos" copy needed.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 983/983
- [x] `npm run lint` clean
- [ ] Live verify: at desktop width, every year shows Jan–Dec
- [ ] Live verify: at mobile width, year clips to filtered first/last month (e.g. a country filter narrows the visible months)
- [ ] Live verify: resize across the 900px breakpoint hot-swaps the grid