### PR TITLE
Fix: null coerced to 0/false on upsert (hide_map + coordinates)

### DIFF
--- a/server/controllers/group-gallery-v1.ts
+++ b/server/controllers/group-gallery-v1.ts
@@ -3,6 +3,7 @@ import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import authorizerFactory from "../lib/authorizer.js";
 import { requireScopeMatches } from "../lib/host-scope.js";
+import { BooleanOrNull } from "../lib/schema-utils.js";
 import modelFactory from "../models/group-gallery.js";
 
 const authorizer = authorizerFactory();
@@ -33,7 +34,7 @@ const RowsResponse = Type.Array(RowResponse);
 const UpsertBody = Type.Object(
   {
     isEditor: Type.Boolean(),
-    hideMap: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
+    hideMap: Type.Optional(BooleanOrNull()),
   },
   { additionalProperties: false }
 );

--- a/server/controllers/photos-v1.ts
+++ b/server/controllers/photos-v1.ts
@@ -9,6 +9,7 @@ import {
   requireUnscoped,
 } from "../lib/host-scope.js";
 import { writeCoordSidecar } from "../lib/inbox-sidecar.js";
+import { NumberOrNull } from "../lib/schema-utils.js";
 import {
   coordsDiffer,
   mergeCoords,
@@ -67,15 +68,9 @@ const PhotoOverridesFields = {
               coordinates: Type.Optional(
                 Type.Object(
                   {
-                    latitude: Type.Optional(
-                      Type.Union([Type.Number(), Type.Null()])
-                    ),
-                    longitude: Type.Optional(
-                      Type.Union([Type.Number(), Type.Null()])
-                    ),
-                    altitude: Type.Optional(
-                      Type.Union([Type.Number(), Type.Null()])
-                    ),
+                    latitude: Type.Optional(NumberOrNull()),
+                    longitude: Type.Optional(NumberOrNull()),
+                    altitude: Type.Optional(NumberOrNull()),
                   },
                   { additionalProperties: false }
                 )

--- a/server/controllers/user-gallery-v1.ts
+++ b/server/controllers/user-gallery-v1.ts
@@ -3,6 +3,7 @@ import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import authorizerFactory from "../lib/authorizer.js";
 import { requireScopeMatches } from "../lib/host-scope.js";
+import { BooleanOrNull } from "../lib/schema-utils.js";
 import modelFactory from "../models/user-gallery.js";
 
 const authorizer = authorizerFactory();
@@ -33,7 +34,7 @@ const RowsResponse = Type.Array(RowResponse);
 const UpsertBody = Type.Object(
   {
     isEditor: Type.Boolean(),
-    hideMap: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
+    hideMap: Type.Optional(BooleanOrNull()),
   },
   { additionalProperties: false }
 );

--- a/server/lib/schema-utils.ts
+++ b/server/lib/schema-utils.ts
@@ -15,13 +15,16 @@ export const StringEnum = <T extends string>(values: readonly T[]) =>
   Type.Unsafe<T>({ type: "string", enum: [...values] });
 
 // Fastify's default Ajv config (`coerceTypes: 'array'`) silently
-// coerces `null` to `false` against `Type.Boolean()` — even inside a
-// `Type.Union([Type.Boolean(), Type.Null()])`, because Ajv coerces
-// before evaluating the union's alternatives. The JSON Schema we want
-// (a plain `type: ["boolean", "null"]`) sidesteps the coercion, but
-// TypeBox 1.x doesn't have a sugar for the multi-type form. Drop
-// straight to JSON Schema via `Type.Unsafe`. The TS-side type stays
-// `boolean | null`, so callers keep their type safety at the
-// destructure site.
+// coerces `null` to the union's non-null alternative — even inside
+// a `Type.Union([Type.X(), Type.Null()])`, because Ajv coerces
+// before evaluating the union's alternatives. `null` against
+// `Type.Boolean` becomes `false`, against `Type.Number` becomes
+// `0`, against `Type.String` becomes `""`. The JSON Schema we want
+// (a plain `type: ["X", "null"]`) sidesteps the coercion, but
+// TypeBox 1.x doesn't sugar the multi-type form. Drop straight to
+// JSON Schema via `Type.Unsafe`. The TS-side type stays
+// `T | null`, so callers keep type safety at the destructure site.
 export const BooleanOrNull = () =>
   Type.Unsafe<boolean | null>({ type: ["boolean", "null"] });
+export const NumberOrNull = () =>
+  Type.Unsafe<number | null>({ type: ["number", "null"] });

--- a/server/lib/schema-utils.ts
+++ b/server/lib/schema-utils.ts
@@ -13,3 +13,15 @@ import { Type } from "typebox";
 // site.
 export const StringEnum = <T extends string>(values: readonly T[]) =>
   Type.Unsafe<T>({ type: "string", enum: [...values] });
+
+// Fastify's default Ajv config (`coerceTypes: 'array'`) silently
+// coerces `null` to `false` against `Type.Boolean()` — even inside a
+// `Type.Union([Type.Boolean(), Type.Null()])`, because Ajv coerces
+// before evaluating the union's alternatives. The JSON Schema we want
+// (a plain `type: ["boolean", "null"]`) sidesteps the coercion, but
+// TypeBox 1.x doesn't have a sugar for the multi-type form. Drop
+// straight to JSON Schema via `Type.Unsafe`. The TS-side type stays
+// `boolean | null`, so callers keep their type safety at the
+// destructure site.
+export const BooleanOrNull = () =>
+  Type.Unsafe<boolean | null>({ type: ["boolean", "null"] });

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3354,13 +3354,9 @@
                     "type": "boolean"
                   },
                   "hideMap": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
+                    "type": [
+                      "boolean",
+                      "null"
                     ]
                   }
                 },
