### PR TITLE
Server: switch to TypeBoxValidatorCompiler (#571)

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 import { readFileSync } from "node:fs";
 
 import Fastify from "fastify";
-import { type TypeBoxTypeProvider } from "@fastify/type-provider-typebox";
+import {
+  TypeBoxValidatorCompiler,
+  type TypeBoxTypeProvider,
+} from "@fastify/type-provider-typebox";
 import fastifyHelmet from "@fastify/helmet";
 import fastifyCompress from "@fastify/compress";
 import fastifyStatic from "@fastify/static";
@@ -63,6 +66,14 @@ export const app = Fastify({
   // `requestLogger` (below) emits the structured per-response line.
   disableRequestLogging: true,
 }).withTypeProvider<TypeBoxTypeProvider>();
+
+// Replace Fastify's default Ajv-based validator with TypeBox's own
+// Compile/Check. TypeBox emits the same JSON Schema TypeBox-typed
+// routes are authored against, validates with no `coerceTypes` —
+// what the schema says is what the handler sees. Avoids the class
+// of bug fixed locally in #570 (`null` against `Type.Union([X,
+// Null])` coerced to the non-null branch's default). Closes #571.
+app.setValidatorCompiler(TypeBoxValidatorCompiler);
 
 const STATIC_DIR =
   process.env.STATIC_DIR ?? path.join(import.meta.dirname, "build");

--- a/server/controllers/group-gallery-v1.ts
+++ b/server/controllers/group-gallery-v1.ts
@@ -3,7 +3,6 @@ import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import authorizerFactory from "../lib/authorizer.js";
 import { requireScopeMatches } from "../lib/host-scope.js";
-import { BooleanOrNull } from "../lib/schema-utils.js";
 import modelFactory from "../models/group-gallery.js";
 
 const authorizer = authorizerFactory();
@@ -34,7 +33,7 @@ const RowsResponse = Type.Array(RowResponse);
 const UpsertBody = Type.Object(
   {
     isEditor: Type.Boolean(),
-    hideMap: Type.Optional(BooleanOrNull()),
+    hideMap: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
   },
   { additionalProperties: false }
 );

--- a/server/controllers/photos-v1.ts
+++ b/server/controllers/photos-v1.ts
@@ -9,7 +9,6 @@ import {
   requireUnscoped,
 } from "../lib/host-scope.js";
 import { writeCoordSidecar } from "../lib/inbox-sidecar.js";
-import { NumberOrNull } from "../lib/schema-utils.js";
 import {
   coordsDiffer,
   mergeCoords,
@@ -68,9 +67,15 @@ const PhotoOverridesFields = {
               coordinates: Type.Optional(
                 Type.Object(
                   {
-                    latitude: Type.Optional(NumberOrNull()),
-                    longitude: Type.Optional(NumberOrNull()),
-                    altitude: Type.Optional(NumberOrNull()),
+                    latitude: Type.Optional(
+                      Type.Union([Type.Number(), Type.Null()])
+                    ),
+                    longitude: Type.Optional(
+                      Type.Union([Type.Number(), Type.Null()])
+                    ),
+                    altitude: Type.Optional(
+                      Type.Union([Type.Number(), Type.Null()])
+                    ),
                   },
                   { additionalProperties: false }
                 )

--- a/server/controllers/user-gallery-v1.ts
+++ b/server/controllers/user-gallery-v1.ts
@@ -3,7 +3,6 @@ import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import authorizerFactory from "../lib/authorizer.js";
 import { requireScopeMatches } from "../lib/host-scope.js";
-import { BooleanOrNull } from "../lib/schema-utils.js";
 import modelFactory from "../models/user-gallery.js";
 
 const authorizer = authorizerFactory();
@@ -34,7 +33,7 @@ const RowsResponse = Type.Array(RowResponse);
 const UpsertBody = Type.Object(
   {
     isEditor: Type.Boolean(),
-    hideMap: Type.Optional(BooleanOrNull()),
+    hideMap: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),
   },
   { additionalProperties: false }
 );

--- a/server/lib/schema-utils.ts
+++ b/server/lib/schema-utils.ts
@@ -14,17 +14,3 @@ import { Type } from "typebox";
 export const StringEnum = <T extends string>(values: readonly T[]) =>
   Type.Unsafe<T>({ type: "string", enum: [...values] });
 
-// Fastify's default Ajv config (`coerceTypes: 'array'`) silently
-// coerces `null` to the union's non-null alternative — even inside
-// a `Type.Union([Type.X(), Type.Null()])`, because Ajv coerces
-// before evaluating the union's alternatives. `null` against
-// `Type.Boolean` becomes `false`, against `Type.Number` becomes
-// `0`, against `Type.String` becomes `""`. The JSON Schema we want
-// (a plain `type: ["X", "null"]`) sidesteps the coercion, but
-// TypeBox 1.x doesn't sugar the multi-type form. Drop straight to
-// JSON Schema via `Type.Unsafe`. The TS-side type stays
-// `T | null`, so callers keep type safety at the destructure site.
-export const BooleanOrNull = () =>
-  Type.Unsafe<boolean | null>({ type: ["boolean", "null"] });
-export const NumberOrNull = () =>
-  Type.Unsafe<number | null>({ type: ["number", "null"] });

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1873,21 +1873,33 @@
                             "type": "object",
                             "properties": {
                               "latitude": {
-                                "type": [
-                                  "number",
-                                  "null"
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
                                 ]
                               },
                               "longitude": {
-                                "type": [
-                                  "number",
-                                  "null"
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
                                 ]
                               },
                               "altitude": {
-                                "type": [
-                                  "number",
-                                  "null"
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
                                 ]
                               }
                             },
@@ -2503,21 +2515,33 @@
                             "type": "object",
                             "properties": {
                               "latitude": {
-                                "type": [
-                                  "number",
-                                  "null"
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
                                 ]
                               },
                               "longitude": {
-                                "type": [
-                                  "number",
-                                  "null"
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
                                 ]
                               },
                               "altitude": {
-                                "type": [
-                                  "number",
-                                  "null"
+                                "anyOf": [
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
                                 ]
                               }
                             },
@@ -3330,9 +3354,13 @@
                     "type": "boolean"
                   },
                   "hideMap": {
-                    "type": [
-                      "boolean",
-                      "null"
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
                     ]
                   }
                 },
@@ -3833,9 +3861,13 @@
                     "type": "boolean"
                   },
                   "hideMap": {
-                    "type": [
-                      "boolean",
-                      "null"
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
                     ]
                   }
                 },


