### PR TITLE
Fix #578: initialView=photo resolves the actual last photo

### DIFF
--- a/react-app/src/components/Gallery/Full.tsx
+++ b/react-app/src/components/Gallery/Full.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { Navigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 
+import config from "../../lib/config";
 import { useGalleryCalendar } from "../../lib/useFilteredCalendar";
+import galleryPhotosService from "../../services/gallery-photos";
 
 import type { Gallery } from "../../models/GalleryModel";
 
@@ -13,14 +16,67 @@ interface Props {
   gallery: Gallery;
 }
 
-// Lands on the gallery's most-recent view (year / month / day per
-// `initialView`). Calendar shape comes from /counts via the
+// Lands on the gallery's most-recent view (year / month / day / photo
+// per `initialView`). Calendar shape comes from /counts via the
 // gallery-wide unfiltered hook so we don't need the gallery's full
-// photo array in memory.
+// photo array in memory. For `initialView: "photo"` we additionally
+// /query the last day to pick the actual last photo id — the picker
+// can't afford this fetch fan-out across N gallery cards, but the
+// bare gallery landing is one gallery so the cost is one round trip.
 const Full = ({ gallery }: Props): React.ReactElement => {
   const cal = useGalleryCalendar(gallery.id());
+  const effectiveInitialView =
+    gallery.initialView() || config.INITIAL_GALLERY_VIEW;
+  const wantsPhoto = effectiveInitialView === "photo";
+  const [lastYear, lastMonth, lastDay] = cal.lastDay();
+  const lastDayKnown =
+    lastYear !== undefined &&
+    lastMonth !== undefined &&
+    lastDay !== undefined;
+  const lastDayPhotosQuery = useQuery({
+    queryKey: [
+      "gallery-photos-query",
+      gallery.id(),
+      {
+        year: lastYear,
+        month: lastMonth,
+        day: lastDay,
+        filter: {},
+        dateRange: undefined,
+        lang: undefined,
+      },
+    ],
+    queryFn: () =>
+      galleryPhotosService.query(gallery.id(), {
+        year: lastYear,
+        month: lastMonth,
+        day: lastDay,
+      }),
+    enabled: wantsPhoto && cal.ready && lastDayKnown,
+  });
   if (!cal.ready) {
     return <></>;
+  }
+  if (wantsPhoto && lastDayKnown) {
+    if (!lastDayPhotosQuery.data) {
+      return <></>;
+    }
+    const photos = lastDayPhotosQuery.data as Array<{ id?: string }>;
+    const lastPhoto = photos[photos.length - 1];
+    const lastPhotoId =
+      lastPhoto && typeof lastPhoto.id === "string"
+        ? lastPhoto.id
+        : undefined;
+    return (
+      <Navigate
+        to={gallery.lastPath({
+          includesPhotos: cal.includesPhotos,
+          lastDay: cal.lastDay,
+          lastPhotoId,
+        })}
+        replace
+      />
+    );
   }
   const path = gallery.lastPath(cal);
   return <Navigate to={path} replace />;

--- a/react-app/src/models/GalleryModel.test.ts
+++ b/react-app/src/models/GalleryModel.test.ts
@@ -258,12 +258,53 @@ describe("Without photos", () => {
           | [number, number, number]
           | [undefined, undefined, undefined],
     };
+    const populatedShape = {
+      includesPhotos: () => true,
+      lastDay: () =>
+        [2024, 3, 15] as
+          | [number, number, number]
+          | [undefined, undefined, undefined],
+    };
     test("empty", () =>
       expect(samples.empty.lastPath(emptyShape)).toBe("/g/empty"));
     test("testing", () =>
       expect(samples.testing.lastPath(emptyShape)).toBe("/g/testing"));
     test("all_photos", () =>
       expect(samples["all_photos"].lastPath(emptyShape)).toBe("/g/all_photos"));
+    test("populated + initialView=month → /g/<id>/YYYY/MM", () =>
+      expect(samples.testing.lastPath(populatedShape)).toBe(
+        "/g/testing/2024/03"
+      ));
+    test("populated + initialView=year → /g/<id>/YYYY", () =>
+      expect(samples["all_photos"].lastPath(populatedShape)).toBe(
+        "/g/all_photos/2024"
+      ));
+    test("populated + initialView=day → /g/<id>/YYYY/MM/DD", () =>
+      expect(samples.daily.lastPath(populatedShape)).toBe(
+        "/g/all_photos/2024/03/15"
+      ));
+    test("populated + initialView=photo without lastPhotoId → month-of-lastDay fallback", () =>
+      expect(samples.photo_view.lastPath(populatedShape)).toBe(
+        "/g/all_photos/2024/03"
+      ));
+    test("populated + initialView=photo with lastPhotoId → full photo URL", () =>
+      expect(
+        samples.photo_view.lastPath({
+          ...populatedShape,
+          lastPhotoId: "shot-42.jpg",
+        })
+      ).toBe("/g/all_photos/2024/03/15/shot-42.jpg"));
+    test("populated + initialView=day ignores lastPhotoId", () =>
+      expect(
+        samples.daily.lastPath({
+          ...populatedShape,
+          lastPhotoId: "shot-42.jpg",
+        })
+      ).toBe("/g/all_photos/2024/03/15"));
+    test("populated + unknown initialView → month fallback", () =>
+      expect(samples.badInitial.lastPath(populatedShape)).toBe(
+        "/g/all_photos/2024/03"
+      ));
   });
   describe("statsPath", () => {
     test("empty", () =>

--- a/react-app/src/models/GalleryModel.ts
+++ b/react-app/src/models/GalleryModel.ts
@@ -130,6 +130,7 @@ const GalleryModel = (galleryData: unknown) => {
     hasTheme: (): boolean => !!gallery.theme,
     theme: (): string | undefined => gallery.theme,
     hideMap: (): boolean => !!gallery.hideMap,
+    initialView: (): string | undefined => gallery.initialView,
     matchesHostname: (hostname: string): boolean => {
       const regex = hostnameRegex();
       if (!regex) {
@@ -148,13 +149,15 @@ const GalleryModel = (galleryData: unknown) => {
     // Caller passes the gallery's calendar shape (see `useGalleryCalendar`)
     // — the gallery model itself no longer carries the photo array
     // that used to drive `firstDay`/`lastDay`/`includesPhotos`.
-    // `photo` initialView falls back to the month-of-lastDay path
-    // here; pinning to the specific last-photo URL would need an
-    // extra fetch beyond /counts, and the gallery list rendering N
-    // gallery cards shouldn't fan out N photo lookups.
+    // `photo` initialView resolves to the actual last-photo URL when
+    // the caller supplies `lastPhotoId` (e.g. <Full> can afford the
+    // extra /query fetch for one gallery). Without it — typically
+    // the gallery picker rendering N cards — fall back to the
+    // month-of-lastDay path so we don't fan out N photo lookups.
     lastPath: (shape: {
       includesPhotos: () => boolean;
       lastDay: () => [number, number, number] | [undefined, undefined, undefined];
+      lastPhotoId?: string;
     }): string => {
       if (!shape.includesPhotos()) {
         return self.path();
@@ -170,6 +173,10 @@ const GalleryModel = (galleryData: unknown) => {
         case "day":
           return self.path(year, month, day);
         case "photo":
+          if (shape.lastPhotoId) {
+            return `${self.path(year, month, day)}/${shape.lastPhotoId}`;
+          }
+          return self.path(year, month);
         default:
         case "month":
           return self.path(year, month);


### PR DESCRIPTION
## Summary

Closes #578. Operator-reported on https://dailybw.misaki.fi — entering the gallery bare URL doesn't land on a photo view despite the gallery having `initialView: "photo"`.

## Root cause

After #532 dropped the in-memory photo array from `GalleryModel`, `lastPath`'s `case "photo"` was rewired to fall back to the month-of-lastDay path. The comment in the model documents the trade-off: the picker renders N gallery cards and can't afford N extra photo-id lookups, so the `photo` case settles for the month URL across the board.

That's fine for the picker. But the bare `/g/<id>` landing in `<Full>` is just **one** gallery's redirect, and the extra round trip there is cheap. Currently, `<Full>` was treating `photo` exactly like `month`, so a gallery with `initialView: "photo"` landed on `/g/<id>/Y/M` instead of `/g/<id>/Y/M/D/<photoId>`.

## Fix

Pass the responsibility for fetching the last photo id to the caller, via a new optional `lastPhotoId` field on `lastPath`'s shape arg:

- **`GalleryModel.lastPath`**: when `lastPhotoId` is supplied and the effective `initialView` is `photo`, return the full `<gallery>/<Y>/<M>/<D>/<photoId>` URL. Without it (picker callers), keep falling back to the month path. Picker behaviour unchanged.
- **`<Full>`**: gated `useQuery` against the last-day's `/query` when the effective initialView is `photo`. The last photo's id flows into `lastPath` via the new shape field. Two fetches total in the `photo` case: `/counts` for the calendar shape, `/query` for the last day's photos. Both gated on initialView=photo — no cost for `year`/`month`/`day` galleries.
- **`GalleryModel.initialView()`**: surfaced as an accessor; previously only consumed inside `lastPath`'s closure.

## Test plan

- [x] Unit tests: `populated + initialView=photo + lastPhotoId → /g/<id>/Y/M/D/<photo>`, `populated + initialView=photo without lastPhotoId → /g/<id>/Y/M` (picker fallback), `populated + initialView=day ignores lastPhotoId`.
- [x] Full suite: 990 / 990 passing.
- [x] `npm run typecheck && npm run lint && npm run build` clean.
- [x] Playwright on dev:
  - `/g/<gallery with initialView=photo>` → redirects to `/g/<id>/Y/M/D/<photoId>` (Photo modal mounts).
  - `/g/<gallery with initialView=month>` → unchanged, `/g/<id>/Y/M`.
  - `/g/<gallery with initialView=day>` → unchanged, `/g/<id>/Y/M/D`.
  - `/` smart-landing (two-hop via picker) → unchanged.

## Notes

The picker's `lastPath` callsite stays as-is. If we ever want the picker's `photo`-initialView galleries to deep-link the actual last photo too, the fix would be to call `lastPath` with a per-gallery `lastPhotoId` resolved from a batch endpoint — out of scope here, but the shape change leaves the door open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)