### PR TITLE
Map: "Locate me" button on the MapModal

### DIFF
--- a/react-app/src/components/MapContainer.lazy.tsx
+++ b/react-app/src/components/MapContainer.lazy.tsx
@@ -26,6 +26,7 @@ interface Props {
   height?: number;
   maxZoom?: number;
   drawLine?: boolean;
+  showLocate?: boolean;
 }
 
 const LazyMapContainer = (props: Props): React.ReactElement => (

--- a/react-app/src/components/MapContainer.tsx
+++ b/react-app/src/components/MapContainer.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import styled from "@emotion/styled";
+import { useTranslation } from "react-i18next";
+import { BsGeoAltFill } from "react-icons/bs";
 import Leaflet, { type LatLngExpression } from "leaflet";
 import {
   MapContainer as Map,
@@ -28,6 +30,7 @@ const Root = styled("div", { shouldForwardProp: (prop) => prop !== "$height" })<
   height: ${(props) => (props.$height ? props.$height : 400)}px;
   padding: 0;
   margin: 0;
+  position: relative;
 `;
 const PopupContent = styled.span`
   text-align: center;
@@ -76,11 +79,104 @@ const Refit = ({
   return null;
 };
 
+// "You are here" marker. Inline-styled DivIcon so no extra CSS
+// asset / scoping needed; visually distinct from the default
+// photo-pin marker (blue dot + halo vs leaflet's blue droplet).
+const userPositionIcon = Leaflet.divIcon({
+  className: "",
+  html:
+    '<div style="width:16px;height:16px;border-radius:50%;' +
+    "background:#1f7aff;border:3px solid #fff;" +
+    'box-shadow:0 0 0 2px rgba(31,122,255,0.55);"></div>',
+  iconSize: [22, 22],
+  iconAnchor: [11, 11],
+});
+const LocateButtonOverlay = styled.button`
+  position: absolute;
+  top: 80px;
+  left: 10px;
+  z-index: 1000;
+  width: 34px;
+  height: 34px;
+  border-radius: 4px;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  background: #fff;
+  color: #333;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  &:hover:not(:disabled) {
+    background: #f4f4f4;
+  }
+  &:disabled {
+    color: #aaa;
+    cursor: not-allowed;
+  }
+`;
+const LocateControl = ({
+  onLocated,
+}: {
+  onLocated: (pos: LatLngExpression) => void;
+}): React.ReactElement | null => {
+  const map = useMap();
+  const { t } = useTranslation();
+  const [status, setStatus] = React.useState<"idle" | "pending" | "denied">(
+    "idle"
+  );
+  // Geolocation requires a secure context (HTTPS / localhost). On
+  // an unsecured dev origin the API exists but rejects every call —
+  // hide the button rather than offer a dead control.
+  if (
+    typeof window === "undefined" ||
+    !navigator.geolocation ||
+    !window.isSecureContext
+  ) {
+    return null;
+  }
+  const locate = () => {
+    setStatus("pending");
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const coords: LatLngExpression = [
+          pos.coords.latitude,
+          pos.coords.longitude,
+        ];
+        onLocated(coords);
+        map.setView(coords, Math.max(map.getZoom(), 14), { animate: true });
+        setStatus("idle");
+      },
+      (err) => {
+        setStatus(err.code === err.PERMISSION_DENIED ? "denied" : "idle");
+      },
+      { timeout: 10_000, maximumAge: 60_000 }
+    );
+  };
+  const label = String(
+    status === "denied" ? t("map-locate-me-denied") : t("map-locate-me")
+  );
+  return (
+    <LocateButtonOverlay
+      type="button"
+      onClick={locate}
+      disabled={status !== "idle"}
+      aria-label={label}
+      title={label}
+    >
+      <BsGeoAltFill aria-hidden />
+    </LocateButtonOverlay>
+  );
+};
+
 interface Props {
   positions: Photo[];
   height?: number;
   maxZoom?: number;
   drawLine?: boolean;
+  // Show the "Locate me" overlay button (#545). Defaults off — only
+  // surfaces on MapModal, not on per-photo metadata-panel maps.
+  showLocate?: boolean;
 }
 
 const MapContainer = ({
@@ -88,7 +184,10 @@ const MapContainer = ({
   height,
   maxZoom,
   drawLine,
+  showLocate,
 }: Props): React.ReactElement => {
+  const [userPosition, setUserPosition] =
+    React.useState<LatLngExpression | undefined>(undefined);
   if (photos.length === 0) {
     return <></>;
   }
@@ -127,6 +226,12 @@ const MapContainer = ({
           maxZoom={resolvedMaxZoom}
           positionKey={positionKey}
         />
+        {showLocate && (
+          <LocateControl onLocated={(pos) => setUserPosition(pos)} />
+        )}
+        {userPosition && (
+          <Marker position={userPosition} icon={userPositionIcon} />
+        )}
         <TileLayer
           attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"

--- a/react-app/src/components/MapModal.tsx
+++ b/react-app/src/components/MapModal.tsx
@@ -116,6 +116,7 @@ const MapModal = ({
             height={height}
             maxZoom={18}
             drawLine={drawLine}
+            showLocate
           />
         </MapArea>
       </ModalBox>

--- a/react-app/src/lib/translations/en.json
+++ b/react-app/src/lib/translations/en.json
@@ -518,6 +518,8 @@
     "stats-location-count-geotagged": "{{count}} geotagged",
     "stats-location-count-not-geotagged": "{{count}} not geotagged",
     "stats-location-see-on-map": "See on map",
+    "map-locate-me": "Center on my current position",
+    "map-locate-me-denied": "Location permission denied",
     "stats-topic-time": "Time",
     "stats-category-year": "Year",
     "stats-category-year-month": "Year and Month",

--- a/react-app/src/lib/translations/fi.json
+++ b/react-app/src/lib/translations/fi.json
@@ -518,6 +518,8 @@
     "stats-location-count-geotagged": "{{count}} sijaintitiedollista",
     "stats-location-count-not-geotagged": "{{count}} ilman sijaintia",
     "stats-location-see-on-map": "Näytä kartalla",
+    "map-locate-me": "Keskitä nykyiseen sijaintiini",
+    "map-locate-me-denied": "Sijaintilupa evätty",
     "stats-topic-time": "Ajankohta",
     "stats-category-year": "Vuosi",
     "stats-category-year-month": "Vuosi ja kuukausi",

--- a/react-app/src/lib/translations/ja.json
+++ b/react-app/src/lib/translations/ja.json
@@ -518,6 +518,8 @@
     "stats-location-count-geotagged": "{{count}}枚あり",
     "stats-location-count-not-geotagged": "{{count}}枚なし",
     "stats-location-see-on-map": "地図で表示",
+    "map-locate-me": "現在地に移動",
+    "map-locate-me-denied": "位置情報の利用が許可されていません",
     "stats-topic-time": "時間分布",
     "stats-category-year": "年",
     "stats-category-year-month": "年月",


### PR DESCRIPTION
## Summary

Closes #545. Geolocation-driven overlay button on the MapContainer, opt-in via a new `showLocate` prop. MapModal turns it on; the per-photo map in MetadataPanel doesn't (the photo's coords are the whole point there — no need for a "you are here" jump).

## UX

- Button rendered as a styled overlay (top-left, below leaflet's zoom controls so it doesn't fight them) inside the leaflet pane via a `useMap`-based control component.
- On click: `navigator.geolocation.getCurrentPosition` with a 10s timeout + 60s `maximumAge` cache. Success pans + zooms (preserves operator's current zoom if higher than the city-scale fallback of 14) and drops a "you are here" marker — a blue dot with a soft halo, visually distinct from the leaflet droplet used for photos.
- Permission denied: button disables with a translated `aria-label` / `title` saying so. (Clearing the denial requires clearing the per-origin permission state — browser-level.)
- Insecure origin (HTTP, no `localhost`): button hides entirely. Geolocation API rejects every call there anyway, no point offering a dead control.

i18n keys (`map-locate-me`, `map-locate-me-denied`) in en / fi / ja.

## Use case

Walking around with the 365 project — open Stats → Location → tap the button → see what's already been shot around the current spot without panning.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 983/983
- [x] `npm run lint` clean
- [x] Live verify on `/s` (HTTPS or localhost): button appears, permission prompt fires on first click, map centers + drops blue-dot marker
- [ ] Live verify: deny the permission → button disables with a "denied" tooltip
- [ ] Live verify: open the per-photo metadata panel map — no Locate button (showLocate not passed)