### PR TITLE
Release 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-06-11
+
+### Bug fixes
+
+- Body fields typed as `T | null` were silently coerced to `0` / `false` by Ajv's default `coerceTypes: 'array'` — the union's null branch never got considered. Affected `hideMap` on `PUT /api/v1/{user,group}-gallery/...` (selecting "Default" persisted `0` / Show, and operators couldn't restore it to NULL via the UI) and `latitude` / `longitude` / `altitude` on `PUT /api/v1/photos/:id` (sending null silently wrote `0` instead of clearing). New `BooleanOrNull()` / `NumberOrNull()` helpers in `lib/schema-utils.ts` use `Type.Unsafe<T | null>({ type: ["X", "null"] })` to sidestep the coercion. The broader `setValidatorCompiler(TypeBoxValidatorCompiler)` migration that resolves the class of bug is filed against 0.16 as #571.
+
 ## [0.15] - 2026-06-11
 
 ### Server

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  0.15.0/                               #   so different instances can run different versions
+  0.15.1/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/0.15.0      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/0.15.1      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  display/  thumbnail/
@@ -136,7 +136,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.15.0
+V=0.15.1
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -151,7 +151,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.15.0/bin/instance.ts /var/photo-diary/dailybw
+/opt/photo-diary/0.15.1/bin/instance.ts /var/photo-diary/dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -183,7 +183,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.15.0/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
+/opt/photo-diary/0.15.1/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                                # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                                     # migration runner applies any schema bumps
@@ -460,9 +460,9 @@ After the hiatus, a burst of releases that modernized the stack, formalized the 
 - **0.10** (May 2026) — UI/UX polish across the calendar and Stats views: photo modal with touch-tracking swipe + controlled zoom, Stats Location card with map-in-modal, clickable title-bar breadcrumb with gallery/stats segmented control, Day merged into Month, seven new themes, server-side logout via refresh-token sessions.
 - **0.11** (May 2026) — Reverse-geocoded place hierarchy: converter intake fetches structured Nominatim data, a backfill daemon fills the historical archive, and audit surfaces operator-vs-geocoded drift. Converter hardens around filename collisions and stub flows; operator scripts gain `audit` subcommands and a `bin/meta.ts`.
 - **0.12** (May 2026) — Geocoded location surfaces across the app: per-language city / state / country in the MetadataPanel, City + State filter categories, Stats Places + State topics, per-language city overlay JSON. Converter intake flows JSON sidecars + recursive subdirs. Beta-gated 35mm-equivalent focal length.
-- **0.13** (Jun 2026) — Admin frontend bundle. Full `/m/*` surface — dashboard, Photos grid with faceted filters + edit drawer + multi-select bulk actions + audit chips, Galleries CRUD, Users + Groups + Access pages — behind `user.is_admin`. Stats splits into `/s/` with a global stats page. Mutation API hardens with TypeBox-validated bodies + field-locked overrides; virtual-host scope narrows reads + writes to a bound gallery; ACL gains user groups. Theme picker becomes a swatch grid with six new built-in themes.
-- **0.14** (Jun 2026) — Admin UI polish. Slug-shaped ids, mutable `user.name` + renamed `group.name`, per-photo bulk Edit-fields modal, bulk Regeocode, dashboard audit-count tiles, filter-sidebar timeline strip with shift-range month picking, gallery-icon cropper, Inbox surface revamp, gallery-editor tier, `xx` sentinel for international waters. Mobile / small-screen pass: scrollable tables, dual pagers with 44px touch targets, Access table redesign, frosted-glass floating `BulkActions` bar, long-press + drag-to-range touch multi-select with edge auto-scroll.
-- **0.15** (Jun 2026) — Composition + scale. Hybrid galleries unioning multiple sources, saved filters as pseudo-galleries layered on a real source, per-language overlays for photo + gallery metadata, date-range filter on per-view + stats endpoints, stats category evolution over time. Public viewer goes lazy: per-view `/query` / `/counts` / `/neighbors` endpoints replace the full-array fetch, filter-values endpoints feed the pill universe. `bin/instance.ts` auto-cycles pm2 on upgrades, takes the positional as a path with `--name` for the logical name.
+- **0.13** (Jun 2026) — Admin frontend bundle. Full `/m/*` surface (dashboard, Photos, Galleries, Users, Groups, Access) behind `user.is_admin`. TypeBox-validated mutations, virtual-host scope, ACL groups, six new themes.
+- **0.14** (Jun 2026) — Admin UI polish. Slug-shaped ids, bulk Edit-fields, bulk Regeocode, dashboard audit tiles, filter-sidebar timeline strip, gallery-icon cropper, gallery-editor tier, mobile pass across the admin surface.
+- **0.15** (Jun 2026) — Composition + scale. Hybrid galleries, saved filters as pseudo-galleries, per-language metadata, date-range filter, stats evolution. Public viewer goes lazy via per-view `/query`/`/counts`/`/neighbors` endpoints. `bin/instance.ts` auto-cycles pm2 on upgrades.
 
 See the [Roadmap](#roadmap) for what's in flight after 0.15.
   

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.1"
   },
-  "version": "0.15.0"
+  "version": "0.15.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -66,5 +66,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.15.0"
+  "version": "0.15.1"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.15.0"
+    "version": "0.15.1"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -57,5 +57,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.15.0"
+  "version": "0.15.1"
 }


### PR DESCRIPTION
## Summary

Hotfix release for the `T | null` body-coercion bug fixed in #570.

- Version bumps to 0.15.1 across all four `package.json` files.
- `server/openapi.json` regenerated.
- `CHANGELOG`: `[Unreleased]` becomes `[0.15.1] - 2026-06-11` with one bullet describing the fix and pointing at the 0.16 follow-up (#571). Fresh empty `[Unreleased]` above.
- README install / upgrade examples shift from `0.15.0` to `0.15.1`.
- README Version History stays headline-only — 0.15.1 isn't promoted there. Took the opportunity to trim 0.13 / 0.14 / 0.15 entries to match the earlier brevity; per-feature detail lives in the CHANGELOG.

## Test plan

- [x] Server: 893 / 893 passing; typecheck + lint clean.
- [x] React: 983 / 983 passing; typecheck + lint clean; build green.
- [x] Converter: typecheck + tests + lint clean.
- [x] Version strings consistent across all four `package.json` files; `openapi.json` info.version = 0.15.1.
- [ ] After merge: tag `v0.15.1`, push, `gh release create` from the CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)