### PR TITLE
Fix #321: title-bar MapModal persists across month/year nav

### DIFF
--- a/react-app/src/components/Gallery/Title.tsx
+++ b/react-app/src/components/Gallery/Title.tsx
@@ -14,6 +14,7 @@ import galleryPhotosService from "../../services/gallery-photos";
 import {
   useFiltersStore,
   useLastGalleryPathStore,
+  useTitleMapModalStore,
   useUserStore,
 } from "../../stores";
 import type { Gallery } from "../../models/GalleryModel";
@@ -196,7 +197,14 @@ const Title = ({
   lang,
 }: Props): React.ReactElement => {
   const navigate = useNavigate();
-  const [mapOpen, setMapOpen] = React.useState(false);
+  // MapModal open state lives in a Zustand store so the modal
+  // survives URL-driven Title remounts during prev/next month and
+  // year nav (#321). Auto-closers below (gallery switch, context
+  // flip) call `closeMap()` explicitly; Photo-modal mount triggers
+  // it from Gallery/index.tsx.
+  const mapOpen = useTitleMapModalStore((s) => s.isOpen);
+  const openMap = useTitleMapModalStore((s) => s.open);
+  const closeMap = useTitleMapModalStore((s) => s.close);
 
   const { t } = useTranslation();
   const user = useUserStore((s) => s.user);
@@ -298,6 +306,10 @@ const Title = ({
         (gallery) => gallery.id() === event.target.value
       );
       if (targetGallery && gallery.id() !== targetGallery.id()) {
+        // Different gallery means different spatial extent. Drop the
+        // map state so the new gallery starts from a clean opt-in
+        // rather than inheriting the previous gallery's pin set.
+        closeMap();
         navigate(getRedirectPath(targetGallery, context));
       }
     };
@@ -336,6 +348,11 @@ const Title = ({
 
   const switchTo = (target: string) => {
     if (target === context) return;
+    // Context flip (Gallery / Stats / Manage) closes the map — the
+    // new surface has its own affordances (Stats has its own
+    // Location card; Manage is non-spatial) and inheriting the
+    // open state across the flip is just visual noise.
+    closeMap();
     // Stats → Gallery: prefer the remembered last-gallery URL for this
     // gallery so the user lands back on the year/month/day they left
     // from. Falls through to `getRedirectPath` if nothing's been
@@ -349,7 +366,9 @@ const Title = ({
   };
 
   useKeyPress("m", () => {
-    if (mapPhotos.length > 0) setMapOpen((o) => !o);
+    if (mapPhotos.length === 0) return;
+    if (mapOpen) closeMap();
+    else openMap();
   });
   useKeyPress("g", () => switchTo("gallery"));
   useKeyPress("s", () => switchTo("stats"));
@@ -464,7 +483,7 @@ const Title = ({
         {mapPhotos.length > 0 && (
           <MapButton
             type="button"
-            onClick={() => setMapOpen(true)}
+            onClick={openMap}
             aria-label={String(t("stats-location-see-on-map"))}
             title={`${t("stats-location-see-on-map")} (m)`}
           >
@@ -478,7 +497,7 @@ const Title = ({
           title={String(t("stats-category-location"))}
           photos={mapPhotos}
           drawLine={context !== "stats"}
-          onClose={() => setMapOpen(false)}
+          onClose={closeMap}
         />
       )}
     </Root>

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -38,6 +38,7 @@ import {
   useFiltersStore,
   useScrollStore,
   useThemePreferenceStore,
+  useTitleMapModalStore,
 } from "../../stores";
 
 interface Meta {
@@ -104,6 +105,15 @@ const Gallery = ({
       window.removeEventListener("scroll", handleScroll);
     };
   }, [location, setScroll]);
+
+  // Photo modal mount auto-closes the title-bar map (#321) — both
+  // can't compete for the screen, and the photo's own
+  // MetadataPanel map is a separate, pin-centric component anyway.
+  const closeTitleMap = useTitleMapModalStore((s) => s.close);
+  const photoIdFromUrl = useParams().photoId;
+  React.useEffect(() => {
+    if (photoIdFromUrl) closeTitleMap();
+  }, [photoIdFromUrl, closeTitleMap]);
 
   const context = isStats ? "stats" : "gallery";
 

--- a/react-app/src/components/MapContainer.tsx
+++ b/react-app/src/components/MapContainer.tsx
@@ -50,10 +50,14 @@ const getPolyline = (positions: LatLngExpression[]) => {
 
 // react-leaflet's `<MapContainer>` uses `center`, `zoom`, and
 // `bounds` only as the initial setup; prop changes after mount
-// don't move the view. The metadata panel keeps the map mounted
-// while the user navigates between photos, so we need to push
-// the new coordinates into Leaflet's instance manually when the
-// position changes.
+// don't move the view. Two consumers keep the map mounted across
+// position changes:
+//
+//   - MetadataPanel pins to a single photo's coords; navigating
+//     between photos changes `singlePoint` and we re-`setView`.
+//   - Title-bar MapModal (#321) stays open across year/month nav.
+//     `boundsLatLngs` covers the new scope's pin set and we call
+//     `fitBounds` to refit.
 //
 // Re-runs only when `positionKey` actually changes (a stable
 // primitive derived from the coordinates), not on every parent
@@ -61,19 +65,29 @@ const getPolyline = (positions: LatLngExpression[]) => {
 // the map view would animate on every render.
 const Refit = ({
   singlePoint,
+  boundsLatLngs,
   maxZoom,
   positionKey,
 }: {
   singlePoint: LatLngExpression | undefined;
+  boundsLatLngs: LatLngExpression[] | undefined;
   maxZoom: number;
   positionKey: string;
 }): null => {
   const map = useMap();
   const pointRef = React.useRef(singlePoint);
   pointRef.current = singlePoint;
+  const boundsRef = React.useRef(boundsLatLngs);
+  boundsRef.current = boundsLatLngs;
   React.useEffect(() => {
     if (pointRef.current) {
       map.setView(pointRef.current, maxZoom, { animate: false });
+      return;
+    }
+    if (boundsRef.current && boundsRef.current.length > 0) {
+      map.fitBounds(Leaflet.latLngBounds(boundsRef.current), {
+        animate: false,
+      });
     }
   }, [map, positionKey, maxZoom]);
   return null;
@@ -223,6 +237,7 @@ const MapContainer = ({
       >
         <Refit
           singlePoint={center}
+          boundsLatLngs={singlePhoto ? undefined : positions}
           maxZoom={resolvedMaxZoom}
           positionKey={positionKey}
         />

--- a/react-app/src/stores/index.ts
+++ b/react-app/src/stores/index.ts
@@ -8,3 +8,4 @@ export { useChangePasswordModalStore } from "./change-password-modal";
 export { useLastGalleryPathStore } from "./last-gallery-path";
 export { useBetaStore } from "./beta";
 export { useThemePreferenceStore } from "./theme-preference";
+export { useTitleMapModalStore } from "./title-map-modal";

--- a/react-app/src/stores/title-map-modal.ts
+++ b/react-app/src/stores/title-map-modal.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+
+// Title-bar MapModal open state. Lifted out of Title.tsx so the
+// modal survives the URL-driven Title remounts that prev/next month
+// and year nav cause — the operator wants the map to persist while
+// they walk through the calendar (#321). Auto-closers (Photo modal
+// mount, gallery switch, Gallery↔Stats flip) call `close()`
+// explicitly; bare year/month nav doesn't touch the store and the
+// map stays open.
+//
+// Distinct from the per-photo MetadataPanel map, which is its own
+// pin-centric component — this store doesn't reach into it.
+interface TitleMapModalState {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const useTitleMapModalStore = create<TitleMapModalState>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
## Summary

Closes #321. The title-bar map modal used to close every time the operator hit prev/next month or year — local component state didn't survive Title's URL-driven remounts. Now it stays open across those nav events; explicit closers fire for context flips and photo modal mounts.

## Design

Confirmed with operator before implementing:

- **Pan/zoom across nav**: refit bounds to each new month/year's pins on year/month nav. (Photo modal's per-photo map is pin-centric and untouched — different component path.)
- **What nav keeps the map open**: month/year prev-next only. Photo modal open, gallery switch, Gallery ↔ Stats flip all auto-close.
- **No URL state**: open/closed is session-only.
- **X button is a hard close**: stays closed until explicit reopen.

## Implementation

- New `useTitleMapModalStore` (Zustand) — `{ isOpen, open, close }`. Title reads + writes through the store instead of local state.
- Gallery/index.tsx: a `useEffect` watching `photoIdFromUrl` calls `closeTitleMap()` when the photo modal mounts.
- Title.tsx `switchTo()` and the gallery-dropdown `changeHandler` both call `closeMap()` before navigating.
- MapContainer's `<Refit>` grew a `boundsLatLngs` arg so the multi-photo case calls `map.fitBounds(...)` on positionKey change. Single-photo `setView` path stays as it was (drives the MetadataPanel's per-photo map). `animate: false` matches the existing CLAUDE.md guidance on Leaflet view changes.

## Test plan

- [x] Open the map on /g/testing/2020/07, click prev-month — map stays open, pins refit. URL changes to /g/testing/2020/06.
- [x] Open a photo from the gallery while map is open — map closes (only the MetadataPanel's per-photo map remains).
- [x] Flip to Stats via the segmented control — map closes.
- [x] Click X on the modal — map closes and stays closed across subsequent month/year nav until reopened.
- [x] `npm run typecheck && npm test && npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)