### PR TITLE
Fix #576: theme picker into a modal

### DIFF
--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -17,6 +17,7 @@ import Gallery from "./components/Gallery";
 import Notifications from "./components/Notifications";
 import LoginModal from "./components/LoginModal";
 import ChangePasswordModal from "./components/ChangePasswordModal";
+import ThemePickerModal from "./components/ThemePickerModal";
 
 // Admin surface (`/m/*`) + cross-gallery stats (`/s`) are gated on
 // `user.isAdmin()` at runtime — public visitors never see them. Lazy-
@@ -167,6 +168,7 @@ const App = (): React.ReactElement => {
       <Notifications />
       <LoginModal />
       <ChangePasswordModal />
+      <ThemePickerModal />
       <Router>
         <TopMenu />
         <ScrollToPosition>

--- a/react-app/src/components/ThemePickerModal.tsx
+++ b/react-app/src/components/ThemePickerModal.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { useTranslation } from "react-i18next";
+
+import ThemePicker from "./ThemePicker";
+import {
+  useThemePickerModalStore,
+  useThemePreferenceStore,
+} from "../stores";
+
+// `position: fixed; inset: 0` overlay over the rest of the app. The
+// picker has a swatch grid that grows with the theme count, so the
+// modal needs to scroll when it doesn't fit — `align-items: flex-
+// start` + `overflow: auto` on the backdrop. z-index above
+// MetadataPanel + Photo modal.
+const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 2000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 20px;
+  overflow: auto;
+`;
+const ModalBox = styled.div`
+  background: var(--primary-background);
+  color: var(--primary-color);
+  border: 1px solid var(--inactive-color);
+  border-radius: 6px;
+  padding: 20px;
+  width: 100%;
+  max-width: 560px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+  margin: auto 0;
+`;
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 14px;
+`;
+const Title = styled.h2`
+  margin: 0;
+  font-size: 1.1em;
+`;
+const CloseButton = styled.button`
+  border: none;
+  background: none;
+  color: var(--inactive-color);
+  font-size: 1.2em;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+  &:hover {
+    color: var(--primary-color);
+  }
+`;
+
+// Theme picker as a dedicated modal opened from the UserMenu (#576).
+// Owns the hover-preview state: open syncs `committedTheme` from the
+// store; hovering a swatch live-previews via `setPreference`; clicking
+// commits both; closing without a click reverts the preview. Same
+// semantics the inline UserMenu picker had before, just moved out.
+const ThemePickerModal = (): React.ReactElement | null => {
+  const { t } = useTranslation();
+  const isOpen = useThemePickerModalStore((s) => s.isOpen);
+  const close = useThemePickerModalStore((s) => s.close);
+  const themePreference = useThemePreferenceStore((s) => s.preference);
+  const setThemePreference = useThemePreferenceStore((s) => s.setPreference);
+
+  const [committedTheme, setCommittedTheme] = React.useState<string | null>(
+    themePreference
+  );
+  const prevIsOpenRef = React.useRef(isOpen);
+  React.useEffect(() => {
+    if (isOpen && !prevIsOpenRef.current) {
+      // Modal opening: snapshot the current preference as the
+      // committed baseline. Hover preview can roam from here.
+      setCommittedTheme(themePreference);
+    } else if (!isOpen && prevIsOpenRef.current) {
+      // Modal closing: if the active preference drifted (uncommitted
+      // hover preview), restore the committed value.
+      if (themePreference !== committedTheme) {
+        setThemePreference(committedTheme);
+      }
+    }
+    prevIsOpenRef.current = isOpen;
+  }, [isOpen, themePreference, committedTheme, setThemePreference]);
+
+  React.useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [isOpen, close]);
+
+  if (!isOpen) return null;
+
+  const onBackdropClick = (event: React.MouseEvent) => {
+    if (event.target === event.currentTarget) close();
+  };
+  const onPreview = (id: string | null) => {
+    // null from ThemePicker means "mouse left the grid" — restore
+    // committed. Otherwise live-preview the hovered theme.
+    if (id === null) {
+      if (themePreference !== committedTheme) {
+        setThemePreference(committedTheme);
+      }
+      return;
+    }
+    setThemePreference(id);
+  };
+  const onChange = (id: string | null) => {
+    setCommittedTheme(id);
+    setThemePreference(id);
+  };
+
+  return (
+    <Backdrop
+      onClick={onBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="theme-picker-modal-title"
+    >
+      <ModalBox>
+        <Header>
+          <Title id="theme-picker-modal-title">{t("theme-label")}</Title>
+          <CloseButton
+            type="button"
+            onClick={close}
+            aria-label={t("close")}
+          >
+            ╳
+          </CloseButton>
+        </Header>
+        <ThemePicker
+          value={committedTheme}
+          onChange={onChange}
+          onPreview={onPreview}
+          defaultLabel={String(t("theme-follow-default"))}
+        />
+      </ModalBox>
+    </Backdrop>
+  );
+};
+export default ThemePickerModal;

--- a/react-app/src/components/UserMenu.tsx
+++ b/react-app/src/components/UserMenu.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { BsPersonFill, BsPerson } from "react-icons/bs";
 
-import ThemePicker from "./ThemePicker";
+import theme from "../lib/theme";
 import { useHostScope } from "../lib/use-host-scope";
 import token from "../lib/token";
 import tokenService from "../services/tokens";
@@ -15,6 +15,7 @@ import {
   useChangePasswordModalStore,
   useBetaStore,
   useThemePreferenceStore,
+  useThemePickerModalStore,
 } from "../stores";
 import { BETA_FEATURES } from "../stores/beta";
 
@@ -96,16 +97,15 @@ const BetaToggle = styled.label`
     color: var(--header-color);
   }
 `;
-const ThemeBlock = styled.div`
+const ThemeMenuItem = styled(MenuItem)`
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 8px 14px;
-  color: var(--primary-color);
-  font: inherit;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 10px;
 `;
-const ThemeBlockLabel = styled.span`
-  font-size: 0.95em;
+const ThemeMenuValue = styled.span`
+  color: var(--inactive-color);
+  font-size: 0.9em;
 `;
 
 // Profile icon in the top-right of the top menu. Anonymous (outlined) when
@@ -128,41 +128,19 @@ const UserMenu = (): React.ReactElement => {
     (f) => betaModes[f] === "user"
   );
   const themePreference = useThemePreferenceStore((s) => s.preference);
-  const setThemePreference = useThemePreferenceStore((s) => s.setPreference);
+  const openThemeModal = useThemePickerModalStore((s) => s.open);
+  // Resolve the committed theme's display name for the menu item's
+  // value suffix. `null` means "Follow gallery default" — fall back to
+  // the i18n label. An unknown id (renamed / removed theme) falls back
+  // to the raw id rather than blanking the menu item.
+  const themeLabel = (() => {
+    if (themePreference === null) return t("theme-follow-default");
+    const entry = theme.manifest.find((e) => e.id === themePreference);
+    return entry?.displayName ?? themePreference;
+  })();
 
   const [isOpen, setIsOpen] = React.useState(false);
   const rootRef = React.useRef<HTMLDivElement>(null);
-
-  // Hover-preview model: hovering a swatch applies the theme live (via
-  // the same store the rest of the app reads), moving away or closing
-  // the picker restores the committed value. `committedTheme` mirrors
-  // what the user clicked; sync it from the store only when the picker
-  // opens, so previewing during hover doesn't move the active outline.
-  const [committedTheme, setCommittedTheme] = React.useState<string | null>(
-    themePreference
-  );
-  const prevIsOpenRef = React.useRef(isOpen);
-  React.useEffect(() => {
-    if (isOpen && !prevIsOpenRef.current) {
-      setCommittedTheme(themePreference);
-    } else if (!isOpen && prevIsOpenRef.current) {
-      if (themePreference !== committedTheme) {
-        setThemePreference(committedTheme);
-      }
-    }
-    prevIsOpenRef.current = isOpen;
-  }, [isOpen, themePreference, committedTheme, setThemePreference]);
-
-  const onSwatchEnter = (id: string | null) => setThemePreference(id);
-  const onGridLeave = () => {
-    if (themePreference !== committedTheme) {
-      setThemePreference(committedTheme);
-    }
-  };
-  const onSwatchClick = (id: string | null) => {
-    setCommittedTheme(id);
-    setThemePreference(id);
-  };
 
   React.useEffect(() => {
     if (!isOpen) return;
@@ -267,18 +245,17 @@ const UserMenu = (): React.ReactElement => {
               {t("stats-menu-entry")}
             </MenuItem>
           )}
-          <ThemeBlock>
-            <ThemeBlockLabel>{t("theme-label")}</ThemeBlockLabel>
-            <ThemePicker
-              value={committedTheme}
-              onChange={onSwatchClick}
-              onPreview={(id) => {
-                if (id === null) onGridLeave();
-                else onSwatchEnter(id);
-              }}
-              defaultLabel={String(t("theme-follow-default"))}
-            />
-          </ThemeBlock>
+          <ThemeMenuItem
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setIsOpen(false);
+              openThemeModal();
+            }}
+          >
+            <span>{t("theme-label")}</span>
+            <ThemeMenuValue>{themeLabel}</ThemeMenuValue>
+          </ThemeMenuItem>
           {userBetaFeatures.map((f) => (
             <BetaToggle key={f}>
               <input

--- a/react-app/src/stores/index.ts
+++ b/react-app/src/stores/index.ts
@@ -8,4 +8,5 @@ export { useChangePasswordModalStore } from "./change-password-modal";
 export { useLastGalleryPathStore } from "./last-gallery-path";
 export { useBetaStore } from "./beta";
 export { useThemePreferenceStore } from "./theme-preference";
+export { useThemePickerModalStore } from "./theme-picker-modal";
 export { useTitleMapModalStore } from "./title-map-modal";

--- a/react-app/src/stores/theme-picker-modal.ts
+++ b/react-app/src/stores/theme-picker-modal.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+
+// Theme picker modal opens from the UserMenu — gets the swatch grid
+// off the menu's flat surface and into a focused modal (#576). Mirrors
+// the other global-modal stores (login, change-password).
+interface ThemePickerModalState {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const useThemePickerModalStore = create<ThemePickerModalState>(
+  (set) => ({
+    isOpen: false,
+    open: () => set({ isOpen: true }),
+    close: () => set({ isOpen: false }),
+  })
+);


### PR DESCRIPTION
## Summary

Closes #576. The theme swatch grid dominated the UserMenu dropdown — moving it into a focused modal lets the menu's smaller items (logout, change-password, language radios, beta toggles) breathe.

## What changed

- **`useThemePickerModalStore`** mirrors the existing global modal stores (login, change-password). One-liner `{isOpen, open, close}`.
- **`<ThemePickerModal>`** owns the hover-preview state: open snapshots the committed theme, hover live-previews via `useThemePreferenceStore`, click commits, close-without-click reverts. Same contract the inline UserMenu picker had, just scoped to the modal. Backdrop click + Escape + X all close. Scrolls within the modal box when the grid grows past the viewport.
- **`<UserMenu>`** drops the inline `<ThemePicker>` block. A new menu item shows `Theme: <current display name>` and opens the modal. Renamed / removed themes still cached in localStorage fall back to the raw id rather than blanking the label.
- **`<App>`** mounts `<ThemePickerModal>` next to LoginModal / ChangePasswordModal.

## Test plan

- [x] `npm run typecheck && npm test && npm run lint` clean.
- [x] Playwright on dev: open UserMenu → see `Theme: <name>` row; click it → modal opens with the full swatch grid (20 buttons including the default-row).
- [ ] Hover-preview semantics: hover a swatch live-previews; closing the modal without clicking restores the committed theme.
- [ ] Clicking a swatch commits and stays open so the operator can keep clicking to compare.
- [ ] After commit, UserMenu's `Theme: <name>` value reflects the new selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)