### PR TITLE
Saved filters as pseudo-galleries (#285)

### DIFF
--- a/react-app/src/components/Manage/GalleryEdit.tsx
+++ b/react-app/src/components/Manage/GalleryEdit.tsx
@@ -190,6 +190,7 @@ interface GalleryData {
   initialView?: string;
   hostname?: string;
   defaultLanguage?: string;
+  type?: "real" | "hybrid" | "saved_filter";
   photos?: Array<{ id: string }>;
 }
 
@@ -457,10 +458,12 @@ const GalleryEdit = (): React.ReactElement => {
             <SummaryLabel>{t("manage-gallery-field-hostname")}</SummaryLabel>
             <SummaryValue>{renderValue(gallery.hostname)}</SummaryValue>
           </Summary>
-          <SavedFiltersSection
-            galleryId={galleryId}
-            defaultLanguage={gallery.defaultLanguage}
-          />
+          {(gallery.type ?? "real") === "real" && (
+            <SavedFiltersSection
+              galleryId={galleryId}
+              defaultLanguage={gallery.defaultLanguage}
+            />
+          )}
           <Footer>
             {isAdmin && (
               <ButtonDanger

--- a/react-app/src/components/Manage/SavedFiltersSection.tsx
+++ b/react-app/src/components/Manage/SavedFiltersSection.tsx
@@ -208,7 +208,6 @@ interface FormState {
   dateFrom: string;
   dateTo: string;
   filterJson: string;
-  ordinal: string;
 }
 
 const emptyLocalized = (): Record<string, string> =>
@@ -225,7 +224,6 @@ const blankForm = (
   dateFrom: galleryExtremes?.from ?? "",
   dateTo: galleryExtremes?.to ?? "",
   filterJson: "",
-  ordinal: "0",
 });
 
 const formFromSaved = (f: SavedFilter): FormState => {
@@ -249,14 +247,12 @@ const formFromSaved = (f: SavedFilter): FormState => {
     dateFrom: f.definition?.dateRange?.from ?? "",
     dateTo: f.definition?.dateRange?.to ?? "",
     filterJson,
-    ordinal: String(f.ordinal ?? 0),
   };
 };
 
 interface BuildResult {
   ok: true;
   definition: SavedFilterDefinition;
-  ordinal: number;
 }
 interface BuildError {
   ok: false;
@@ -278,11 +274,7 @@ const buildDefinition = (form: FormState): BuildResult | BuildError => {
     if (form.dateFrom) definition.dateRange.from = form.dateFrom;
     if (form.dateTo) definition.dateRange.to = form.dateTo;
   }
-  const ordinal = Number(form.ordinal || "0");
-  if (!Number.isFinite(ordinal)) {
-    return { ok: false, reason: "Ordinal must be a number" };
-  }
-  return { ok: true, definition, ordinal };
+  return { ok: true, definition };
 };
 
 const localizedPatch = (
@@ -413,7 +405,6 @@ const SavedFiltersSection = ({
           form.descriptionLocalized
         ),
         definition: built.definition,
-        ordinal: built.ordinal,
       });
     } else if (editingId) {
       updateMutation.mutate({
@@ -433,7 +424,6 @@ const SavedFiltersSection = ({
             form.descriptionLocalized
           ),
           definition: built.definition,
-          ordinal: built.ordinal,
         },
       });
     }

--- a/react-app/src/lib/api-schema.ts
+++ b/react-app/src/lib/api-schema.ts
@@ -792,7 +792,7 @@ export interface paths {
                     content: {
                         "application/json": {
                             id: string;
-                            galleryId: string;
+                            sourceGalleryId: string;
                             title: string;
                             description: string;
                             titleLocalized: {
@@ -814,7 +814,6 @@ export interface paths {
                             } & {
                                 [key: string]: unknown;
                             };
-                            ordinal: number;
                         }[];
                     };
                 };
@@ -856,7 +855,6 @@ export interface paths {
                         } & {
                             [key: string]: unknown;
                         };
-                        ordinal?: number;
                     };
                 };
             };
@@ -904,7 +902,7 @@ export interface paths {
                     content: {
                         "application/json": {
                             id: string;
-                            galleryId: string;
+                            sourceGalleryId: string;
                             title: string;
                             description: string;
                             titleLocalized: {
@@ -926,7 +924,6 @@ export interface paths {
                             } & {
                                 [key: string]: unknown;
                             };
-                            ordinal: number;
                         };
                     };
                 };
@@ -967,7 +964,6 @@ export interface paths {
                         } & {
                             [key: string]: unknown;
                         };
-                        ordinal?: number;
                     };
                 };
             };

--- a/react-app/src/services/saved-filters.ts
+++ b/react-app/src/services/saved-filters.ts
@@ -13,13 +13,12 @@ export interface SavedFilterDefinition {
 }
 export interface SavedFilter {
   id: string;
-  galleryId: string;
+  sourceGalleryId: string;
   title: string;
   description: string;
   titleLocalized: Record<string, string>;
   descriptionLocalized: Record<string, string>;
   definition: SavedFilterDefinition;
-  ordinal: number;
 }
 
 const list = async (galleryId: string): Promise<SavedFilter[]> =>
@@ -43,7 +42,6 @@ export interface SavedFilterCreateBody {
   titleLocalized?: Record<string, string>;
   descriptionLocalized?: Record<string, string>;
   definition: SavedFilterDefinition;
-  ordinal?: number;
 }
 const create = async (
   galleryId: string,
@@ -63,7 +61,6 @@ export interface SavedFilterUpdatePatch {
   titleLocalized?: Record<string, string>;
   descriptionLocalized?: Record<string, string>;
   definition?: SavedFilterDefinition;
-  ordinal?: number;
 }
 const update = async (
   galleryId: string,

--- a/server/bin/gallery.ts
+++ b/server/bin/gallery.ts
@@ -408,21 +408,15 @@ await yargs(hideBin(process.argv))
             const filters = (await db.loadSavedFilters(galleryId)) as Array<{
               id: string;
               title: string;
-              ordinal: number;
               definition: Record<string, unknown>;
             }>;
             if (filters.length === 0) {
               console.log("(no saved filters)");
               return;
             }
-            const rows: string[][] = [["id", "title", "ordinal", "definition"]];
+            const rows: string[][] = [["id", "title", "definition"]];
             for (const f of filters) {
-              rows.push([
-                f.id,
-                f.title,
-                String(f.ordinal),
-                JSON.stringify(f.definition),
-              ]);
+              rows.push([f.id, f.title, JSON.stringify(f.definition)]);
             }
             console.log(formatTable(rows));
           }
@@ -455,10 +449,6 @@ await yargs(hideBin(process.argv))
                   "JSON string for the filter envelope: `{filter?, dateRange?}`",
                 type: "string",
                 demandOption: true,
-              })
-              .option("ordinal", {
-                describe: "Display order index (default 0)",
-                type: "number",
               }),
           async (argv) => {
             const galleryId = argv.gallery as string;
@@ -477,13 +467,12 @@ await yargs(hideBin(process.argv))
             }
             await db.createSavedFilter({
               id: filterId,
-              galleryId,
+              sourceGalleryId: galleryId,
               title: (argv.title as string | undefined) ?? "",
               description: (argv.description as string | undefined) ?? "",
               titleLocalized: {},
               descriptionLocalized: {},
               definition,
-              ordinal: (argv.ordinal as number | undefined) ?? 0,
             });
             console.log(
               `✓ Created saved filter "${filterId}" on gallery "${galleryId}".`
@@ -534,8 +523,7 @@ await yargs(hideBin(process.argv))
               .option("definition", {
                 describe: "JSON string replacing the filter envelope",
                 type: "string",
-              })
-              .option("ordinal", { type: "number" }),
+              }),
           async (argv) => {
             const galleryId = argv.gallery as string;
             const filterId = argv.id as string;
@@ -543,11 +531,9 @@ await yargs(hideBin(process.argv))
               title?: string;
               description?: string;
               definition?: Record<string, unknown>;
-              ordinal?: number;
             } = {};
             if ("title" in argv) patch.title = argv.title as string;
             if ("description" in argv) patch.description = argv.description as string;
