### PR TITLE
Release 0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.15] - 2026-06-11
+
 ### Server
 
 - `bin/instance.ts` positional is the instance directory, resolved via `path.resolve()` against cwd — `dev` and `./dev` both mean `<cwd>/dev`; `../sibling` and absolute paths resolve as expected. `--base` is gone (the positional itself encodes the parent). New `--name <name>` overrides the logical instance name (default: dir basename); honored on bootstrap and on re-runs (writes through to `INSTANCE_NAME` in `.env`). Part of #537.

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  0.14.0/                               #   so different instances can run different versions
+  0.15.0/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/0.14.0      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/0.15.0      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  display/  thumbnail/
@@ -136,7 +136,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.14.0
+V=0.15.0
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -151,7 +151,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.14.0/bin/instance.ts /var/photo-diary/dailybw
+/opt/photo-diary/0.15.0/bin/instance.ts /var/photo-diary/dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -183,7 +183,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.14.0/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
+/opt/photo-diary/0.15.0/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                                # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                                     # migration runner applies any schema bumps
@@ -412,7 +412,8 @@ End-to-end flow from a new JPG arriving on the host to it being browsable in the
 
 Active milestones on the way to 1.0, plus the far-out 2.0 direction. Each bullet links the GitHub milestone for live status.
 
