### PR TITLE
Fix #574: kill the /m/photos cache-miss page flash

### DIFF
--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -18,6 +18,7 @@ import Notifications from "./components/Notifications";
 import LoginModal from "./components/LoginModal";
 import ChangePasswordModal from "./components/ChangePasswordModal";
 import ThemePickerModal from "./components/ThemePickerModal";
+import GlobalFetchIndicator from "./components/GlobalFetchIndicator";
 
 // Admin surface (`/m/*`) + cross-gallery stats (`/s`) are gated on
 // `user.isAdmin()` at runtime — public visitors never see them. Lazy-
@@ -165,6 +166,7 @@ const App = (): React.ReactElement => {
       <title>Photo diary</title>
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <meta name="robots" content="noindex" />
+      <GlobalFetchIndicator />
       <Notifications />
       <LoginModal />
       <ChangePasswordModal />

--- a/react-app/src/components/GlobalFetchIndicator.tsx
+++ b/react-app/src/components/GlobalFetchIndicator.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { keyframes } from "@emotion/react";
+import styled from "@emotion/styled";
+import { useIsFetching } from "@tanstack/react-query";
+
+// Top-of-viewport progress bar shown while any TanStack Query is
+// fetching. Pairs with the `keepPreviousData` sweep (#574) — the
+// page no longer unmounts to a loader, but the operator still
+// wants feedback that a refetch is in flight after a chip toggle
+// or drawer open. 2px bar slides a gradient horizontally; hides
+// completely when nothing's fetching.
+//
+// Mounted once in App.tsx so the signal works across every route.
+
+const slide = keyframes`
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+`;
+const Bar = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  z-index: 2500;
+  overflow: hidden;
+  background: transparent;
+  pointer-events: none;
+`;
+const Pulse = styled.div`
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--primary-color) 50%,
+    transparent 100%
+  );
+  animation: ${slide} 1.2s linear infinite;
+`;
+
+// Tiny anti-flicker debounce — render the bar only when a fetch
+// has been in flight for ≥ ~120 ms. Cached responses resolve
+// faster than the eye can register, and rendering the bar for
+// 50 ms feels like noise.
+const SHOW_AFTER_MS = 120;
+
+const GlobalFetchIndicator = (): React.ReactElement | null => {
+  const fetching = useIsFetching();
+  const [show, setShow] = React.useState(false);
+  React.useEffect(() => {
+    if (fetching === 0) {
+      setShow(false);
+      return;
+    }
+    const handle = window.setTimeout(() => setShow(true), SHOW_AFTER_MS);
+    return () => window.clearTimeout(handle);
+  }, [fetching]);
+  if (!show) return null;
+  return (
+    <Bar role="status" aria-live="polite" aria-label="Loading">
+      <Pulse />
+    </Bar>
+  );
+};
+export default GlobalFetchIndicator;

--- a/react-app/src/components/Manage/PhotoDrawer.tsx
+++ b/react-app/src/components/Manage/PhotoDrawer.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   BsArrowClockwise,
   BsBookmarkStar,
@@ -755,6 +760,12 @@ const PhotoDrawer = (): React.ReactElement => {
   const { data, isLoading, isError } = useQuery({
     queryKey: ["manage-photo", id],
     queryFn: () => photosService.get(id) as Promise<PhotoData>,
+    // Keep the previous drawer's data painted while a different
+    // photo's row is opened — the parent grid stays put thanks to
+    // keepPreviousData on `manage-photos`, and the drawer mirroring
+    // that keeps the transition smooth instead of flashing "loading"
+    // mid-swap (#574).
+    placeholderData: keepPreviousData,
   });
 
   // Galleries fetched once for the whole drawer to resolve the

--- a/react-app/src/components/Manage/Photos.tsx
+++ b/react-app/src/components/Manage/Photos.tsx
@@ -8,7 +8,11 @@ import {
 } from "react-router-dom";
 import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { BsCheck, BsFunnel, BsXLg } from "react-icons/bs";
 
 import photosService, {
@@ -578,6 +582,12 @@ const Photos = (): React.ReactElement => {
   const { data, isLoading, isError } = useQuery({
     queryKey: ["manage-photos", filter, page, PAGE_SIZE, photoIdFocus],
     queryFn: () => photosService.list(filter, page, PAGE_SIZE, photoIdFocus),
+    // Hold the previous grid while a chip toggle / page flip / drawer
+    // open refetches under a new key — without this the whole grid
+    // unmounts to "loading" between renders (#574). isLoading still
+    // fires on the very first mount; from then on cache misses paint
+    // the previous data + refetch in the background.
+    placeholderData: keepPreviousData,
   });
 
   // Filter for the sidebar timeline — strip dateFrom / dateTo so
@@ -593,6 +603,7 @@ const Photos = (): React.ReactElement => {
   const timelineQuery = useQuery({
     queryKey: ["manage-photos-year-months", timelineFilter],
     queryFn: () => photosService.getYearMonths(timelineFilter),
+    placeholderData: keepPreviousData,
   });
 
   // After photoIdFocus resolves a non-1 page, write it back to the


### PR DESCRIPTION
## Summary

Closes #574. The operator-reported pain: clicking a photo on `/m/photos` to open the drawer unmounted the whole grid to "Loading…" until the new fetch landed. Same shape for chip toggles + page flips. Two pieces of fix:

1. **`keepPreviousData` on the cache-miss-prone queries** — `manage-photos`, `manage-photos-year-months` (sidebar timeline), and `manage-photo` (drawer). The previous render stays painted while the new query resolves in the background. `isLoading` still fires on the very first mount; only cache misses get the smooth handoff.

2. **`<GlobalFetchIndicator>`** — small new component mounted in App.tsx. Reads `useIsFetching()` and paints a thin 2 px gradient bar at the top of the viewport while any TanStack query is in flight. 120 ms debounce keeps cached-response flashes off the screen. Restores the "something's happening" feedback the keepPreviousData change removed for the cache-miss case.

## Audit notes — what stays as-is

The single-entity admin edits (UserEdit / GroupEdit / GalleryEdit) keep their full-page `<Notice>Loading</Notice>` because applying `keepPreviousData` there would briefly render the previous entity's data under the new URL (e.g. switching `/m/users/alice` → `/m/users/bob` would show Alice's name on Bob's page). The honest-flash is the right behaviour there.

List pages (Galleries / Users / Groups / Access) only refetch on cold load or post-mutation invalidation — the flash there is rare + brief, and these pages don't have the URL-key-changes-while-mounted pattern that `keepPreviousData` is designed for.

## Test plan

- [x] `npm run typecheck && npm test && npm run lint` clean.
- [x] Playwright on dev: `/m/photos` shows 100 thumbnails. Click a thumbnail to open the drawer — thumbnail count stays at 100 before, immediately after, and after the drawer settles. No unmount-to-loader between renders.
- [ ] Chip toggle on `/m/photos` keeps the grid painted while the filtered result fetches.
- [ ] Page flip via the bottom paginator keeps the previous page's grid painted briefly.
- [ ] On a slow connection (DevTools throttling), the top progress bar appears while fetches are in flight; doesn't appear for warm-cache responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)