@@ -3861,13 +3857,9 @@
                     "type": "boolean"
                   },
                   "hideMap": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
+                    "type": [
+                      "boolean",
+                      "null"
                     ]
                   }
                 },

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1873,33 +1873,21 @@
                             "type": "object",
                             "properties": {
                               "latitude": {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "number",
+                                  "null"
                                 ]
                               },
                               "longitude": {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "number",
+                                  "null"
                                 ]
                               },
                               "altitude": {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "number",
+                                  "null"
                                 ]
                               }
                             },
@@ -2515,33 +2503,21 @@
                             "type": "object",
                             "properties": {
                               "latitude": {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "number",
+                                  "null"
                                 ]
                               },
                               "longitude": {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "number",
+                                  "null"
                                 ]
                               },
                               "altitude": {
-                                "anyOf": [
-                                  {
-                                    "type": "number"
-                                  },
-                                  {
-                                    "type": "null"
-                                  }
+                                "type": [
+                                  "number",
+                                  "null"
                                 ]
                               }
                             },

--- a/server/tests/api/group-gallery.test.ts
+++ b/server/tests/api/group-gallery.test.ts
@@ -102,6 +102,35 @@ describe("As admin", () => {
     expect(after.body).toStrictEqual({ id: "gallery2", hideMap: false });
   });
 
+  test("Upsert with hideMap=null persists NULL (inherit)", async () => {
+    const auth = await adminAuth();
+    await setupGroup(auth);
+    // Seed with hideMap=true (hide).
+    await api
+      .put("/api/v1/group-gallery/family/gallery2")
+      .set("Authorization", auth)
+      .send({ isEditor: false, hideMap: true })
+      .expect(204);
+    let result = await api
+      .get("/api/v1/group-gallery")
+      .query({ groupId: "family", galleryId: "gallery2" })
+      .set("Authorization", auth)
+      .expect(200);
+    expect(result.body[0].hide_map).toBe(1);
+    // Move back to inherit by sending hideMap=null.
+    await api
+      .put("/api/v1/group-gallery/family/gallery2")
+      .set("Authorization", auth)
+      .send({ isEditor: false, hideMap: null })
+      .expect(204);
+    result = await api
+      .get("/api/v1/group-gallery")
+      .query({ groupId: "family", galleryId: "gallery2" })
+      .set("Authorization", auth)
+      .expect(200);
+    expect(result.body[0].hide_map).toBeNull();
+  });
+
   test("List filters by groupId / galleryId", async () => {
     const auth = await adminAuth();
     await setupGroup(auth);

--- a/server/tests/api/photos.test.ts
+++ b/server/tests/api/photos.test.ts
@@ -500,6 +500,43 @@ describe("Mutations as admin", () => {
         },
       })
       .expect(204));
