### PR TITLE
Release 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## [0.15.2] - 2026-06-12
+
+### Bug fixes
+
+- `<Full>` now resolves the actual last photo when a gallery has `initialView: "photo"`; previously fell through to the month-of-lastDay view because the in-memory photo array was dropped in #532 and the new `lastPath` couldn't synthesize the URL. `<Full>` does one extra `/query` against the last day to pick the id; picker callers (N gallery cards) still take the month fallback to avoid fan-out. Closes #578.
+- Photo modal's neighbors + per-id queries now wire `AbortSignal` through `getNeighbors` / `getOne`, so rapid prev/next nav cancels in-flight fetches instead of racing them. Closes #577 (partial — placeholder-data tightening deferred for a typing issue).
+
+### Server
+
+- `setValidatorCompiler(TypeBoxValidatorCompiler)` replaces Fastify's default Ajv across every endpoint, removing the `coerceTypes` path that silently turned `null` into `false` / `0` / `""` against `Type.Union([X, Null])` schemas. The local `BooleanOrNull` / `NumberOrNull` workarounds from 0.15.1 retire — callers go back to plain `Type.Union([Type.X(), Type.Null()])`. The latent `FilterKey` coercion (silent stringification of every alternative) is fixed as a side effect; downstream filter eval was already forgiving so no user-visible change beyond schema-and-runtime alignment. Closes #571.
+
+### Frontend
+
+- The `/m/*` admin surface and `/s` global stats are now lazy-loaded — public visitors drop ~615 kB / ~172 kB gzipped off the main bundle (1 MB → 387 kB raw, 287 kB → 115 kB gzipped). Admin pages fan out into per-page chunks loaded on demand. Closes #573.
+
 ## [0.15.1] - 2026-06-11
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  0.15.1/                               #   so different instances can run different versions
+  0.15.2/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/0.15.1      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/0.15.2      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  display/  thumbnail/
@@ -136,7 +136,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.15.1
+V=0.15.2
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -151,7 +151,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.15.1/bin/instance.ts /var/photo-diary/dailybw
+/opt/photo-diary/0.15.2/bin/instance.ts /var/photo-diary/dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -183,7 +183,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.15.1/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
+/opt/photo-diary/0.15.2/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                                # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                                     # migration runner applies any schema bumps

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.1"
   },
-  "version": "0.15.1"
+  "version": "0.15.2"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -66,5 +66,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.15.1"
+  "version": "0.15.2"
 }

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -14,26 +14,52 @@ import "./App.css";
 import ScrollToPosition from "./components/ScrollToPosition";
 import TopMenu from "./components/TopMenu";
 import Gallery from "./components/Gallery";
-import Manage from "./components/Manage";
-import ManagePlaceholder from "./components/Manage/Placeholder";
-import ManagePhotos from "./components/Manage/Photos";
-import ManagePhotoDrawer from "./components/Manage/PhotoDrawer";
-import ManageGalleries from "./components/Manage/Galleries";
-import ManageGalleryEdit from "./components/Manage/GalleryEdit";
-import ManageGalleryCreate from "./components/Manage/GalleryCreate";
-import ManageDashboard from "./components/Manage/Dashboard";
-import ManageUsers from "./components/Manage/Users";
-import ManageUserEdit from "./components/Manage/UserEdit";
-import ManageUserCreate from "./components/Manage/UserCreate";
-import ManageGroups from "./components/Manage/Groups";
-import ManageGroupEdit from "./components/Manage/GroupEdit";
-import ManageGroupCreate from "./components/Manage/GroupCreate";
-import ManageGalleryAccess from "./components/Manage/GalleryAccess";
-import ManageAccess from "./components/Manage/Access";
-import GlobalStats from "./components/GlobalStats";
 import Notifications from "./components/Notifications";
 import LoginModal from "./components/LoginModal";
 import ChangePasswordModal from "./components/ChangePasswordModal";