### PR DESCRIPTION
## Summary

Closes #571. Replaces Fastify's default Ajv validator with `TypeBoxValidatorCompiler` from `@fastify/type-provider-typebox`. The change makes the runtime validator match what the TypeBox types say — no coercion between the wire and the handler.

## Why

Ajv with `coerceTypes` (Fastify's default) evaluates coercion before stepping through `anyOf` alternatives. The result is that `null` against `Type.Union([X, Null])` is silently coerced to the non-null branch's default — `false` for `boolean`, `0` for `number`, `""` for `string`. We patched two real cases locally in #570 (`hideMap` on user/group-gallery upsert; photo coordinates) with `Type.Unsafe<...>({ type: ["X", "null"] })` helpers, but the underlying issue applied to every `Type.Union([X, Null])` site, and `FilterKey` had the same bug latent on every filter-taking endpoint (the silent stringification just happened to match downstream comparison code, masking it).

`TypeBoxValidatorCompiler` uses TypeBox's own `Compile(schema).Check(value)`, which doesn't coerce. The schema text becomes the runtime behaviour.

## What changed

- **`server/app.ts`**: `app.setValidatorCompiler(TypeBoxValidatorCompiler)` after the `withTypeProvider` call.
- **`server/lib/schema-utils.ts`**: `BooleanOrNull` / `NumberOrNull` workarounds removed. `StringEnum` stays — different rationale (Swagger UI enum-dropdown rendering).
- **`server/controllers/user-gallery-v1.ts`** + **`group-gallery-v1.ts`** + **`photos-v1.ts`**: `hideMap` and coordinate fields revert from `BooleanOrNull()` / `NumberOrNull()` back to plain `Type.Union([Type.X(), Type.Null()])`.
- **`server/openapi.json`**: regenerated — schemas that used the multi-type form (`type: ["X", "null"]`) revert to `anyOf`. `react-app/src/lib/api-schema.ts` codegen produces no diff (both shapes yield `X | null` in TypeScript).

## Audit notes

Swept every `querystring:` and `params:` schema across the controllers — they're all `Type.String()` (path/query/header values arrive as strings; nothing in our routes relies on string-to-number coercion). Bodies arrive typed via JSON.parse, so the body schemas' Type.Number / Type.Boolean / Type.Integer were never coercing anyway. No endpoint regressed under the switch.

The latent `FilterKey = Type.Union([String, Number, Boolean, Null])` coercion bug is now resolved as a side effect — non-string values reach the handler with their original type. Downstream filter eval was already forgiving (`String(key) === value` for string categories, `Number(key)` fallback in `matchesNumber`), so no user-visible behaviour change; just schema-and-runtime are in sync now.

## Test plan

- [x] `npm run typecheck && npm test && npm run lint` on server — 893 / 893 passing.
- [x] React-app typecheck + tests clean (no API-schema diff after codegen).
- [x] The null-preservation tests added in #570 (`user-gallery.test.ts`, `group-gallery.test.ts`, `photos.test.ts`) still pin the no-coerce behaviour — they're the same shape they were on the workaround, just now they verify the underlying validator instead of the workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)