### PR TITLE
bin/instance.ts upgrade: run the pm2 cycle, don't just print it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 - Global Stats Galleries section honours the Filters sidebar. The section now reads the per-gallery filtered counts off `/stats`'s new `byGallery` field instead of walking the cross-gallery photo array client-side. Same queryKey as the sibling `<Stats globalScope>` fetch, so TanStack dedupes — one network call for both sections. Empty `byGallery` (no galleries hit by the active filter) hides the section. (closes #446)
 - GlobalStats no longer fetches the full cross-gallery photo array at mount. The filter pill universe comes from the new global `/filter-values` endpoint; the empty-instance signal reads off the response's `categoryValues.year`. The Location map fetch is lazy via the new `POST /api/v1/photos/query` (gated on `mapPhotosWanted`, flipped when the user opens the MapModal) and now respects the active filter chips — toggling the country filter narrows the map pins to match. Brief empty-map flash on first open while the fetch completes; subsequent opens hit the TanStack cache. The legacy paginated `fetchAllPhotos` and `buildUniqueValuesFromPhotos` photo-walking helpers are gone. (followup to #532)
 
+### Tooling
+
+- `bin/instance.ts upgrade` runs the pm2 cycle (`pm2 delete <instance> <instance>-converter` → `start-prod.sh` server → `start-prod.sh` converter → `pm2 save`) directly instead of printing the commands for the operator to copy-paste. Confirmation prompt on a TTY (via `@inquirer/prompts`), pre-cycle sanity check via `pm2 jlist` (both processes expected to be online before the switch), post-cycle `pm2 jlist` + `GET /api/v1/meta` probe to confirm the new version is actually serving. Non-TTY runs and `--print-only` keep the previous instruction-printing behaviour; `--auto` skips the prompt for cron / batch usage. Rollback steps still print after every path. Closes #546.
+
 ## [0.14.0] - 2026-06-07
 
 ### Server

--- a/bin/instance.ts
+++ b/bin/instance.ts
@@ -27,11 +27,13 @@
  * instance to run.
  */
 
+import { spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { confirm } from "@inquirer/prompts";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
@@ -162,6 +164,53 @@ const looksLikeInstanceDir = (dir: string): boolean => {
   }
 };
 
+// --- pm2 cycle helpers (upgrade mode, #546) --------------------------------
+interface Pm2Process {
+  name: string;
+  pm2_env: { status: string };
+}
+const pm2Jlist = (): Pm2Process[] | undefined => {
+  const res = spawnSync("pm2", ["jlist"], { encoding: "utf8" });
+  if (res.status !== 0) return undefined;
+  try {
+    return JSON.parse(res.stdout) as Pm2Process[];
+  } catch {
+    return undefined;
+  }
+};
+const pm2Status = (
+  list: Pm2Process[] | undefined,
+  name: string
+): string | undefined => list?.find((p) => p.name === name)?.pm2_env.status;
+const runStep = (
+  label: string,
+  cmd: string,
+  args: string[],
+  cwd?: string
+): boolean => {
+  log(`  $ ${cmd} ${args.join(" ")}`);
+  const res = spawnSync(cmd, args, { stdio: "inherit", cwd });
+  if (res.status !== 0) {
+    console.error(`✗ ${label} failed (exit ${res.status ?? "?"})`);
+    return false;
+  }
+  return true;
+};
+// Best-effort post-cycle probe — server's /api/v1/meta is unauthenticated
+// and cheap. PORT is required in .env so we always have it. Non-fatal:
+// returns false on any error, caller decides what to do with that.
+const probeMeta = async (port: number): Promise<boolean> => {
+  const url = `http://127.0.0.1:${port}/api/v1/meta`;
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(5000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+};
+
 const argv = yargs(hideBin(process.argv))
   .scriptName("instance.ts")
   .locale("en")
@@ -193,6 +242,18 @@ const argv = yargs(hideBin(process.argv))
           default: false,
           alias: "q",
         })