+
+// Admin surface (`/m/*`) + cross-gallery stats (`/s`) are gated on
+// `user.isAdmin()` at runtime — public visitors never see them. Lazy-
+// load the whole subtree so the admin bundle isn't paid for on every
+// gallery view. Per-page chunks of Manage co-bundle via Rollup's
+// shared-chunk hoisting (one Manage entry, the per-page components
+// follow via their dynamic-import edges into the Manage shell).
+const Manage = React.lazy(() => import("./components/Manage"));
+const ManagePhotos = React.lazy(() => import("./components/Manage/Photos"));
+const ManagePhotoDrawer = React.lazy(
+  () => import("./components/Manage/PhotoDrawer")
+);
+const ManageGalleries = React.lazy(
+  () => import("./components/Manage/Galleries")
+);
+const ManageGalleryEdit = React.lazy(
+  () => import("./components/Manage/GalleryEdit")
+);
+const ManageGalleryCreate = React.lazy(
+  () => import("./components/Manage/GalleryCreate")
+);
+const ManageDashboard = React.lazy(
+  () => import("./components/Manage/Dashboard")
+);
+const ManageUsers = React.lazy(() => import("./components/Manage/Users"));
+const ManageUserEdit = React.lazy(
+  () => import("./components/Manage/UserEdit")
+);
+const ManageUserCreate = React.lazy(
+  () => import("./components/Manage/UserCreate")
+);
+const ManageGroups = React.lazy(() => import("./components/Manage/Groups"));
+const ManageGroupEdit = React.lazy(
+  () => import("./components/Manage/GroupEdit")
+);
+const ManageGroupCreate = React.lazy(
+  () => import("./components/Manage/GroupCreate")
+);
+const ManageGalleryAccess = React.lazy(
+  () => import("./components/Manage/GalleryAccess")
+);
+const ManageAccess = React.lazy(() => import("./components/Manage/Access"));
+const GlobalStats = React.lazy(() => import("./components/GlobalStats"));
 
 import config from "./lib/config";
 import metaService from "./services/meta";