-- [**0.15 — Composition + scale**](https://github.com/vlumi/photo-diary/milestone/15): the larger architectural shifts. Hybrid galleries (#22), DB drivers beyond SQLite (#265), content localization for photo metadata (#281), saved filters / sub-galleries (#285), per-language editing for place / title / description (#343), stats category evolution over time (#383), year view full Jan–Dec on wide screens (#399), Galleries section composes with the Filters sidebar (#446), audit residue after bulk regeocode (#485).
+- [**0.16 — Filter & viewing UX polish**](https://github.com/vlumi/photo-diary/milestone/16): range filters for continuous values beyond date (#264), edit-in-place filter pills (#342), map modal that survives prev/next navigation (#321), stats-chart bucket snapping (#549), filter widget full redesign (#560), saved-filter editor sharing the new filter-builder component (#563).
+- [**0.17 — Per-photo metadata + admin polish**](https://github.com/vlumi/photo-diary/milestone/17): per-photo visibility flag (#480), license metadata + download control (#263), runtime-overridable `.env` defaults from `/m/` (#513), viewport-sized rendition selection (#262), Finnish location-localization policy (#362), subdivision-name dataset (#366), audit revisit after bulk regeocode (#485), `bin/instance.ts` `--edit` mode + interactive prompts (#537), admin user bootstrap during instance creation (#557).
 - [**1.0 — Pre-release audits**](https://github.com/vlumi/photo-diary/milestone/4): test-coverage gap analysis (#194), frontend security audit (#217), end-to-end UI test suite (#261), documentation overhaul (#283), `bin/photo.ts` subcommand-surface tidy (#376).
 - [**2.0 — Thin server, cloud-native direction**](https://github.com/vlumi/photo-diary/milestone/18) *(direction-setting, far out)*: shape may change significantly. Originals leave the server and live client-side or in cold storage; the converter's sharp pipeline becomes a local uploader bundled from the admin UI; all DB ops route through the API (no direct backdoor); storage backends behind a vendor-agnostic interface so S3-compatible / CDN deployments are an option. Vision and sub-ticket breakdown in #469. Likely diverges from today's self-hosted-monolith shape enough that it may end up being a different product line.
 
@@ -461,6 +462,7 @@ After the hiatus, a burst of releases that modernized the stack, formalized the 
 - **0.12** (May 2026) — Geocoded location surfaces across the app: per-language city / state / country in the MetadataPanel, City + State filter categories, Stats Places + State topics, per-language city overlay JSON. Converter intake flows JSON sidecars + recursive subdirs. Beta-gated 35mm-equivalent focal length.
 - **0.13** (Jun 2026) — Admin frontend bundle. Full `/m/*` surface — dashboard, Photos grid with faceted filters + edit drawer + multi-select bulk actions + audit chips, Galleries CRUD, Users + Groups + Access pages — behind `user.is_admin`. Stats splits into `/s/` with a global stats page. Mutation API hardens with TypeBox-validated bodies + field-locked overrides; virtual-host scope narrows reads + writes to a bound gallery; ACL gains user groups. Theme picker becomes a swatch grid with six new built-in themes.
 - **0.14** (Jun 2026) — Admin UI polish. Slug-shaped ids, mutable `user.name` + renamed `group.name`, per-photo bulk Edit-fields modal, bulk Regeocode, dashboard audit-count tiles, filter-sidebar timeline strip with shift-range month picking, gallery-icon cropper, Inbox surface revamp, gallery-editor tier, `xx` sentinel for international waters. Mobile / small-screen pass: scrollable tables, dual pagers with 44px touch targets, Access table redesign, frosted-glass floating `BulkActions` bar, long-press + drag-to-range touch multi-select with edge auto-scroll.
+- **0.15** (Jun 2026) — Composition + scale. Hybrid galleries unioning multiple sources, saved filters as pseudo-galleries layered on a real source, per-language overlays for photo + gallery metadata, date-range filter on per-view + stats endpoints, stats category evolution over time. Public viewer goes lazy: per-view `/query` / `/counts` / `/neighbors` endpoints replace the full-array fetch, filter-values endpoints feed the pill universe. `bin/instance.ts` auto-cycles pm2 on upgrades, takes the positional as a path with `--name` for the logical name.
 
-See the [Roadmap](#roadmap) for what's in flight after 0.14.
+See the [Roadmap](#roadmap) for what's in flight after 0.15.
   

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.1"
   },
-  "version": "0.14.0"
+  "version": "0.15.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -66,5 +66,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.14.0"
+  "version": "0.15.0"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.14.0"
+    "version": "0.15.0"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -57,5 +57,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.14.0"
+  "version": "0.15.0"
 }


### PR DESCRIPTION
## Summary

Cuts 0.15. Bumps the version stamp across the four package.json files, regenerates the OpenAPI dump for the new `info.version`, retires `[Unreleased]` in the CHANGELOG as `[0.15] - 2026-06-11`, and reshuffles the README's Roadmap / Version History sections.

The themes that landed in 0.15 (per the new Version History entry):

- **Composition + scale.** Hybrid galleries unioning multiple sources, saved filters as pseudo-galleries layered on a real source, per-language overlays for photo + gallery metadata, date-range filter on per-view + stats endpoints, stats category evolution over time.
- **Public viewer goes lazy.** Per-view `/query` / `/counts` / `/neighbors` endpoints replace the full-array fetch; new gallery + global filter-values endpoints feed the pill universe.
- **Operator tooling.** `bin/instance.ts` auto-cycles pm2 on upgrades, takes the positional as a path with `--name` for the logical instance name; new `bin/meta.ts` script.

Milestone reorg captured in the README Roadmap section:

- 0.15 closed (18 issues shipped, 0 open) → moves out of Roadmap into Version History.
- 0.16 (Filter & viewing UX polish) and 0.17 (Per-photo metadata + admin polish) added to Roadmap as the next two active milestones.
- 1.0 audits and 2.0 thin-server direction unchanged.

## Test plan

- [x] `npm run typecheck && npm test && npm run lint` across all three subtrees (server: 889 / react: 983 / converter: green).
- [x] `npm run build` on react-app — clean.
- [x] Version strings consistent in all four `package.json` files.
- [x] OpenAPI dump regenerated; openapi.json `info.version: 0.15.0`.
- [x] README install / upgrade examples bumped from 0.14.0 to 0.15.0.
- [ ] After merge: tag `v0.15.0`, push, `gh release create` from the new CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)