+        .option("auto", {
+          describe:
+            "Upgrade only: skip the proceed-with-pm2-cycle prompt and run unattended. Default behaviour prompts on a TTY and prints copy-paste instructions otherwise.",
+          type: "boolean",
+          default: false,
+        })
+        .option("print-only", {
+          describe:
+            "Upgrade only: never run the pm2 cycle; just print the instructions (the pre-#546 behaviour). Wins over --auto if both are set.",
+          type: "boolean",
+          default: false,
+        })
   )
   .alias("help", "h")
   .strict()
@@ -202,6 +263,8 @@ const positional = argv.name as string | undefined;
 const baseFlag = argv.base;
 const fix = argv.fix;
 const quiet = argv.quiet;
+const auto = argv.auto as boolean;
+const printOnly = argv["print-only"] as boolean;
 
 const log: typeof console.log = (...args) => {
   if (!quiet) console.log(...args);
@@ -420,29 +483,156 @@ if (mode === "new") {
   log(`  ./bin/gallery.ts create ${instanceName} --title "${instanceName}"`);
   log("  ./bin/user.ts make-admin <username>");
 } else if (mode === "upgrade") {
-  log("Upgrade prepared. Next — cycle pm2 to pick up the new version:");
-  log();
-  log(`  pm2 delete ${instanceName} ${instanceName}-converter`);
-  log(`  cd ${instanceDir}`);
-  log("  ./code/server/bin/start-prod.sh");
-  log("  ./code/converter/bin/start-prod.sh");
-  log("  pm2 save");
-  log();
-  log(
-    "  Note: pm2 restart silently keeps the old version (cached script path"
-  );
-  log(
-    "  + package.json are read at start time). Delete + start forces re-resolution."
-  );
-  log();
-  log("─".repeat(60));
-  log("Rollback — ONLY if the steps above didn't work:");
-  log();
-  log(`  pm2 delete ${instanceName} ${instanceName}-converter`);
-  log("  cp db.sqlite3.pre-<version> db.sqlite3");
-  log(`  ln -snf <old-code-root> ${codeLinkPath}`);
-  log("  ./code/server/bin/start-prod.sh");
-  log("  ./code/converter/bin/start-prod.sh");
+  const converterName = `${instanceName}-converter`;
+  const printInstructions = () => {
+    log("Upgrade prepared. Next — cycle pm2 to pick up the new version:");
+    log();
+    log(`  pm2 delete ${instanceName} ${converterName}`);
+    log(`  cd ${instanceDir}`);
+    log("  ./code/server/bin/start-prod.sh");
+    log("  ./code/converter/bin/start-prod.sh");
+    log("  pm2 save");
+    log();
+    log(
+      "  Note: pm2 restart silently keeps the old version (cached script path"
+    );
+    log(
+      "  + package.json are read at start time). Delete + start forces re-resolution."
+    );
+  };
+  const printRollback = () => {
+    log("─".repeat(60));
+    log("Rollback — ONLY if the steps above didn't work:");
+    log();
+    log(`  pm2 delete ${instanceName} ${converterName}`);
+    log("  cp db.sqlite3.pre-<version> db.sqlite3");
+    log(`  ln -snf <old-code-root> ${codeLinkPath}`);
+    log("  ./code/server/bin/start-prod.sh");
+    log("  ./code/converter/bin/start-prod.sh");
+  };
+
+  // Decide between three paths:
+  //   --print-only          → today's behaviour, never run the cycle
+  //   --auto                → run unattended (CI / cron)
+  //   TTY + interactive     → prompt to confirm, run on yes, fall back to
+  //                           printed instructions on no
+  //   non-TTY without --auto → print instructions (no stdin to prompt from)
+  const isTTY = !!process.stdin.isTTY && !!process.stdout.isTTY;
+  let runCycle: boolean;
+  if (printOnly) {
+    runCycle = false;
+  } else if (auto) {
+    runCycle = true;
+  } else if (!isTTY) {
+    runCycle = false;
+  } else {
+    // Sanity-check pm2 state up front so the confirmation prompt has
+    // a clear picture: both processes are expected to be online with
+    // the OLD code (the upgrade is happening WHILE they're serving).
+    const before = pm2Jlist();
+    const serverBefore = pm2Status(before, instanceName);
+    const converterBefore = pm2Status(before, converterName);
+    log();
+    log("pm2 state:");
+    log(`  ${serverBefore === "online" ? "✓" : "✗"} ${instanceName}: ${serverBefore ?? "(missing)"}`);
+    log(
+      `  ${converterBefore === "online" ? "✓" : "✗"} ${converterName}: ${converterBefore ?? "(missing)"}`
+    );
+    if (serverBefore !== "online" || converterBefore !== "online") {
+      log();
+      log(
+        "  One or both processes aren't online with the previous version —"
+      );
+      log(
+        "  the cycle assumes a running instance. Falling back to printed"
+      );
+      log("  instructions; review and run manually.");
+      log();
+      printInstructions();
+      log();
+      printRollback();
+      process.exit(0);
+    }
+    log();
+    try {
+      runCycle = await confirm({
+        message: `Cycle pm2 (${instanceName} + ${converterName}) to pick up the new version?`,
+        default: true,
+      });
+    } catch {
+      // Ctrl+C inside the prompt — fall back to manual.
+      log();
+      log("Cancelled. Printing instructions instead:");
+      log();
+      printInstructions();
+      log();
+      printRollback();
+      process.exit(0);
+    }
+  }
+
+  if (!runCycle) {
+    printInstructions();
+    log();
+    printRollback();
+  } else {
+    log();
+    log("Cycling pm2 …");
+    const ok =
+      runStep("pm2 delete", "pm2", ["delete", instanceName, converterName]) &&
+      runStep(
+        "start server",
+        "./code/server/bin/start-prod.sh",
+        [],
+        instanceDir
+      ) &&
+      runStep(
+        "start converter",
+        "./code/converter/bin/start-prod.sh",
+        [],
+        instanceDir
+      ) &&
+      runStep("pm2 save", "pm2", ["save"]);
+    if (!ok) {
+      console.error("✗ Cycle aborted. See output above; rollback instructions:");
+      console.error();
+      printRollback();
+      process.exit(1);
+    }
+    // Post-cycle sanity: both processes back online, server actually
+    // serving on its declared port.
+    const after = pm2Jlist();
+    const serverAfter = pm2Status(after, instanceName);
+    const converterAfter = pm2Status(after, converterName);
+    log();
+    log("pm2 state after cycle:");
+    log(`  ${serverAfter === "online" ? "✓" : "✗"} ${instanceName}: ${serverAfter ?? "(missing)"}`);
+    log(
+      `  ${converterAfter === "online" ? "✓" : "✗"} ${converterName}: ${converterAfter ?? "(missing)"}`
+    );
+    const envForProbe = parseEnv(fs.readFileSync(envPath, "utf8"));
+    const portStr = envForProbe.PORT;
+    const port = portStr ? Number(portStr) : NaN;
+    if (Number.isFinite(port)) {
+      const served = await probeMeta(port);
+      log(
+        `  ${served ? "✓" : "✗"} GET http://127.0.0.1:${port}/api/v1/meta ${served ? "responded" : "didn't respond within 5s"}`
+      );
+      if (!served) {
+        console.error();
+        console.error(
+          "✗ Server is up in pm2 but not answering on its port — review pm2 logs."
+        );
+        process.exit(1);
+      }
+    } else {
+      log(
+        `  ! PORT not parseable from .env (${portStr ?? "missing"}); skipping HTTP probe`
+      );
+    }
+    log();
+    log("✓ Upgrade complete.");
+  }
 } else {
   log("Instance state OK.");
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -19,7 +19,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -2171,6 +2171,334 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.3",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.1",
+        "@inquirer/confirm": "^6.1.1",
+        "@inquirer/editor": "^5.2.2",
+        "@inquirer/expand": "^5.1.1",
+        "@inquirer/input": "^5.1.2",
+        "@inquirer/number": "^4.1.1",
+        "@inquirer/password": "^5.1.1",
+        "@inquirer/rawlist": "^5.3.1",
+        "@inquirer/search": "^4.2.1",
+        "@inquirer/select": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2884,7 +3212,7 @@
       "version": "25.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -3966,6 +4294,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "license": "MIT"
+    },
     "node_modules/chart.js": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
@@ -3998,6 +4332,15 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/cliui": {
       "version": "9.0.1",
@@ -5131,6 +5474,21 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -5146,6 +5504,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fastify": {
       "version": "5.8.5",
@@ -5873,6 +6240,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -7190,6 +7573,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -8576,6 +8968,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -8843,6 +9241,18 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -9647,7 +10057,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -10218,7 +10628,7 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -10546,7 +10956,7 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -10556,6 +10966,7 @@
         "@fastify/swagger": "^9.7.0",
         "@fastify/swagger-ui": "^5.2.6",
         "@fastify/type-provider-typebox": "^6.1.0",
+        "@inquirer/prompts": "^8.5.2",
         "bcrypt": "^6.0.0",
         "better-sqlite3": "^12.10.0",
         "dotenv": "^17.4.2",

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^5.2.6",
     "@fastify/type-provider-typebox": "^6.1.0",
+    "@inquirer/prompts": "^8.5.2",
     "bcrypt": "^6.0.0",
     "better-sqlite3": "^12.10.0",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
## Summary

Closes #546. `bin/instance.ts upgrade` flipped the symlink + backed up the DB, then printed the pm2 cycle commands for the operator to paste. The gap between "prepared" and "done" was operator vigilance — easy to miss the converter line, easy to forget `pm2 save`, easy to mis-paste the `cd`.

Now the script does the cycle itself.

## TTY flow (default)

1. `pm2 jlist` sanity check — both `<instance>` and `<instance>-converter` expected to be online with the old code. If either is missing or stopped, fall back to printed instructions (the cycle assumes a running instance).
2. `@inquirer/prompts` confirm: "Cycle pm2 (\<instance\> + \<instance\>-converter) to pick up the new version?" [Y/n] (default yes; Ctrl-C falls back to printed instructions).
3. Run, each step surfaced inline, abort on non-zero:
   - `pm2 delete <instance> <instance>-converter`
   - `<instance>/code/server/bin/start-prod.sh`
   - `<instance>/code/converter/bin/start-prod.sh`
   - `pm2 save`
4. `pm2 jlist` sanity check after — both processes back online.
5. `GET http://127.0.0.1:<PORT>/api/v1/meta` probe (5s timeout). Online-but-not-serving wouldn't pass.

## Escape hatches

- `--print-only` — pre-#546 behaviour, never runs the cycle.
- `--auto` — skip the prompt outright. For cron / batch.
- Non-TTY without `--auto` — falls back to printed instructions automatically (no stdin to prompt from).

Rollback instructions still print after every path; the cycle doesn't remove them as the recovery surface.

## Test plan

- [x] `npm run typecheck` (server + via root tsconfig for bin/)
- [x] `npm test` — 858/858 server
- [x] `npm run lint` clean
- [ ] Live verify on the operator's dev instance: run `./code/bin/instance.ts <name>` from inside an existing instance dir, get the confirmation prompt, accept, see the cycle complete + probe succeed
- [ ] Live verify `--print-only` still prints today's instructions verbatim
- [ ] Live verify non-TTY (`./code/bin/instance.ts <name> < /dev/null`) prints instructions without prompting