+  test("Update accepts null coordinates (clears, doesn't silently 0)", async () => {
+    // Seed with non-zero coordinates so we can tell a NULL-write apart
+    // from the silent-0 coercion the prior `Type.Union([Number, Null])`
+    // shape used to produce.
+    await api
+      .put("/api/v1/photos/gallery1photo.jpg")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        taken: {
+          location: {
+            coordinates: { latitude: 48.85, longitude: 2.35, altitude: 100 },
+          },
+        },
+      })
+      .expect(204);
+    // Clear all three with null.
+    await api
+      .put("/api/v1/photos/gallery1photo.jpg")
+      .set("Authorization", `Bearer ${token}`)
+      .send({
+        taken: {
+          location: {
+            coordinates: {
+              latitude: null,
+              longitude: null,
+              altitude: null,
+            },
+          },
+        },
+      })
+      .expect(204);
+    const after = await getPhoto(token, "gallery1photo.jpg");
+    const coords = after.body.taken?.location?.coordinates;
+    expect(coords?.latitude).toBeNull();
+    expect(coords?.longitude).toBeNull();
+    expect(coords?.altitude).toBeNull();
+  });
   test("Update accepts operator-set focal-35mm-equiv", () =>
     api
       .put("/api/v1/photos/gallery1photo.jpg")

--- a/server/tests/api/user-gallery.test.ts
+++ b/server/tests/api/user-gallery.test.ts
@@ -124,6 +124,45 @@ describe("As admin", () => {
       .expect(200);
     expect(result.body.length).toBe(0);
   });
+  test("Upsert with hideMap=null persists NULL (inherit)", async () => {
+    // Seed with hideMap=true (hide) so we can verify the move back to null.
+    await api
+      .put("/api/v1/user-gallery/plainuser/gallery1")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ isEditor: false, hideMap: true })
+      .expect(204);
+    let result = await api
+      .get("/api/v1/user-gallery")
+      .query({ userId: "plainuser", galleryId: "gallery1" })
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    expect(result.body[0].hide_map).toBe(1);
+    // Move back to inherit by sending hideMap=null.
+    await api
+      .put("/api/v1/user-gallery/plainuser/gallery1")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ isEditor: false, hideMap: null })
+      .expect(204);
+    result = await api
+      .get("/api/v1/user-gallery")
+      .query({ userId: "plainuser", galleryId: "gallery1" })
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    expect(result.body[0].hide_map).toBeNull();
+  });
+  test("Upsert with hideMap omitted persists NULL (default on insert)", async () => {
+    await api
+      .put("/api/v1/user-gallery/plainuser/gallery1")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ isEditor: false })
+      .expect(204);
+    const result = await api
+      .get("/api/v1/user-gallery")
+      .query({ userId: "plainuser", galleryId: "gallery1" })
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200);
+    expect(result.body[0].hide_map).toBeNull();
+  });
   test("Upsert with invalid isEditor → 400", () =>
     api
       .put("/api/v1/user-gallery/plainuser/gallery1")


### PR DESCRIPTION
## Summary

Two instances of the same Fastify+Ajv+TypeBox coercion bug — `null` was silently coerced against `Type.Union([X, Type.Null()])` schemas before the null branch could be evaluated.

| Endpoint | Field | Coerced behaviour |
|---|---|---|
| `PUT /api/v1/user-gallery/:user/:gallery` | `hideMap: boolean \| null` | `null` → `false` (Show) — operator-reported |
| `PUT /api/v1/group-gallery/:group/:gallery` | `hideMap: boolean \| null` | `null` → `false` (Show) |
| `PUT /api/v1/photos/:id` | `coordinates.{latitude,longitude,altitude}: number \| null` | `null` → `0` (silently wrote equator / prime meridian / sea level instead of clearing) |

## Root cause

A default-config interaction in the Fastify + Ajv + TypeBox stack — not a single library's bug:

- Fastify defaults Ajv to `coerceTypes: 'array'`, including for body validation.
- Ajv with `coerceTypes` evaluates coercion *before* stepping through `anyOf` alternatives. A JSON `null` against `{anyOf: [{type: "boolean"}, {type: "null"}]}` is first coerced to `false` for the boolean branch, the null branch never gets considered, validation passes, and the handler sees `false` instead of `null`. Same for `number` (→ `0`) and `string` (→ `""`).
- `Type.Union([Type.X(), Type.Null()])` emits exactly that `anyOf` shape, so it inherits the coercion.
- The TypeBox provider exports its own `TypeBoxValidatorCompiler` that does NOT coerce, but we only use `withTypeProvider<TypeBoxTypeProvider>()` (types-only) — Fastify still uses default Ajv at runtime.

## Fix

Two new helpers in [`server/lib/schema-utils.ts`](server/lib/schema-utils.ts) emit the JSON Schema directly:

```ts
export const BooleanOrNull = () => Type.Unsafe<boolean | null>({ type: ["boolean", "null"] });
export const NumberOrNull = () => Type.Unsafe<number | null>({ type: ["number", "null"] });
```

The multi-type form (`type` as an array) doesn't trigger Ajv's union-coercion path the way `anyOf` does. Three call sites converted:

- `user-gallery-v1.ts` — `hideMap: Type.Optional(BooleanOrNull())`
- `group-gallery-v1.ts` — `hideMap: Type.Optional(BooleanOrNull())`
- `photos-v1.ts` — `coordinates.{latitude,longitude,altitude}: Type.Optional(NumberOrNull())`

Wire shape on the boundary is unchanged.

## Other latent uses of the same pattern

`FilterKey` (used in `/query`/`/counts`/`/stats` endpoints across `gallery-photos-v1`, `stats-v1`, `saved-filters-v1`, `photos-v1`) is `Type.Union([Type.String(), Type.Number(), Type.Boolean(), Type.Null()])`. Same root cause — Ajv coerces every alternative to the first one (`String`). Tested isolation case: `null → ""`, `42 → "42"`, `true → "true"`, `false → "false"`.

Not fixed in this PR because filter eval downstream is string-based, so the silent stringification happens to match the comparison shape. Switching to `Type.Unsafe<...>({ type: [...] })` would suddenly pass typed values through (numbers, booleans), and the downstream comparison may not handle them correctly — needs an audit. Deferred to #571 (global `TypeBoxValidatorCompiler` switch), which is the canonical fix.

## Test plan

- [x] `Upsert with hideMap=null persists NULL (inherit)` in `user-gallery.test.ts` — round-trips `null` (failed pre-fix, passes post-fix).
- [x] Same shape on `group-gallery.test.ts`.
- [x] `Upsert with hideMap omitted persists NULL (default on insert)`.
- [x] `Update accepts null coordinates (clears, doesn't silently 0)` in `photos.test.ts` — sets non-zero coords, then writes `null`, verifies the GET reads back `null` (not `0`). Existing coordinates test sent `altitude: null` alongside `latitude: 0` and only checked status; couldn't have caught the bug.
- [x] Full server suite: 893 / 893 passing.
- [x] `npm run typecheck && npm run lint` clean.
- [x] OpenAPI dump regenerated (CI openapi-version check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)