-            if ("ordinal" in argv) patch.ordinal = argv.ordinal as number;
             if ("definition" in argv && argv.definition !== undefined) {
               try {
                 patch.definition = JSON.parse(

--- a/server/controllers/saved-filters-v1.ts
+++ b/server/controllers/saved-filters-v1.ts
@@ -62,15 +62,18 @@ const ParamsOne = Type.Object({
   filterId: Type.String(),
 });
 
+// Saved filters live as galleries of type='saved_filter' (#285).
+// `id` is a gallery id in its own right (collision-checked against
+// every other gallery on create); `sourceGalleryId` points at the
+// gallery the saved filter is anchored to.
 const SavedFilterResponse = Type.Object({
   id: Type.String(),
-  galleryId: Type.String(),
+  sourceGalleryId: Type.String(),
   title: Type.String(),
   description: Type.String(),
   titleLocalized: LocalizedMap,
   descriptionLocalized: LocalizedMap,
   definition: SavedFilterDefinition,
-  ordinal: Type.Integer(),
 });
 const SavedFiltersListResponse = Type.Array(SavedFilterResponse);
 
@@ -82,7 +85,6 @@ const CreateBody = Type.Object(
     titleLocalized: Type.Optional(LocalizedMap),
     descriptionLocalized: Type.Optional(LocalizedMap),
     definition: SavedFilterDefinition,
-    ordinal: Type.Optional(Type.Integer()),
   },
   { additionalProperties: false }
 );
@@ -93,7 +95,6 @@ const UpdateBody = Type.Object(
     titleLocalized: Type.Optional(LocalizedMap),
     descriptionLocalized: Type.Optional(LocalizedMap),
     definition: Type.Optional(SavedFilterDefinition),
-    ordinal: Type.Optional(Type.Integer()),
   },
   { additionalProperties: false }
 );

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -245,33 +245,37 @@ export default {
     return (await db.isReferencedAsSource(galleryId)) as boolean;
   },
 
-  // Saved filters (#285).
-  loadSavedFilters: async (galleryId: string): Promise<SavedFilter[]> => {
-    return (await db.loadSavedFilters(galleryId)) as SavedFilter[];
+  // Saved filters (#285): pseudo-galleries of type='saved_filter'
+  // anchored to a source gallery + a stored baseline. `sourceGalleryId`
+  // identifies which gallery owns the saved filter for listing /
+  // routing purposes; the saved filter's own id is a gallery id in
+  // its own right (unified namespace).
+  loadSavedFilters: async (sourceGalleryId: string): Promise<SavedFilter[]> => {
+    return (await db.loadSavedFilters(sourceGalleryId)) as SavedFilter[];
   },
   loadSavedFilter: async (
-    galleryId: string,
+    sourceGalleryId: string,
     id: string
   ): Promise<SavedFilter> => {
-    return (await db.loadSavedFilter(galleryId, id)) as SavedFilter;
+    return (await db.loadSavedFilter(sourceGalleryId, id)) as SavedFilter;
   },
   createSavedFilter: async (filter: SavedFilter): Promise<void> => {
     await db.createSavedFilter(filter);
   },
   updateSavedFilter: async (
-    galleryId: string,
+    sourceGalleryId: string,
     id: string,
     patch: Partial<
-      Pick<SavedFilter, "title" | "description" | "definition" | "ordinal">
+      Pick<SavedFilter, "title" | "description" | "definition">
     > & {
       titleLocalized?: Record<string, string | undefined>;
       descriptionLocalized?: Record<string, string | undefined>;
     }
   ): Promise<void> => {
-    await db.updateSavedFilter(galleryId, id, patch);
+    await db.updateSavedFilter(sourceGalleryId, id, patch);
   },
-  deleteSavedFilter: async (galleryId: string, id: string): Promise<void> => {
-    await db.deleteSavedFilter(galleryId, id);
+  deleteSavedFilter: async (sourceGalleryId: string, id: string): Promise<void> => {
+    await db.deleteSavedFilter(sourceGalleryId, id);
   },
 
   loadGalleryPhotos: async (galleryId: string, lang?: string) => {

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -32,9 +32,8 @@ import schemaFactory, {
   type PhotoInput,
   type PhotoLocalizedRow,
   type PhotoRow,
+  type GallerySavedFilterRow,
   type SavedFilter,
-  type SavedFilterLocalizedRow,
-  type SavedFilterRow,
   type SessionRow,
   type User,
   type UserGalleryRow,
@@ -468,6 +467,89 @@ const resolveHideMap = async (
   return guest?.hide_map;
 };
 
+// Resolves a gallery id to the pieces the read path needs:
+//
+//   - `sources`: list of real-gallery ids whose `gallery_photo`
+//     rows make up the gallery's contents. Real gallery → [self];
+//     hybrid → its stored sources (virtual_gallery_source); saved
+//     filter → [source_gallery_id] from gallery_saved_filter.
+//
+//   - `baseline`: filter + dateRange stored on a saved-filter
+//     gallery. Applied on top of the source's photos so the gallery
+//     reads as a narrowed view. Undefined for real and hybrid.
+//
+// Every read path (load photos / counts / neighbors / filter values)
+// goes through this resolver — type dispatch lives here, downstream
+// callers stay uniform.
+interface GalleryRef {
+  sources: string[];
+  baseline?: { filter?: FilterShape; dateRange?: DateRange };
+}
+const resolveGalleryRef = (galleryId: string): GalleryRef => {
+  const savedFilter = loadGallerySavedFilterRow(galleryId);
+  if (savedFilter) {
+    let baseline: { filter?: FilterShape; dateRange?: DateRange } = {};
+    try {
+      baseline = JSON.parse(savedFilter.definition) as {
+        filter?: FilterShape;
+        dateRange?: DateRange;
+      };
+    } catch {
+      // Malformed JSON shouldn't happen (writes go through
+      // JSON.stringify) but if it does, treat as empty baseline.
+    }
+    return {
+      sources: [savedFilter.source_gallery_id],
+      baseline: {
+        filter: baseline.filter,
+        dateRange: baseline.dateRange,
+      },
+    };
+  }
+  const virtual = loadVirtualGallerySources(galleryId);
+  if (virtual !== undefined) return { sources: virtual };
+  return { sources: [galleryId] };
+};
+// Drop photos that fail the saved-filter gallery's baseline. No-op
+// when called against a real or hybrid gallery (`ref.baseline`
+// absent).
+const applyBaseline = (photos: Photo[], ref: GalleryRef): Photo[] => {
+  if (!ref.baseline) return photos;
+  const { filter, dateRange } = ref.baseline;
+  return photos.filter(
+    (p) => matchesDateRange(dateRange, p) && matchesFilter(filter, p)
+  );
+};
+// Single-photo baseline check. NotFoundError-style: returns true if
+// the photo is part of the saved filter's effective set.
+const photoPassesBaseline = (photo: Photo, ref: GalleryRef): boolean => {
+  if (!ref.baseline) return true;
+  return (
+    matchesDateRange(ref.baseline.dateRange, photo) &&
+    matchesFilter(ref.baseline.filter, photo)
+  );
+};
+
+const loadGallerySavedFilterRow = (
+  galleryId: string
+): GallerySavedFilterRow | undefined => {
+  return db
+    .prepare(
+      "SELECT gallery_id, source_gallery_id, definition FROM gallery_saved_filter WHERE gallery_id = ?"
+    )
+    .get(galleryId) as GallerySavedFilterRow | undefined;
+};
+const loadAllGallerySavedFilters = (): Map<string, GallerySavedFilterRow> => {
+  const rows = db
+    .prepare(
+      "SELECT gallery_id, source_gallery_id, definition FROM gallery_saved_filter"
+    )
+    .all() as GallerySavedFilterRow[];
+  const out = new Map<string, GallerySavedFilterRow>();
+  for (const r of rows) out.set(r.gallery_id, r);
+  return out;
+};
+
 // Virtual galleries: sibling `virtual_gallery_source` junction
 // table holds one row per (virtual, source) pair, ordered by
 // `ordinal` to preserve the operator's input order (#22). A
@@ -499,14 +581,6 @@ const loadVirtualGallerySources = (galleryId: string): string[] | undefined => {
   if (rows.length === 0) return undefined;
   return rows.map((r) => r.source_id);
 };
-// Resolves a galleryId to the list of source gallery IDs whose
-// `gallery_photo` rows make up its contents. Real gallery → [self].
-// Virtual gallery → its stored sources. Empty sources or missing
-// row treated as "no contents" (returns []).
-const resolveGallerySources = (galleryId: string): string[] => {
-  const sources = loadVirtualGallerySources(galleryId);
-  return sources === undefined ? [galleryId] : sources;
-};
 const isVirtualGallery = async (galleryId: string): Promise<boolean> => {
   const row = db
     .prepare(
@@ -535,6 +609,27 @@ const decorateGalleryWithSources = (
   const sources = sourcesByGallery.get(gallery.id);
   return sources === undefined ? gallery : { ...gallery, sources };
 };
+const decorateGalleryWithSavedFilter = (
+  gallery: Gallery,
+  byGallery: Map<string, GallerySavedFilterRow>
+): Gallery => {
+  if (gallery.type !== "saved_filter") return gallery;
+  const row = byGallery.get(gallery.id);
+  if (!row) return gallery;
+  let definition: Record<string, unknown> = {};
+  try {
+    definition = JSON.parse(row.definition) as Record<string, unknown>;
+  } catch {
+    // Stale / malformed JSON — fall through to empty definition.
+  }
+  return {
+    ...gallery,
+    savedFilter: {
+      sourceGalleryId: row.source_gallery_id,
+      definition,
+    },
+  };
+};
 // Replace the source set atomically — DELETE existing rows then
 // INSERT each in input order. better-sqlite3's `transaction(fn)`
 // wraps the body in BEGIN/COMMIT.
@@ -548,147 +643,147 @@ const upsertVirtualGallery = async (
   const ins = db.prepare(
     "INSERT INTO virtual_gallery_source (gallery_id, source_id, ordinal) VALUES (?, ?, ?)"
   );
+  const stampType = db.prepare(
+    "UPDATE gallery SET type = 'hybrid' WHERE id = ?"
+  );
   const replace = db.transaction((gid: string, list: string[]) => {
     del.run(gid);
     list.forEach((sourceId, i) => {
       ins.run(gid, sourceId, i);
     });
+    stampType.run(gid);
   });
   replace(galleryId, sources);
 };
 const deleteVirtualGallery = async (galleryId: string): Promise<void> => {
-  db.prepare(
-    "DELETE FROM virtual_gallery_source WHERE gallery_id = ?"
-  ).run(galleryId);
+  // Drop the sources and revert the gallery to a plain real gallery so
+  // `type` stays in sync with side-table presence.
+  const tx = db.transaction((gid: string) => {
+    db.prepare(
+      "DELETE FROM virtual_gallery_source WHERE gallery_id = ?"
+    ).run(gid);
+    db.prepare("UPDATE gallery SET type = 'real' WHERE id = ?").run(gid);
+  });
+  tx(galleryId);
 };
 
-// Saved filters / sub-galleries (#285). One row per (gallery, id)
-// pair; `definition` is a JSON string holding the same `filter` +
-// `dateRange` envelope the per-view endpoints already accept, so
-// applying a saved filter is just unmarshalling and forwarding.
-// Localized title / description live in `saved_filter_localized`,
-// mirroring the gallery localization shape from #281.
-const mapSavedFilterRow = (
-  row: SavedFilterRow,
-  localized?: SavedFilterLocalizedRow[]
-): SavedFilter => ({
-  id: row.id,
-  galleryId: row.gallery_id,
-  title: row.title,
-  description: row.description,
-  titleLocalized: buildLocalizedMap(localized, "title"),
-  descriptionLocalized: buildLocalizedMap(localized, "description"),
-  ordinal: row.ordinal,
-  definition: (() => {
-    try {
-      return JSON.parse(row.definition) as Record<string, unknown>;
-    } catch {
-      return {};
-    }
-  })(),
-});
-const loadSavedFilterLocalizedFor = (
-  galleryId: string,
-  filterIds: string[]
-): Map<string, SavedFilterLocalizedRow[]> => {
-  if (filterIds.length === 0) return new Map();
-  const placeholders = filterIds.map(() => "?").join(",");
-  const rows = db
-    .prepare(
-      `SELECT gallery_id, filter_id, lang, title, description
-       FROM saved_filter_localized
-       WHERE gallery_id = ? AND filter_id IN (${placeholders})`
-    )
-    .all(galleryId, ...filterIds) as SavedFilterLocalizedRow[];
-  const byId = new Map<string, SavedFilterLocalizedRow[]>();
-  for (const r of rows) {
-    const list = byId.get(r.filter_id);
-    if (list) list.push(r);
-    else byId.set(r.filter_id, [r]);
+// Saved filters live as galleries of `type='saved_filter'` (#285).
+// The saved-filter id IS the gallery id. Title / description /
+// localized maps come from the gallery row + gallery_localized;
+// source + definition come from the side table gallery_saved_filter.
+// CRUD here writes both atomically; the model layer enforces the
+// id-uniqueness invariants (no collision with other gallery ids,
+// source gallery exists, slug shape).
+const mapSavedFilterGalleryRow = (
+  galleryRow: GalleryRow,
+  sfRow: GallerySavedFilterRow,
+  localized?: GalleryLocalizedRow[]
+): SavedFilter => {
+  let parsed: Record<string, unknown> = {};
+  try {
+    parsed = JSON.parse(sfRow.definition) as Record<string, unknown>;
+  } catch {
+    // Malformed JSON shouldn't be reachable through the write path
+    // (createSavedFilter always JSON.stringify's), but guard against
+    // a stale row from outside.
   }
-  return byId;
+  return {
+    id: galleryRow.id,
+    sourceGalleryId: sfRow.source_gallery_id,
+    title: galleryRow.title,
+    description: galleryRow.description,
+    titleLocalized: buildLocalizedMap(localized, "title"),
+    descriptionLocalized: buildLocalizedMap(localized, "description"),
+    definition: parsed,
+  };
 };
-const loadSavedFilters = async (galleryId: string): Promise<SavedFilter[]> => {
-  // Sort by id ASC, matching the gallery list's ordering. The
-  // dormant `ordinal` column stays for now (a follow-up drops it
-  // and reworks the schema); operators pick id slugs they want to
-  // sort by, no separate ordinal control needed.
+const loadSavedFilters = async (sourceGalleryId: string): Promise<SavedFilter[]> => {
+  // Fetch saved-filter galleries pointing at this source. Sort by
+  // gallery id ASC, matching the gallery list's natural order.
   const rows = db
     .prepare(
-      `SELECT id, gallery_id, title, description, definition, ordinal
-       FROM saved_filter
-       WHERE gallery_id = ?
-       ORDER BY id ASC`
+      `SELECT g.id, g.title, g.description, g.icon, g.icon_source, g.epoch,
+              g.epoch_type, g.theme, g.initial_view, g.hostname,
+              g.default_language, g.type,
+              sf.gallery_id, sf.source_gallery_id, sf.definition
+       FROM gallery_saved_filter sf
+       JOIN gallery g ON g.id = sf.gallery_id
+       WHERE sf.source_gallery_id = ? AND g.type = 'saved_filter'
+       ORDER BY g.id ASC`
     )
-    .all(galleryId) as SavedFilterRow[];
-  const localized = loadSavedFilterLocalizedFor(
-    galleryId,
-    rows.map((r) => r.id)
+    .all(sourceGalleryId) as Array<GalleryRow & GallerySavedFilterRow>;
+  const localized = loadGalleryLocalizedFor(rows.map((r) => r.id));
+  return rows.map((row) =>
+    mapSavedFilterGalleryRow(
+      row,
+      {
+        gallery_id: row.gallery_id,
+        source_gallery_id: row.source_gallery_id,
+        definition: row.definition,
+      },
+      localized.get(row.id)
+    )
   );
-  return rows.map((row) => mapSavedFilterRow(row, localized.get(row.id)));
 };
 const loadSavedFilter = async (
-  galleryId: string,
+  sourceGalleryId: string,
   id: string
 ): Promise<SavedFilter> => {
-  const row = db
-    .prepare(
-      `SELECT id, gallery_id, title, description, definition, ordinal
-       FROM saved_filter
-       WHERE gallery_id = ? AND id = ?`
-    )
-    .get(galleryId, id) as SavedFilterRow | undefined;
-  if (!row) throw new NotFoundError();
+  const galleryRow = db
+    .prepare(SCHEMA.gallery.buildSelectByIdQuery())
+    .get(id) as GalleryRow | undefined;
+  if (!galleryRow || galleryRow.type !== "saved_filter") {
+    throw new NotFoundError();
+  }
+  const sfRow = loadGallerySavedFilterRow(id);
+  if (!sfRow || sfRow.source_gallery_id !== sourceGalleryId) {
+    throw new NotFoundError();
+  }
   const localized = db
-    .prepare(
-      `SELECT gallery_id, filter_id, lang, title, description
-       FROM saved_filter_localized
-       WHERE gallery_id = ? AND filter_id = ?`
-    )
-    .all(galleryId, id) as SavedFilterLocalizedRow[];
-  return mapSavedFilterRow(row, localized);
+    .prepare("SELECT * FROM gallery_localized WHERE gallery_id = ?")
+    .all(id) as GalleryLocalizedRow[];
+  return mapSavedFilterGalleryRow(galleryRow, sfRow, localized);
 };
-// Per-language overlay upsert — same shape + semantics as the
-// gallery / photo localized writers: missing key leaves the column
-// alone; empty string clears it (sets NULL); both columns NULL
-// keeps the row in place (harmless empty entry, GC'd by FK cascade
-// on saved filter delete).
-const upsertSavedFilterLocalized = (
-  galleryId: string,
-  filterId: string,
-  lang: string,
-  fields: { title?: string | null; description?: string | null }
-): void => {
-  const cols: string[] = [];
-  const vals: unknown[] = [];
-  if (fields.title !== undefined) {
-    cols.push("title");
-    vals.push(fields.title);
+// Write the gallery row (type='saved_filter') + the gallery_saved_filter
+// side row + any localized overlays in one transaction so a halfway
+// state can't leak. Source gallery existence and id-collision checks
+// belong to the model layer.
+const createSavedFilter = async (filter: SavedFilter): Promise<void> => {
+  // Inherit the default_language from the source so the canonical
+  // title / description sit in the same language. Other gallery-shape
+  // columns get safe defaults — saved-filter pseudo-galleries don't
+  // carry their own icon / theme / epoch (icon is a follow-up).
+  const sourceRow = db
+    .prepare(SCHEMA.gallery.buildSelectByIdQuery())
+    .get(filter.sourceGalleryId) as GalleryRow | undefined;
+  if (!sourceRow) {
+    throw new NotFoundError();
   }
-  if (fields.description !== undefined) {
-    cols.push("description");
-    vals.push(fields.description);
-  }
-  if (cols.length === 0) return;
-  const colList = cols.join(", ");
-  const placeholders = cols.map(() => "?").join(", ");
-  const updates = cols.map((c) => `${c} = excluded.${c}`).join(", ");
-  db.prepare(
-    `INSERT INTO saved_filter_localized (gallery_id, filter_id, lang, ${colList})
-     VALUES (?, ?, ?, ${placeholders})
-     ON CONFLICT (gallery_id, filter_id, lang) DO UPDATE SET ${updates}`
-  ).run(galleryId, filterId, lang, ...vals);
-};
-const applyLocalizedPatch = (
-  galleryId: string,
-  filterId: string,
-  titleMap?: Record<string, string | undefined>,
-  descMap?: Record<string, string | undefined>
-): void => {
-  const perLang = new Map<
-    string,
-    { title?: string | null; description?: string | null }
-  >();
+  const insert = db.transaction(() => {
+    db.prepare(SCHEMA.gallery.buildCreateQuery()).run(
+      SCHEMA.gallery.mapInsert({
+        id: filter.id,
+        title: filter.title,
+        description: filter.description,
+        icon: "",
+        iconSource: null,
+        epoch: "",
+        epochType: "",
+        theme: "",
+        initialView: "",
+        hostname: "",
+        defaultLanguage: sourceRow.default_language || "en",
+        type: "saved_filter",
+      })
+    );
+    db.prepare(
+      "INSERT INTO gallery_saved_filter (gallery_id, source_gallery_id, definition) VALUES (?, ?, ?)"
+    ).run(filter.id, filter.sourceGalleryId, JSON.stringify(filter.definition ?? {}));
+  });
+  insert();
+  // Localized overlays go to gallery_localized via the gallery path
+  // (reused, since saved filter IS a gallery now).
+  const perLang = new Map<string, { title?: string | null; description?: string | null }>();
   const merge = (
     map: Record<string, string | undefined> | undefined,
     field: "title" | "description"
@@ -701,80 +796,69 @@ const applyLocalizedPatch = (
       perLang.set(lang, entry);
     }
   };
-  merge(titleMap, "title");
-  merge(descMap, "description");
+  merge(filter.titleLocalized, "title");
+  merge(filter.descriptionLocalized, "description");
   for (const [lang, fields] of perLang) {
-    upsertSavedFilterLocalized(galleryId, filterId, lang, fields);
+    upsertGalleryLocalizedFields(filter.id, lang, fields);
   }
 };
-const createSavedFilter = async (
-  filter: SavedFilter
-): Promise<void> => {
-  db.prepare(
-    `INSERT INTO saved_filter (id, gallery_id, title, description, definition, ordinal)
-     VALUES (?, ?, ?, ?, ?, ?)`
-  ).run(
-    filter.id,
-    filter.galleryId,
-    filter.title,
-    filter.description,
-    JSON.stringify(filter.definition ?? {}),
-    filter.ordinal
-  );
-  applyLocalizedPatch(
-    filter.galleryId,
-    filter.id,
-    filter.titleLocalized,
-    filter.descriptionLocalized
-  );
-};
 const updateSavedFilter = async (
-  galleryId: string,
+  sourceGalleryId: string,
   id: string,
   patch: Partial<
-    Pick<SavedFilter, "title" | "description" | "definition" | "ordinal">
+    Pick<SavedFilter, "title" | "description" | "definition">
   > & {
     titleLocalized?: Record<string, string | undefined>;
     descriptionLocalized?: Record<string, string | undefined>;
   }
 ): Promise<void> => {
-  const updates: string[] = [];
-  const values: unknown[] = [];
-  if ("title" in patch && patch.title !== undefined) {
-    updates.push("title = ?");
-    values.push(patch.title);
+  // Verify the row exists + belongs to this source; matches the
+  // loadSavedFilter check so updates can't drift across sources.
+  await loadSavedFilter(sourceGalleryId, id);
+  // Canonical title / description are gallery columns.
+  if (patch.title !== undefined || patch.description !== undefined) {
+    const galleryPatch: GalleryInput = {};
+    if (patch.title !== undefined) galleryPatch.title = patch.title;
+    if (patch.description !== undefined)
+      galleryPatch.description = patch.description;
+    const { query, values } = SCHEMA.gallery.buildUpdateByIdQuery(galleryPatch);
+    if (query && values) {
+      db.prepare(query).run([...values, id]);
+    }
   }
-  if ("description" in patch && patch.description !== undefined) {
-    updates.push("description = ?");
-    values.push(patch.description);
-  }
-  if ("definition" in patch && patch.definition !== undefined) {
-    updates.push("definition = ?");
-    values.push(JSON.stringify(patch.definition));
-  }
-  if ("ordinal" in patch && patch.ordinal !== undefined) {
-    updates.push("ordinal = ?");
-    values.push(patch.ordinal);
-  }
-  if (updates.length > 0) {
+  if (patch.definition !== undefined) {
     db.prepare(
-      `UPDATE saved_filter SET ${updates.join(", ")} WHERE gallery_id = ? AND id = ?`
-    ).run(...values, galleryId, id);
+      "UPDATE gallery_saved_filter SET definition = ? WHERE gallery_id = ?"
+    ).run(JSON.stringify(patch.definition), id);
   }
-  applyLocalizedPatch(
-    galleryId,
-    id,
-    patch.titleLocalized,
-    patch.descriptionLocalized
-  );
+  // Localized overlays via the gallery path.
+  const perLang = new Map<string, { title?: string | null; description?: string | null }>();
+  const merge = (
+    map: Record<string, string | undefined> | undefined,
+    field: "title" | "description"
+  ) => {
+    if (!map) return;
+    for (const [lang, value] of Object.entries(map)) {
+      if (value === undefined) continue;
+      const entry = perLang.get(lang) ?? {};
+      entry[field] = value === "" ? null : value;
+      perLang.set(lang, entry);
+    }
+  };
+  merge(patch.titleLocalized, "title");
+  merge(patch.descriptionLocalized, "description");
+  for (const [lang, fields] of perLang) {
+    upsertGalleryLocalizedFields(id, lang, fields);
+  }
 };
 const deleteSavedFilter = async (
-  galleryId: string,
+  sourceGalleryId: string,
   id: string
 ): Promise<void> => {
-  db.prepare(
-    "DELETE FROM saved_filter WHERE gallery_id = ? AND id = ?"
-  ).run(galleryId, id);
+  // ON DELETE CASCADE on gallery_saved_filter + gallery_localized
+  // tears down the side rows when the gallery goes.
+  await loadSavedFilter(sourceGalleryId, id);
+  db.prepare("DELETE FROM gallery WHERE id = ?").run(id);
 };
 
 const loadGalleries = async () => {
@@ -782,10 +866,12 @@ const loadGalleries = async () => {
     .prepare(SCHEMA.gallery.buildSelectQuery())
     .all() as GalleryRow[];
   const sourcesByGallery = loadAllVirtualGalleries();
+  const savedFiltersByGallery = loadAllGallerySavedFilters();
   const localizedByGallery = loadGalleryLocalizedFor(rows.map((r) => r.id));
   return rows
     .map((row) => SCHEMA.gallery.mapRow(row, localizedByGallery.get(row.id)))
-    .map((g) => decorateGalleryWithSources(g, sourcesByGallery));
+    .map((g) => decorateGalleryWithSources(g, sourcesByGallery))
+    .map((g) => decorateGalleryWithSavedFilter(g, savedFiltersByGallery));
 };
 const createGallery = async (gallery: Gallery) => {
   db.prepare(SCHEMA.gallery.buildCreateQuery()).run(
@@ -820,9 +906,29 @@ const loadGallery = async (galleryId: string) => {
   const localizedRows = db
     .prepare("SELECT * FROM gallery_localized WHERE gallery_id = ?")
     .all(galleryId) as GalleryLocalizedRow[];
-  const base = SCHEMA.gallery.mapRow(row, localizedRows);
-  const sources = loadVirtualGallerySources(galleryId);
-  return sources === undefined ? base : { ...base, sources };
+  let gallery = SCHEMA.gallery.mapRow(row, localizedRows);
+  if (gallery.type === "hybrid") {
+    const sources = loadVirtualGallerySources(galleryId);
+    if (sources !== undefined) gallery = { ...gallery, sources };
+  } else if (gallery.type === "saved_filter") {
+    const sfRow = loadGallerySavedFilterRow(galleryId);
+    if (sfRow) {
+      let definition: Record<string, unknown> = {};
+      try {
+        definition = JSON.parse(sfRow.definition) as Record<string, unknown>;
+      } catch {
+        // Stale / malformed JSON — fall through to empty definition.
+      }
+      gallery = {
+        ...gallery,
+        savedFilter: {
+          sourceGalleryId: sfRow.source_gallery_id,
+          definition,
+        },
+      };
+    }
+  }
+  return gallery;
 };
 const updateGallery = async (galleryId: string, gallery: GalleryInput) => {
   const { query, values } = SCHEMA.gallery.buildUpdateByIdQuery(gallery);
@@ -881,25 +987,25 @@ const deleteGallery = async (galleryId: string) =>
 
 const loadGalleryPhotos = async (galleryId: string, lang?: string) => {
   const schema = SCHEMA.photo;
-  const sources = resolveGallerySources(galleryId);
-  if (sources.length === 0) return [];
-  // Virtual galleries (#22) widen the gallery_id check from `= ?`
+  const ref = resolveGalleryRef(galleryId);
+  if (ref.sources.length === 0) return [];
+  // Hybrid galleries (#22) widen the gallery_id check from `= ?`
   // to `IN (?, ?, …)`. Real galleries resolve to `[galleryId]`,
-  // producing the same single-id IN-clause — equivalent to the
-  // previous `gallery_id = ?` behaviour. DEDUPLICATION is already
-  // implicit in the photo `id IN (...)` outer membership: each
-  // photo row appears at most once in the result.
-  const placeholders = sources.map(() => "?").join(", ");
+  // producing the same single-id IN-clause. Saved-filter galleries
+  // resolve to `[source_gallery_id]` + a baseline applied below in
+  // JS — the SQL load is identical to a real source.
+  const placeholders = ref.sources.map(() => "?").join(", ");
   const stmt = db.prepare(
     schema.buildSelectQuery([
       `id IN (SELECT photo_id FROM gallery_photo WHERE gallery_id IN (${placeholders}))`,
     ])
   );
-  const rows = stmt.all(...sources) as PhotoRow[];
+  const rows = stmt.all(...ref.sources) as PhotoRow[];
   const localized = loadLocalizedFor(rows.map((r) => r.id));
-  return rows.map((row, index) =>
+  const photos = rows.map((row, index) =>
     schema.mapRow(row, index, localized.get(row.id), lang)
   );
+  return applyBaseline(photos, ref);
 };
 const linkGalleryPhoto = async (
   galleryIds: string[],
@@ -1129,26 +1235,30 @@ const loadGalleryPhoto = async (
   lang?: string
 ) => {
   const schema = SCHEMA.photo;
-  const sources = resolveGallerySources(galleryId);
-  if (sources.length === 0) throw new NotFoundError();
-  // Virtual gallery aware (#22): widen membership check to the
-  // resolved source set. Same SQL shape — IN (?, ?, …) instead of
-  // = ?. The photo `id` predicate still pins to a single row.
-  const placeholders = sources.map(() => "?").join(", ");
+  const ref = resolveGalleryRef(galleryId);
+  if (ref.sources.length === 0) throw new NotFoundError();
+  const placeholders = ref.sources.map(() => "?").join(", ");
   const stmt = db.prepare(
     schema.buildSelectQuery([
       `id IN (SELECT photo_id FROM gallery_photo WHERE gallery_id IN (${placeholders}))`,
       "id = ?",
     ])
   );
-  const rows = stmt.all(...sources, photoId) as PhotoRow[];
+  const rows = stmt.all(...ref.sources, photoId) as PhotoRow[];
   if (rows.length === 0) {
     throw new NotFoundError();
   }
   const localizedRows = db
     .prepare("SELECT * FROM photo_localized WHERE photo_id = ?")
     .all(photoId) as PhotoLocalizedRow[];
-  return schema.mapRow(rows[0], 0, localizedRows, lang);
+  const photo = schema.mapRow(rows[0], 0, localizedRows, lang);
+  // Saved-filter galleries: a photo that's in the source but
+  // excluded by the baseline reads as NotFound on the saved filter,
+  // matching how the photo list behaves.
+  if (!photoPassesBaseline(photo, ref)) {
+    throw new NotFoundError();
+  }
+  return photo;
 };
 const unlinkGalleryPhoto = async (galleryId: string, photoId: string) => {
   db.prepare(SCHEMA.galleryPhoto.buildDeleteByIdQuery()).run([
@@ -1271,23 +1381,27 @@ const loadGalleryPhotoByOriginalFilename = async (
   lang?: string
 ) => {
   const schema = SCHEMA.photo;
-  const sources = resolveGallerySources(galleryId);
-  if (sources.length === 0) throw new NotFoundError();
-  const placeholders = sources.map(() => "?").join(", ");
+  const ref = resolveGalleryRef(galleryId);
+  if (ref.sources.length === 0) throw new NotFoundError();
+  const placeholders = ref.sources.map(() => "?").join(", ");
   const stmt = db.prepare(
     schema.buildSelectQuery([
       `id IN (SELECT photo_id FROM gallery_photo WHERE gallery_id IN (${placeholders}))`,
       "original_filename = ? COLLATE NOCASE",
     ])
   );
-  const rows = stmt.all(...sources, originalFilename) as PhotoRow[];
+  const rows = stmt.all(...ref.sources, originalFilename) as PhotoRow[];
   if (rows.length === 0) {
     throw new NotFoundError();
   }
   const localizedRows = db
     .prepare("SELECT * FROM photo_localized WHERE photo_id = ?")
     .all(rows[0].id) as PhotoLocalizedRow[];
-  return schema.mapRow(rows[0], 0, localizedRows, lang);
+  const photo = schema.mapRow(rows[0], 0, localizedRows, lang);
+  if (!photoPassesBaseline(photo, ref)) {
+    throw new NotFoundError();
+  }
+  return photo;
 };
 // Photo rows with no gallery_photo link — useful for `bin/photo.ts audit`.
 // The SPA doesn't surface orphan photos anywhere; they're a data-drift

--- a/server/db/sqlite3/migrations/024_saved_filter_as_gallery.sql
+++ b/server/db/sqlite3/migrations/024_saved_filter_as_gallery.sql
@@ -1,0 +1,77 @@
+-- Collapse saved filters into the gallery namespace as a third kind
+-- of gallery, alongside real and hybrid. A saved-filter gallery has
+-- one source gallery + a JSON definition (filter + dateRange); the
+-- read path resolves the gallery to its source's photos with the
+-- definition merged into the request. Browsing, stats, ACL,
+-- localization and the picker all reuse the gallery code paths.
+--
+-- Schema changes:
+--
+--   - `gallery.type` enum: `real` | `hybrid` | `saved_filter`. Existing
+--     hybrids (rows with virtual_gallery_source entries) are stamped
+--     `hybrid`; everything else stays `real`. The enum makes the kind
+--     explicit, avoids a JOIN to dispatch in the read path, and lets
+--     future kinds slot in.
+--
+--   - `gallery_saved_filter` side table holds the source pointer and
+--     the definition blob, keyed by gallery_id. Cascade-delete on the
+--     gallery row removes the side row. The source FK has no cascade
+--     — deleting a real gallery that's referenced as a saved-filter
+--     source is left as a sanity error rather than silently nuking the
+--     saved-filter gallery.
+--
+-- Data move:
+--
+--   - Each pre-existing `saved_filter` row becomes a gallery row
+--     (id = saved_filter.id, title/description copied, default_language
+--     inherited from source) plus a `gallery_saved_filter` row carrying
+--     source + definition. Per-lang overlays move from
+--     `saved_filter_localized` into `gallery_localized`.
+--
+--   - Globally-unique ids: the old `(gallery_id, id)` PK on
+--     saved_filter allowed the same filter id across different source
+--     galleries. The new shape requires a globally unique id (it's a
+--     gallery id now). If duplicates exist in the wild, this migration
+--     fails at the INSERT INTO gallery step on the duplicate row —
+--     surface that loudly rather than silently renaming.
+--
+-- After the move both old tables are dropped.
+
+-- Type enum: column-level CHECK enforces the allowed set without a
+-- separate trigger / index. DEFAULT 'real' so the ALTER works against
+-- existing rows.
+ALTER TABLE gallery ADD COLUMN type TEXT NOT NULL DEFAULT 'real'
+  CHECK (type IN ('real', 'hybrid', 'saved_filter'));
+
+UPDATE gallery SET type = 'hybrid'
+WHERE id IN (SELECT DISTINCT gallery_id FROM virtual_gallery_source);
+
+CREATE TABLE gallery_saved_filter (
+  gallery_id        TEXT PRIMARY KEY REFERENCES gallery(id) ON DELETE CASCADE,
+  source_gallery_id TEXT NOT NULL REFERENCES gallery(id),
+  definition        TEXT NOT NULL
+);
+
+-- Promote each saved_filter into a gallery row. default_language is
+-- inherited from the source so the canonical title/description sit in
+-- the same language as the source.
+INSERT INTO gallery (id, title, description, default_language, type)
+SELECT
+  sf.id,
+  sf.title,
+  sf.description,
+  g.default_language,
+  'saved_filter'
+FROM saved_filter sf
+JOIN gallery g ON g.id = sf.gallery_id;
+
+INSERT INTO gallery_saved_filter (gallery_id, source_gallery_id, definition)
+SELECT id, gallery_id, definition FROM saved_filter;
+
+INSERT INTO gallery_localized (gallery_id, lang, title, description)
+SELECT filter_id, lang, title, description FROM saved_filter_localized;
+
+DROP TABLE saved_filter_localized;
+DROP TABLE saved_filter;
+
+UPDATE meta SET value='24' WHERE key='schema_version';

--- a/server/db/sqlite3/schema.ts
+++ b/server/db/sqlite3/schema.ts
@@ -44,6 +44,13 @@ export interface GroupGalleryRow {
   is_editor: number;
   hide_map: number | null;
 }
+// Three flavours of gallery row. `real` rows have photos linked via
+// `gallery_photo`; `hybrid` rows have sources in `virtual_gallery_source`
+// and union those sources' photos; `saved_filter` rows have a single
+// source + a stored filter in `gallery_saved_filter`, presented to
+// readers as a narrowed view of the source.
+export type GalleryType = "real" | "hybrid" | "saved_filter";
+
 export interface GalleryRow {
   id: string;
   title: string;
@@ -61,6 +68,7 @@ export interface GalleryRow {
   // from `.env DEFAULT_LANGUAGE` (server create path) or 'en' as
   // the column default.
   default_language: string;
+  type: GalleryType;
 }
 export interface GalleryLocalizedRow {
   gallery_id: string;
@@ -159,47 +167,50 @@ export interface Gallery {
   // Canonical fields above stay the universal fallback.
   titleLocalized?: Record<string, string>;
   descriptionLocalized?: Record<string, string>;
-  // Virtual gallery sources (#22). Undefined for real galleries;
-  // populated array of source gallery IDs for a virtual gallery
-  // whose contents are the union of those sources' photos.
+  // Discriminates how the gallery's photos are resolved at read
+  // time. See `GalleryType`.
+  type: GalleryType;
+  // Hybrid galleries only: source gallery IDs whose photos union
+  // into this one. Undefined for real and saved-filter galleries.
   sources?: string[];
+  // Saved-filter galleries only: source gallery + the stored
+  // baseline filter applied on top of the source's photos. The
+  // public read path merges this into incoming /query / /counts
+  // bodies (filter union per category, dateRange intersection).
+  // Undefined for real and hybrid galleries.
+  savedFilter?: {
+    sourceGalleryId: string;
+    definition: Record<string, unknown>;
+  };
 }
 export interface VirtualGallerySourceRow {
   gallery_id: string;
   source_id: string;
   ordinal: number;
 }
-export interface SavedFilterRow {
-  id: string;
+// Side table for saved-filter galleries. Storage shape only — the
+// app layer projects this onto `Gallery.savedFilter` and exposes the
+// admin DTO `SavedFilter` below.
+export interface GallerySavedFilterRow {
   gallery_id: string;
-  title: string;
-  description: string;
-  // JSON string — parsed into `SavedFilter.definition` by mapRow.
-  // Wire shape: `{ filter?: FilterShape, dateRange?: DateRange }`.
+  source_gallery_id: string;
+  // JSON string. Wire shape: `{ filter?: FilterShape, dateRange?: DateRange }`.
   definition: string;
-  ordinal: number;
 }
-export interface SavedFilterLocalizedRow {
-  gallery_id: string;
-  filter_id: string;
-  lang: string;
-  title: string | null;
-  description: string | null;
-}
-// App-side shape of a saved filter row. `definition` is parsed
-// from the stored JSON; the controller / client passes it back
-// verbatim as the body of `/query` / `/counts` / `/neighbors`
-// when applying the filter. `*Localized` mirror the gallery
-// localization shape — empty `{}` when no overlays exist.
+// Admin / public DTO for a saved-filter gallery. Carries the
+// gallery's identifying fields plus the source pointer and parsed
+// definition — what /galleries/:gallery/filters endpoints accept
+// and return. Title / description / *Localized are projected from
+// the underlying gallery row + gallery_localized; `sourceGalleryId`
+// from gallery_saved_filter.
 export interface SavedFilter {
   id: string;
-  galleryId: string;
+  sourceGalleryId: string;
   title: string;
   description: string;
   titleLocalized: Record<string, string>;
   descriptionLocalized: Record<string, string>;
   definition: Record<string, unknown>;
-  ordinal: number;
 }
 export interface GalleryPhoto {
   galleryId: string;
@@ -455,6 +466,7 @@ export default () => {
         defaultLanguage: row.default_language || "en",
         titleLocalized: buildLocalizedMap(localized, "title"),
         descriptionLocalized: buildLocalizedMap(localized, "description"),
+        type: row.type ?? "real",
       }),
       mapInsert: (gallery: Gallery): unknown[] => [
         gallery.id,
@@ -468,6 +480,7 @@ export default () => {
         gallery.initialView,
         gallery.hostname,
         gallery.defaultLanguage || "en",
+        gallery.type ?? "real",
       ],
 
       buildCreateQuery: () => buildCreateQuery(SCHEMA.gallery),
@@ -749,6 +762,7 @@ const galleryMapToRow = (
   if ("hostname" in gallery) result.hostname = gallery.hostname;
   if ("defaultLanguage" in gallery)
     result.default_language = gallery.defaultLanguage;
+  if ("type" in gallery) result.type = gallery.type;
   return result;
 };
 
@@ -930,10 +944,18 @@ const SCHEMA = {
       "initial_view",
       "hostname",
       "default_language",
+      "type",
     ],
     primaryKey: ["id"],
     order: ["id ASC"],
     mapToRow: galleryMapToRow as (data: Record<string, unknown>) => Record<string, unknown>,
+  },
+  gallerySavedFilter: {
+    table: "gallery_saved_filter",
+    columns: ["gallery_id", "source_gallery_id", "definition"],
+    primaryKey: ["gallery_id"],
+    order: ["gallery_id ASC"],
+    mapToRow: (): Record<string, unknown> => ({}),
   },
   galleryPhoto: {
     table: "gallery_photo",

--- a/server/lib/authorizer.ts
+++ b/server/lib/authorizer.ts
@@ -49,34 +49,67 @@ const authorizeAdmin = async (userId: string): Promise<void> => {
 // is now strictly admin.
 const authorizeView = authorizeAdmin;
 
+// Saved-filter pseudo-galleries (#285) inherit view + editor access
+// from their source gallery: if the user can view / edit the source,
+// they can view / edit the saved filter. A direct grant on the saved
+// filter extends access (e.g., expose a slice to a user who has no
+// rights on the source) but never narrows — having source access
+// always passes. Real and hybrid galleries take the direct grant
+// check only.
+const loadSourceFor = async (
+  galleryId: string
+): Promise<string | undefined> => {
+  try {
+    const gallery = (await db.loadGallery(galleryId)) as {
+      type?: string;
+      savedFilter?: { sourceGalleryId: string };
+    };
+    if (gallery.type === "saved_filter" && gallery.savedFilter) {
+      return gallery.savedFilter.sourceGalleryId;
+    }
+  } catch {
+    // Missing gallery falls through to direct-check semantics; the
+    // caller's resolve() will throw NotFound / AccessError for it.
+  }
+  return undefined;
+};
+
 const authorizeGalleryView = async (
   userId: string,
   galleryId: string
 ): Promise<string> => {
-  const { hasAccess } = await resolve(userId, galleryId);
-  if (!hasAccess) {
-    throw new AccessError(undefined, { userId, galleryId, required: "view" });
+  const direct = await resolve(userId, galleryId);
+  if (direct.hasAccess) return galleryId;
+  const source = await loadSourceFor(galleryId);
+  if (source !== undefined) {
+    const inherited = await resolve(userId, source);
+    if (inherited.hasAccess) return galleryId;
   }
-  return galleryId;
+  throw new AccessError(undefined, { userId, galleryId, required: "view" });
 };
 
 // Gallery-editor tier. Backed by the `is_editor` flag on
 // `user_gallery` / `group_gallery`. Global admins implicitly
-// pass — they can do everything an editor can.
+// pass — they can do everything an editor can. Saved-filter
+// galleries inherit editor from their source on the same
+// extend-never-narrow rule as view.
 const authorizeGalleryEditor = async (
   userId: string,
   galleryId: string
 ): Promise<string> => {
   if (await isGlobalAdmin(userId)) return galleryId;
-  const { isEditor } = await resolve(userId, galleryId);
-  if (!isEditor) {
-    throw new AccessError(undefined, {
-      userId,
-      galleryId,
-      required: "gallery-editor",
-    });
+  const direct = await resolve(userId, galleryId);
+  if (direct.isEditor) return galleryId;
+  const source = await loadSourceFor(galleryId);
+  if (source !== undefined) {
+    const inherited = await resolve(userId, source);
+    if (inherited.isEditor) return galleryId;
   }
-  return galleryId;
+  throw new AccessError(undefined, {
+    userId,
+    galleryId,
+    required: "gallery-editor",
+  });
 };
 
 // Photo-level editor check: the user is allowed to edit the

--- a/server/models/saved-filter.ts
+++ b/server/models/saved-filter.ts
@@ -16,24 +16,28 @@ export default () => ({
 
 const init = async () => {};
 
-const getSavedFilters = async (galleryId: string): Promise<SavedFilter[]> => {
-  logger.debug("Listing saved filters", { galleryId });
-  // FK ON DELETE CASCADE means rows only exist for existing galleries
-  // — but the gallery may still be a virtual gallery whose `sources`
-  // resolve at /query time; we don't try to constrain that here.
-  return await db.loadSavedFilters(galleryId);
+// `sourceGalleryId` is the gallery the saved filter is anchored to —
+// the source whose photos it narrows. The saved filter's own id is a
+// gallery id in its own right (unified namespace; collision-checked
+// at create).
+
+const getSavedFilters = async (
+  sourceGalleryId: string
+): Promise<SavedFilter[]> => {
+  logger.debug("Listing saved filters", { sourceGalleryId });
+  return await db.loadSavedFilters(sourceGalleryId);
 };
 
 const getSavedFilter = async (
-  galleryId: string,
+  sourceGalleryId: string,
   id: string
 ): Promise<SavedFilter> => {
-  logger.debug("Loading saved filter", { galleryId, id });
-  return await db.loadSavedFilter(galleryId, id);
+  logger.debug("Loading saved filter", { sourceGalleryId, id });
+  return await db.loadSavedFilter(sourceGalleryId, id);
 };
 
 const createSavedFilter = async (
-  galleryId: string,
+  sourceGalleryId: string,
   body: {
     id: string;
     title?: string;
@@ -41,31 +45,25 @@ const createSavedFilter = async (
     titleLocalized?: Record<string, string>;
     descriptionLocalized?: Record<string, string>;
     definition: Record<string, unknown>;
-    ordinal?: number;
   }
 ): Promise<void> => {
   assertSlugId(body.id);
-  logger.debug("Creating saved filter", { galleryId, id: body.id });
-  // The gallery must exist — FK would reject otherwise, but surface
-  // a cleaner error than a SQLITE_CONSTRAINT for the API consumer.
+  logger.debug("Creating saved filter", { sourceGalleryId, id: body.id });
+  // Source gallery must exist. Surface as ValidationError rather than
+  // letting the gallery_saved_filter FK throw a SQLITE_CONSTRAINT.
   try {
-    await db.loadGallery(galleryId);
+    await db.loadGallery(sourceGalleryId);
   } catch (err) {
     if (err instanceof NotFoundError) {
       throw new ValidationError("Source gallery does not exist", {
-        galleryId,
+        sourceGalleryId,
       });
     }
     throw err;
   }
-  // Saved filters surface alongside real galleries in the public
-  // viewer's title-bar selector — id collisions across the two
-  // namespaces would shadow one another. Reject if any gallery
-  // (including this one's source) carries the proposed id. The
-  // (gallery_id, id) primary key on saved_filter still allows
-  // cross-gallery collisions between saved filters, which is
-  // fine (a filter named "spring" can exist on both gallery A
-  // and gallery B — they're addressed at different URLs).
+  // The saved filter id IS a gallery id in the unified namespace —
+  // reject if anything (real / hybrid / other saved-filter gallery)
+  // already owns the id.
   try {
     await db.loadGallery(body.id);
     throw new ValidationError(
@@ -75,49 +73,37 @@ const createSavedFilter = async (
   } catch (err) {
     if (!(err instanceof NotFoundError)) throw err;
   }
-  // Reject duplicate id within the same gallery up-front for the
-  // same friendlier-error reason.
-  try {
-    await db.loadSavedFilter(galleryId, body.id);
-    throw new ValidationError(
-      "Saved filter with this id already exists in this gallery",
-      { galleryId, id: body.id }
-    );
-  } catch (err) {
-    if (!(err instanceof NotFoundError)) throw err;
-  }
   await db.createSavedFilter({
     id: body.id,
-    galleryId,
+    sourceGalleryId,
     title: body.title ?? "",
     description: body.description ?? "",
     titleLocalized: body.titleLocalized ?? {},
     descriptionLocalized: body.descriptionLocalized ?? {},
     definition: body.definition,
-    ordinal: body.ordinal ?? 0,
   });
 };
 
 const updateSavedFilter = async (
-  galleryId: string,
+  sourceGalleryId: string,
   id: string,
   patch: Partial<
-    Pick<SavedFilter, "title" | "description" | "definition" | "ordinal">
+    Pick<SavedFilter, "title" | "description" | "definition">
   > & {
     titleLocalized?: Record<string, string | undefined>;
     descriptionLocalized?: Record<string, string | undefined>;
   }
 ): Promise<void> => {
-  logger.debug("Updating saved filter", { galleryId, id });
-  await db.loadSavedFilter(galleryId, id);
-  await db.updateSavedFilter(galleryId, id, patch);
+  logger.debug("Updating saved filter", { sourceGalleryId, id });
+  await db.loadSavedFilter(sourceGalleryId, id);
+  await db.updateSavedFilter(sourceGalleryId, id, patch);
 };
 
 const deleteSavedFilter = async (
-  galleryId: string,
+  sourceGalleryId: string,
   id: string
 ): Promise<void> => {
-  logger.debug("Deleting saved filter", { galleryId, id });
-  await db.loadSavedFilter(galleryId, id);
-  await db.deleteSavedFilter(galleryId, id);
+  logger.debug("Deleting saved filter", { sourceGalleryId, id });
+  await db.loadSavedFilter(sourceGalleryId, id);
+  await db.deleteSavedFilter(sourceGalleryId, id);
 };

--- a/server/models/saved-filter.ts
+++ b/server/models/saved-filter.ts
@@ -49,10 +49,16 @@ const createSavedFilter = async (
 ): Promise<void> => {
   assertSlugId(body.id);
   logger.debug("Creating saved filter", { sourceGalleryId, id: body.id });
-  // Source gallery must exist. Surface as ValidationError rather than
-  // letting the gallery_saved_filter FK throw a SQLITE_CONSTRAINT.
+  // Source gallery must exist + be a real gallery. Mirrors the hybrid
+  // gallery's "sources point at real galleries only" rule from #22 /
+  // migration 020 — chaining saved filters off hybrids or other saved
+  // filters runs into the same composition / cycle issues. The
+  // resolver in the driver doesn't recurse, so the query path would
+  // return zero photos for non-real sources anyway; reject up-front
+  // with a clear error instead.
+  let source: { type?: string };
   try {
-    await db.loadGallery(sourceGalleryId);
+    source = (await db.loadGallery(sourceGalleryId)) as { type?: string };
   } catch (err) {
     if (err instanceof NotFoundError) {
       throw new ValidationError("Source gallery does not exist", {
@@ -60,6 +66,12 @@ const createSavedFilter = async (
       });
     }
     throw err;
+  }
+  if ((source.type ?? "real") !== "real") {
+    throw new ValidationError(
+      "Saved filters can only be attached to real galleries",
+      { sourceGalleryId, sourceType: source.type ?? "real" }
+    );
   }
   // The saved filter id IS a gallery id in the unified namespace —
   // reject if anything (real / hybrid / other saved-filter gallery)

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1092,19 +1092,18 @@
                     "type": "object",
                     "required": [
                       "id",
-                      "galleryId",
+                      "sourceGalleryId",
                       "title",
                       "description",
                       "titleLocalized",
                       "descriptionLocalized",
-                      "definition",
-                      "ordinal"
+                      "definition"
                     ],
                     "properties": {
                       "id": {
                         "type": "string"
                       },
-                      "galleryId": {
+                      "sourceGalleryId": {
                         "type": "string"
                       },
                       "title": {
@@ -1169,9 +1168,6 @@
                           }
                         },
                         "additionalProperties": true
-                      },
-                      "ordinal": {
-                        "type": "integer"
                       }
                     }
                   }
@@ -1264,9 +1260,6 @@
                       }
                     },
                     "additionalProperties": true
-                  },
-                  "ordinal": {
-                    "type": "integer"
                   }
                 },
                 "additionalProperties": false
@@ -1329,19 +1322,18 @@
                   "type": "object",
                   "required": [
                     "id",
-                    "galleryId",
+                    "sourceGalleryId",
                     "title",
                     "description",
                     "titleLocalized",
                     "descriptionLocalized",
-                    "definition",
-                    "ordinal"
+                    "definition"
                   ],
                   "properties": {
                     "id": {
                       "type": "string"
                     },
-                    "galleryId": {
+                    "sourceGalleryId": {
                       "type": "string"
                     },
                     "title": {
@@ -1406,9 +1398,6 @@
                         }
                       },
                       "additionalProperties": true
-                    },
-                    "ordinal": {
-                      "type": "integer"
                     }
                   }
                 }
@@ -1491,9 +1480,6 @@
                       }
                     },
                     "additionalProperties": true
-                  },
-                  "ordinal": {
-                    "type": "integer"
                   }
                 },
                 "additionalProperties": false

--- a/server/tests/api/saved-filters.test.ts
+++ b/server/tests/api/saved-filters.test.ts
@@ -142,6 +142,28 @@ describe("As admin", () => {
     await create(token, "no-such-gallery", { id: "x", definition: {} }, 422);
   });
 
+  test("source gallery must be type='real' (rejects hybrid)", async () => {
+    // Promote gallery1 to hybrid by adding it a source. Then attempt
+    // to attach a saved filter to it — should 422.
+    await api
+      .put("/api/v1/galleries/gallery1")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ sources: ["gallery2"] })
+      .expect(204);
+    await create(token, "gallery1", { id: "x", definition: {} }, 422);
+  });
+
+  test("source gallery must be type='real' (rejects saved_filter)", async () => {
+    // Create a saved filter on gallery1 (a real gallery), then try to
+    // chain another saved filter off it. Chained saved filters are
+    // rejected by the same "real source only" rule.
+    await create(token, "gallery1", {
+      id: "first-sf",
+      definition: { filter: {} },
+    });
+    await create(token, "first-sf", { id: "chained", definition: {} }, 422);
+  });
+
   test("id can't collide with an existing gallery id", async () => {
     // gallery2 exists in the fixture; using its id as a filter id
     // would shadow it in the public viewer's title-bar selector.

--- a/server/tests/api/saved-filters.test.ts
+++ b/server/tests/api/saved-filters.test.ts
@@ -172,6 +172,64 @@ describe("As admin", () => {
   });
 });
 
+describe("Public viewer (saved filter as pseudo-gallery)", () => {
+  let token: string;
+  beforeEach(async () => {
+    token = await loginUser(api, "admin");
+  });
+
+  test("/api/v1/galleries returns saved-filter galleries alongside real ones", async () => {
+    await create(token, "gallery1", {
+      id: "japan-only",
+      title: "Japan only",
+      definition: { filter: { general: { country: ["jp"] } } },
+    });
+    const listed = await api
+      .get("/api/v1/galleries")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    const ids = (listed.body as Array<{ id: string; type?: string }>).map(
+      (g) => g.id
+    );
+    expect(ids).toContain("japan-only");
+    const found = (
+      listed.body as Array<{ id: string; type?: string }>
+    ).find((g) => g.id === "japan-only");
+    expect(found?.type).toBe("saved_filter");
+  });
+
+  test("GET /galleries/<sf-id>/photos returns source photos narrowed by baseline", async () => {
+    // gallery1's photos: gallery1photo (country=jp), gallery12photo (country=nl)
+    // Baseline filter country=jp → only gallery1photo passes.
+    await create(token, "gallery1", {
+      id: "jp-on-gallery1",
+      definition: { filter: { general: { country: ["jp"] } } },
+    });
+    const res = await api
+      .get("/api/v1/gallery-photos/jp-on-gallery1")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    const ids = (res.body as Array<{ id: string }>).map((p) => p.id);
+    expect(ids).toEqual(["gallery1photo.jpg"]);
+  });
+
+  test("baseline dateRange intersects with the request body's range", async () => {
+    // Baseline restricts to 2018; an empty user filter on the saved
+    // filter id should yield exactly the 2018 photo.
+    await create(token, "gallery1", {
+      id: "year-2018",
+      definition: { dateRange: { from: "2018-01-01", to: "2018-12-31" } },
+    });
+    const res = await api
+      .post("/api/v1/gallery-photos/year-2018/query")
+      .set("Authorization", `Bearer ${token}`)
+      .send({})
+      .expect(200);
+    const ids = (res.body as Array<{ id: string }>).map((p) => p.id);
+    expect(ids).toEqual(["gallery1photo.jpg"]);
+  });
+});
+
 describe("ACL", () => {
   test("guest can list public-gallery saved filters but not mutate", async () => {
     // Seed a filter on gallery3 (the public `:guest`-readable one).

--- a/server/tests/api/saved-filters.test.ts
+++ b/server/tests/api/saved-filters.test.ts
@@ -87,13 +87,12 @@ describe("As admin", () => {
     expect(listed.body.length).toBe(1);
     expect(listed.body[0]).toMatchObject({
       id: "japan-2024",
-      galleryId: "gallery1",
+      sourceGalleryId: "gallery1",
       title: "Japan 2024",
       description: "Spring trip across Honshu",
       titleLocalized: {},
       descriptionLocalized: {},
       definition,
-      ordinal: 0,
     });
     const one = await get(token, "gallery1", "japan-2024");
     expect(one.body.id).toBe("japan-2024");

--- a/server/tests/db/sqlite3/gallery.test.ts
+++ b/server/tests/db/sqlite3/gallery.test.ts
@@ -30,6 +30,7 @@ describe("gallery CRUD", () => {
       theme: "blue",
       initialView: "month",
       hostname: "^sample\\.",
+      type: "real",
     });
     const row = (await driver.loadGallery("g-full")) as {
       title: string;

--- a/server/tests/db/sqlite3/helper.ts
+++ b/server/tests/db/sqlite3/helper.ts
@@ -35,5 +35,6 @@ export const mkGallery = (partial: Partial<Gallery> & { id: string }): Gallery =
   initialView: "",
   hostname: "",
   defaultLanguage: "en",
+  type: "real",
   ...partial,
 });

--- a/server/tests/db/sqlite3/meta.test.ts
+++ b/server/tests/db/sqlite3/meta.test.ts
@@ -15,7 +15,7 @@ describe("meta", () => {
   test("loadMetas returns the baseline migration seeds", async () => {
     const metas = (await driver.loadMetas()) as Array<Record<string, string>>;
     const merged = Object.assign({}, ...metas);
-    expect(merged.schema_version).toBe("23");
+    expect(merged.schema_version).toBe("24");
     expect(merged.instance_name).toBe("");
   });
 

--- a/server/tests/db/sqlite3/migrate.test.ts
+++ b/server/tests/db/sqlite3/migrate.test.ts
@@ -33,7 +33,7 @@ describe("migrate", () => {
   test("fresh DB runs every migration and lands at the highest version", () => {
     const db = open();
     migrate(db);
-    expect(schemaVersion(db)).toBe(23);
+    expect(schemaVersion(db)).toBe(24);
     expect(tableNames(db)).toEqual(
       expect.arrayContaining([
         "gallery",
@@ -115,7 +115,7 @@ describe("migrate", () => {
 
     migrate(db);
 
-    expect(schemaVersion(db)).toBe(23);
+    expect(schemaVersion(db)).toBe(24);
     expect(gallerPhotoFkRefs(db).sort()).toEqual(["gallery", "photo"]);
     const rows = db.prepare("SELECT * FROM gallery_photo").all();
     expect(rows).toEqual([{ gallery_id: "g1", photo_id: "p1" }]);

--- a/server/tests/db/sqlite3/schema.test.ts
+++ b/server/tests/db/sqlite3/schema.test.ts
@@ -161,10 +161,11 @@ describe("Gallery", () => {
     "initial_view",
     "hostname",
     "default_language",
+    "type",
   ].join(",");
   test("Build create query", () =>
     expect(schema.gallery.buildCreateQuery()).toBe(
-      `INSERT INTO gallery (${cols}) VALUES (?,?,?,?,?,?,?,?,?,?,?)`
+      `INSERT INTO gallery (${cols}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`
     ));
   test("Build select by id query", () =>
     expect(schema.gallery.buildSelectByIdQuery()).toBe(


### PR DESCRIPTION
## Summary

Saved filters were modelled as a sibling table (`saved_filter` + `saved_filter_localized`, FK'd to a source gallery, addressed at `/g/<source>/f/<filter-id>`). This PR collapses them into the gallery namespace as a third kind of gallery — `type='saved_filter'` — with a side table `gallery_saved_filter(gallery_id, source_gallery_id, definition)`. To the public viewer a saved filter now reads as just another gallery: it shows up in the picker, has a breadcrumb, browses months / photos / stats, and accepts user-pill filters layered on top of the server-side baseline. Operators still CRUD them under the source gallery's `/galleries/:gallery/filters` endpoints (admin UX stays put), but the resulting row lives in the unified id namespace.

## What changes

- Migration 024 adds `gallery.type` (`real` | `hybrid` | `saved_filter`) — stamps the existing virtual galleries to `hybrid`, creates `gallery_saved_filter`, moves saved-filter rows (and per-language overlays from `saved_filter_localized` into `gallery_localized`), drops the old tables.
- Driver: new `resolveGalleryRef(galleryId) → {sources, baseline}` is the single dispatch point for read paths. Real and hybrid keep current behaviour; saved-filter rows resolve to `[source]` + the stored baseline, applied in JS to `loadGalleryPhotos` / `loadGalleryPhoto` / `loadGalleryPhotoByOriginalFilename` (so single-photo lookups are also baseline-checked — a photo excluded by the saved filter reads as `NotFound` on it). `upsertVirtualGallery` / `deleteVirtualGallery` keep `gallery.type` in sync with `virtual_gallery_source` presence.
- Saved-filter CRUD writes to `gallery` + `gallery_saved_filter` + `gallery_localized` in one transaction. The model enforces unified-namespace uniqueness (no collision with any other gallery id) and source existence; controller/wire shape drops `ordinal` and renames `galleryId` → `sourceGalleryId`.
- Authorizer: `authorizeGalleryView` and `authorizeGalleryEditor` extend with "if the current gallery is a saved-filter pseudo-gallery and the user has no direct grant on it, fall through to the source gallery's grant." Direct rows on the saved filter still work (operator can expose a slice to a user without source access) but never narrow — source access always passes.
- `bin/gallery.ts filter` subcommands: drop `--ordinal`, pass `sourceGalleryId` to the driver.
- Server tests: `schema_version` bumped to 24; saved-filter DTO assertions updated; new tests for (1) saved-filter galleries appearing in `/api/v1/galleries`, (2) `/gallery-photos/<sf-id>` returning baseline-narrowed photos, (3) baseline dateRange intersecting with the query body. `gallery.test` + `helper.ts` carry `type: "real"` on test gallery constructions.
- Front-end: `services/saved-filters.ts` + `SavedFiltersSection.tsx` carry `sourceGalleryId` and drop the ordinal field; admin UX otherwise unchanged. OpenAPI dump + `react-app/src/lib/api-schema.ts` regenerated from the new schema. Public picker / Title selector picks saved-filter galleries up through the existing `/api/v1/galleries` list — no front-end wiring needed.

## What this replaces

A prior WIP slice on this branch attempted the sub-mode model (`/g/<g>/f/<f>` URL, sub-selector under the gallery crumb, a `useActiveFilter` hook that merged user pills with a separately-fetched saved filter). It was reverted before any commit — the abstraction didn't match the "behave like a normal gallery" intent and the URL didn't read like one in the picker.

## Test plan

- [x] `cd server && npm run typecheck && npm test && npm run lint` — 887 passing.
- [x] `cd react-app && npm run typecheck && npm test && npm run lint` — 983 passing.
- [ ] Operator dev DB needs a manual one-time apply of migration 024 if the prior 023 was already there (a follow-up note will land with the migration's commit body) — or wipe and re-seed.
- [ ] Smoke test: create a saved filter against gallery1, land on `/g/<sf-id>` in the public viewer, confirm only baseline-passing months / photos surface and that adding a user pill further narrows without revealing source photos outside the baseline.
- [ ] Smoke test: as a non-admin viewer with only source-gallery view access, confirm the saved filter is browseable (ACL inherit).
- [ ] Smoke test: as a non-admin viewer with only a direct grant on the saved-filter pseudo-gallery (no source access), confirm the saved filter is browseable (ACL extend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)