@@ -147,45 +173,50 @@ const App = (): React.ReactElement => {
           {!countryDataReady ? (
             <div>{t("loading")}</div>
           ) : (
-            <Routes>
-              <Route
-                path="/s/:galleryId"
-                element={<Gallery isStats={true} />}
-              />
-              <Route path="/s" element={<GlobalStats />} />
-              <Route
-                path="/g/:galleryId/:year/:month/:day/:photoId"
-                element={<Gallery />}
-              />
-              <Route
-                path="/g/:galleryId/:year?/:month?/:day?"
-                element={<Gallery />}
-              />
-              <Route path="/g" element={<Gallery />} />
-              <Route path="/m" element={<Manage />}>
-                <Route index element={<ManageDashboard />} />
-                <Route path="users" element={<ManageUsers />} />
-                <Route path="users/new" element={<ManageUserCreate />} />
-                <Route path="users/:userId" element={<ManageUserEdit />} />
-                <Route path="groups" element={<ManageGroups />} />
-                <Route path="groups/new" element={<ManageGroupCreate />} />
-                <Route path="groups/:groupId" element={<ManageGroupEdit />} />
-                <Route path="access" element={<ManageAccess />} />
-                <Route path="galleries" element={<ManageGalleries />} />
+            <React.Suspense fallback={<div>{t("loading")}</div>}>
+              <Routes>
                 <Route
-                  path="galleries/new"
-                  element={<ManageGalleryCreate />}
+                  path="/s/:galleryId"
+                  element={<Gallery isStats={true} />}
                 />
-                <Route path="photos" element={<ManagePhotos />}>
-                  <Route path=":photoId" element={<ManagePhotoDrawer />} />
+                <Route path="/s" element={<GlobalStats />} />
+                <Route
+                  path="/g/:galleryId/:year/:month/:day/:photoId"
+                  element={<Gallery />}
+                />
+                <Route
+                  path="/g/:galleryId/:year?/:month?/:day?"
+                  element={<Gallery />}
+                />
+                <Route path="/g" element={<Gallery />} />
+                <Route path="/m" element={<Manage />}>
+                  <Route index element={<ManageDashboard />} />
+                  <Route path="users" element={<ManageUsers />} />
+                  <Route path="users/new" element={<ManageUserCreate />} />
+                  <Route path="users/:userId" element={<ManageUserEdit />} />
+                  <Route path="groups" element={<ManageGroups />} />
+                  <Route path="groups/new" element={<ManageGroupCreate />} />
+                  <Route
+                    path="groups/:groupId"
+                    element={<ManageGroupEdit />}
+                  />
+                  <Route path="access" element={<ManageAccess />} />
+                  <Route path="galleries" element={<ManageGalleries />} />
+                  <Route
+                    path="galleries/new"
+                    element={<ManageGalleryCreate />}
+                  />
+                  <Route path="photos" element={<ManagePhotos />}>
+                    <Route path=":photoId" element={<ManagePhotoDrawer />} />
+                  </Route>
+                  <Route path="g/:galleryId">
+                    <Route index element={<ManageGalleryEdit />} />
+                    <Route path="access" element={<ManageGalleryAccess />} />
+                  </Route>
                 </Route>
-                <Route path="g/:galleryId">
-                  <Route index element={<ManageGalleryEdit />} />
-                  <Route path="access" element={<ManageGalleryAccess />} />
-                </Route>
-              </Route>
-              <Route path="/" element={<Gallery smartLanding />} />
-            </Routes>
+                <Route path="/" element={<Gallery smartLanding />} />
+              </Routes>
+            </React.Suspense>
           )}
         </ScrollToPosition>
         <Footer>

--- a/react-app/src/components/Gallery/Photo/index.tsx
+++ b/react-app/src/components/Gallery/Photo/index.tsx
@@ -290,10 +290,13 @@ const Photo = ({
       photo.id(),
       serverFilters,
     ],
-    queryFn: () =>
-      galleryPhotosService.getNeighbors(gallery.id(), photo.id(), {
-        filter: serverFilters,
-      }),
+    queryFn: ({ signal }) =>
+      galleryPhotosService.getNeighbors(
+        gallery.id(),
+        photo.id(),
+        { filter: serverFilters },
+        signal
+      ),
     placeholderData: keepPreviousData,
   });
   // Prime the per-id query cache (Gallery/index.tsx reads from

--- a/react-app/src/components/Gallery/Title.tsx
+++ b/react-app/src/components/Gallery/Title.tsx
@@ -220,11 +220,13 @@ const Title = ({
       serverFilters,
       dateRange,
     ],
-    queryFn: () =>
-      galleryPhotosService.getNeighbors(gallery.id(), photo!.id(), {
-        filter: serverFilters,
-        dateRange,
-      }),
+    queryFn: ({ signal }) =>
+      galleryPhotosService.getNeighbors(
+        gallery.id(),
+        photo!.id(),
+        { filter: serverFilters, dateRange },
+        signal
+      ),
     enabled: !!photo,
     placeholderData: keepPreviousData,
   });

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -150,8 +150,13 @@ const Gallery = ({
   // common case pays for one round trip, not two.
   const photoByIdQuery = useQuery({
     queryKey: ["gallery-photo-by-id", galleryId, photoId, lang],
-    queryFn: () =>
-      galleryPhotosService.getOne(galleryId as string, photoId as string, lang),
+    queryFn: ({ signal }) =>
+      galleryPhotosService.getOne(
+        galleryId as string,
+        photoId as string,
+        lang,
+        signal
+      ),
     enabled: !!photoId && galleryInList,
     retry: false,
   });

--- a/react-app/src/services/gallery-photos.ts
+++ b/react-app/src/services/gallery-photos.ts
@@ -41,16 +41,21 @@ const getCounts = async (
   );
 
 // Prev / next / first / last photos within the filtered set —
-// drives the Photo modal's carousel + keyboard nav (#406).
+// drives the Photo modal's carousel + keyboard nav (#406). `signal`
+// lets TanStack's per-query AbortController cancel in-flight
+// requests when the user blasts through prev/next faster than the
+// network responds (#577).
 const getNeighbors = async (
   galleryId: string,
   photoId: string,
-  opts: { filter?: ServerFilters; dateRange?: DateRange; lang?: string } = {}
+  opts: { filter?: ServerFilters; dateRange?: DateRange; lang?: string } = {},
+  signal?: AbortSignal
 ) =>
   unwrap(
     api.POST("/api/v1/gallery-photos/{galleryId}/neighbors", {
       params: { path: { galleryId } },
       body: { photoId, ...opts },
+      signal,
     })
   );
 
@@ -69,13 +74,19 @@ const getFilterValues = async (galleryId: string, lang?: string) =>
 // One photo by id within a gallery context. Drives the Photo modal
 // mount under #532 phase 2 — replaces the in-memory `gallery.photo
 // (...)` lookup that needed the gallery's full photo array.
-const getOne = async (galleryId: string, photoId: string, lang?: string) =>
+const getOne = async (
+  galleryId: string,
+  photoId: string,
+  lang?: string,
+  signal?: AbortSignal
+) =>
   unwrap(
     api.GET("/api/v1/gallery-photos/{galleryId}/{photoId}", {
       params: {
         path: { galleryId, photoId },
         query: lang ? { lang } : undefined,
       },
+      signal,
     })
   );
 

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.15.1"
+    "version": "0.15.2"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -57,5 +57,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.15.1"
+  "version": "0.15.2"
 }


### PR DESCRIPTION
## Summary

Patch release sweeping four 0.16-bound improvements into the 0.15.x line:

| # | Description |
|---|---|
| #578 | `initialView=photo` redirect regression — `<Full>` now resolves the actual last photo (one extra `/query` for one gallery; picker callers keep the month fallback). |
| #571 | Server-wide `setValidatorCompiler(TypeBoxValidatorCompiler)` switch — removes Ajv's `coerceTypes` path that silently coerced `null` to `false` / `0` / `""` against `Type.Union([X, Null])` schemas. Retires the local `BooleanOrNull` / `NumberOrNull` workarounds from 0.15.1. |
| #573 | Admin surface (`/m/*` + `/s`) lazy-loaded — public bundle drops ~615 kB / ~172 kB gzipped (1 MB → 387 kB raw, 287 kB → 115 kB gzipped). |
| #577 | `AbortSignal` wired into `getNeighbors` / `getOne` — rapid prev/next nav cancels in-flight fetches instead of racing them. Placeholder-data tightening deferred (typing issue, separate follow-up). |

#578 and #571 already merged to main; #573 and #577 land in this branch as part of the release.

## What's stamped

- Version bumps to 0.15.2 across all four `package.json` files.
- `server/openapi.json` regenerated (no schema-shape diff beyond `info.version`).
- `CHANGELOG`: `[Unreleased]` becomes `[0.15.2] - 2026-06-12` with grouped bullets (Bug fixes / Server / Frontend). Fresh empty `[Unreleased]` above.
- README install / upgrade examples shift from `0.15.1` to `0.15.2`. Version History stays headline-only.

## Test plan

- [x] Server: 893 / 893 passing; typecheck + lint clean.
- [x] React: 990 / 990 passing; typecheck + lint clean; build green (~115 kB gzipped main bundle).
- [x] Converter: typecheck + tests + lint clean.
- [x] Playwright on dev: `/g/<gallery with initialView=photo>` lands on the photo modal; `/m` dashboard loads via the lazy chunk; public gallery viewer works unchanged.
- [ ] After merge: tag `v0.15.2`, push, `gh release create` from the new CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)