### PR TITLE
Fix #585: drag-and-drop gallery ordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "0.14.0",
+  "version": "0.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "0.14.0",
+      "version": "0.15.2",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -19,7 +19,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "0.14.0",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -391,6 +391,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -10628,8 +10681,11 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "0.14.0",
+      "version": "0.15.2",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@react-leaflet/core": "^3.0.0",
@@ -10956,7 +11012,7 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "0.14.0",
+      "version": "0.15.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -16,6 +16,9 @@
     "api:codegen": "openapi-typescript ../server/openapi.json -o src/lib/api-schema.ts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@react-leaflet/core": "^3.0.0",

--- a/react-app/src/components/Manage/Galleries.tsx
+++ b/react-app/src/components/Manage/Galleries.tsx
@@ -2,13 +2,34 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
-import { useQuery } from "@tanstack/react-query";
-import { BsImages, BsPlus, BsShieldLock } from "react-icons/bs";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  BsGripVertical,
+  BsImages,
+  BsPlus,
+  BsShieldLock,
+  BsSortAlphaDown,
+} from "react-icons/bs";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 import GalleryTypeIcon from "./GalleryTypeIcon";
 import config from "../../lib/config";
 import galleriesService from "../../services/galleries";
-import { useUserStore } from "../../stores";
+import { useNotificationsStore, useUserStore } from "../../stores";
 
 // body has text-align: center globally; cancel it here so column
 // content (and the heading above the table) lines up with the
@@ -44,6 +65,56 @@ const CreateButton = styled.button`
   border-radius: 4px;
   font-size: 0.85em;
   cursor: pointer;
+`;
+const TitleActions = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+`;
+const SortButton = styled.button`
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: var(--primary-background);
+  color: var(--primary-color);
+  border: 1px solid var(--inactive-color);
+  border-radius: 4px;
+  font-size: 0.85em;
+  cursor: pointer;
+  &:hover:not(:disabled) {
+    background: var(--header-background);
+    color: var(--header-color);
+  }
+  &:disabled {
+    color: var(--inactive-color);
+    cursor: not-allowed;
+  }
+`;
+const DragHandleCell = styled.td`
+  padding: 8px 0 8px 4px;
+  width: 24px;
+  vertical-align: middle;
+`;
+const DragHandle = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--inactive-color);
+  cursor: grab;
+  font-size: 1.1em;
+  &:hover {
+    color: var(--primary-color);
+  }
+  &:active {
+    cursor: grabbing;
+  }
 `;
 const Notice = styled.p`
   color: var(--inactive-color);
@@ -160,10 +231,114 @@ interface GalleryRow {
   type?: "real" | "hybrid" | "saved_filter";
 }
 
+// One row of the gallery list. Wraps with @dnd-kit/sortable so the
+// drag handle in the leftmost cell moves the row; the rest of the
+// row keeps the existing "click anywhere to open" behaviour. Drag-
+// translate updates inline via the transform/transition styles
+// `useSortable` returns.
+interface SortableRowProps {
+  gallery: GalleryRow;
+}
+const SortableRow = ({ gallery }: SortableRowProps): React.ReactElement => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const {
+    setNodeRef,
+    transform,
+    transition,
+    listeners,
+    attributes,
+    isDragging,
+  } = useSortable({ id: gallery.id });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : 1,
+  };
+  return (
+    <Row
+      ref={setNodeRef}
+      style={style}
+      onClick={() => navigate(`/m/g/${gallery.id}`)}
+    >
+      <DragHandleCell onClick={(e) => e.stopPropagation()}>
+        <DragHandle
+          type="button"
+          aria-label={String(t("manage-galleries-drag-handle"))}
+          title={String(t("manage-galleries-drag-handle"))}
+          {...attributes}
+          {...listeners}
+        >
+          <BsGripVertical aria-hidden />
+        </DragHandle>
+      </DragHandleCell>
+      <IconCell>
+        {gallery.icon ? (
+          <IconImg
+            src={`${config.PHOTO_ROOT_URL}${gallery.icon}`}
+            alt=""
+            loading="lazy"
+          />
+        ) : (
+          <IconPlaceholder aria-hidden />
+        )}
+      </IconCell>
+      <Td>
+        <IdCell>
+          <GalleryTypeIcon type={gallery.type} />
+          <Mono>{gallery.id}</Mono>
+        </IdCell>
+      </Td>
+      <Td>{gallery.title || ""}</Td>
+      <Td>{gallery.epoch ? gallery.epoch.substring(0, 10) : ""}</Td>
+      <Td>
+        <Mono>{gallery.hostname || ""}</Mono>
+      </Td>
+      <Td>{gallery.theme || ""}</Td>
+      <Td>
+        <Actions>
+          <ActionButton
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/m/photos?gallery=${gallery.id}`);
+            }}
+            role="link"
+            tabIndex={0}
+            title={String(t("manage-gallery-link-photos"))}
+          >
+            <BsImages aria-hidden />
+            {t("manage-gallery-link-photos")}
+          </ActionButton>
+          <ActionButton
+            onClick={(e) => {
+              e.stopPropagation();
+              navigate(`/m/g/${gallery.id}/access`);
+            }}
+            role="link"
+            tabIndex={0}
+            title={String(t("manage-gallery-link-access"))}
+          >
+            <BsShieldLock aria-hidden />
+            {t("manage-gallery-link-access")}
+          </ActionButton>
+        </Actions>
+      </Td>
+    </Row>
+  );
+};
+
 const Galleries = (): React.ReactElement => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const user = useUserStore((s) => s.user);
+  const queryClient = useQueryClient();
+  const notify = useNotificationsStore((s) => s.notify);
+  // 4 px activation distance keeps row-clicks from being interpreted
+  // as drags — operators can click a row to open it without the
+  // handle stealing the gesture.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } })
+  );
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ["manage-galleries", user?.id ?? null],
@@ -171,24 +346,73 @@ const Galleries = (): React.ReactElement => {
     enabled: !!user?.isAdmin(),
   });
 
+  // Server returns galleries in (ordinal, id) order — render in that
+  // order without re-sorting client-side. Rows are the cache
+  // representation; drag-end calls the reorder mutation which
+  // optimistically rewrites the cache via setQueryData.
   const rows = React.useMemo<GalleryRow[]>(() => {
     if (!Array.isArray(data)) return [];
-    return (data as GalleryRow[]).slice().sort((a, b) =>
-      a.id.localeCompare(b.id)
-    );
+    return data as GalleryRow[];
   }, [data]);
+
+  const reorderMutation = useMutation({
+    mutationFn: (ids: string[]) => galleriesService.reorder(ids),
+    onError: (err: Error) => {
+      // Revert: refetch to ditch the optimistic order.
+      queryClient.invalidateQueries({ queryKey: ["manage-galleries"] });
+      notify("error", err.message);
+    },
+    onSuccess: () => {
+      // Public surfaces (picker, title selector) consume the same
+      // gallery list — invalidate so they pick up the new order too.
+      queryClient.invalidateQueries({ queryKey: ["galleries"] });
+    },
+  });
+
+  const applyOrder = (ids: string[]) => {
+    const before = data as GalleryRow[] | undefined;
+    if (!before) return;
+    const byId = new Map(before.map((g) => [g.id, g]));
+    const next = ids.map((id) => byId.get(id)).filter(Boolean) as GalleryRow[];
+    queryClient.setQueryData(["manage-galleries", user?.id ?? null], next);
+    reorderMutation.mutate(ids);
+  };
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const ids = rows.map((g) => g.id);
+    const from = ids.indexOf(active.id as string);
+    const to = ids.indexOf(over.id as string);
+    if (from < 0 || to < 0) return;
+    applyOrder(arrayMove(ids, from, to));
+  };
+  const handleSortById = () => {
+    const ids = rows.map((g) => g.id).slice().sort();
+    applyOrder(ids);
+  };
 
   return (
     <Root>
       <TitleRow>
         <Title>{t("manage-page-galleries-title")}</Title>
-        <CreateButton
-          type="button"
-          onClick={() => navigate("/m/galleries/new")}
-        >
-          <BsPlus aria-hidden />
-          {t("manage-galleries-create")}
-        </CreateButton>
+        <TitleActions>
+          <SortButton
+            type="button"
+            onClick={handleSortById}
+            disabled={rows.length === 0 || reorderMutation.isPending}
+            title={String(t("manage-galleries-sort-by-id"))}
+          >
+            <BsSortAlphaDown aria-hidden />
+            {t("manage-galleries-sort-by-id")}
+          </SortButton>
+          <CreateButton
+            type="button"
+            onClick={() => navigate("/m/galleries/new")}
+          >
+            <BsPlus aria-hidden />
+            {t("manage-galleries-create")}
+          </CreateButton>
+        </TitleActions>
       </TitleRow>
       {isLoading ? (
         <Notice>{t("loading")}</Notice>
@@ -198,76 +422,36 @@ const Galleries = (): React.ReactElement => {
         <Notice>{t("manage-galleries-empty")}</Notice>
       ) : (
         <TableScroll>
-          <Table>
-            <thead>
-            <tr>
-              <Th></Th>
-              <Th>{t("manage-galleries-col-id")}</Th>
-              <Th>{t("manage-galleries-col-title")}</Th>
-              <Th>{t("manage-galleries-col-epoch")}</Th>
-              <Th>{t("manage-galleries-col-hostname")}</Th>
-              <Th>{t("manage-galleries-col-theme")}</Th>
-              <Th></Th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map((g) => (
-              <Row key={g.id} onClick={() => navigate(`/m/g/${g.id}`)}>
-                <IconCell>
-                  {g.icon ? (
-                    <IconImg
-                      src={`${config.PHOTO_ROOT_URL}${g.icon}`}
-                      alt=""
-                      loading="lazy"
-                    />
-                  ) : (
-                    <IconPlaceholder aria-hidden />
-                  )}
-                </IconCell>
-                <Td>
-                  <IdCell>
-                    <GalleryTypeIcon type={g.type} />
-                    <Mono>{g.id}</Mono>
-                  </IdCell>
-                </Td>
-                <Td>{g.title || ""}</Td>
-                <Td>{g.epoch ? g.epoch.substring(0, 10) : ""}</Td>
-                <Td>
-                  <Mono>{g.hostname || ""}</Mono>
-                </Td>
-                <Td>{g.theme || ""}</Td>
-                <Td>
-                  <Actions>
-                    <ActionButton
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        navigate(`/m/photos?gallery=${g.id}`);
-                      }}
-                      role="link"
-                      tabIndex={0}
-                      title={String(t("manage-gallery-link-photos"))}
-                    >
-                      <BsImages aria-hidden />
-                      {t("manage-gallery-link-photos")}
-                    </ActionButton>
-                    <ActionButton
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        navigate(`/m/g/${g.id}/access`);
-                      }}
-                      role="link"
-                      tabIndex={0}
-                      title={String(t("manage-gallery-link-access"))}
-                    >
-                      <BsShieldLock aria-hidden />
-                      {t("manage-gallery-link-access")}
-                    </ActionButton>
-                  </Actions>
-                </Td>
-              </Row>
-            ))}
-          </tbody>
-          </Table>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <Table>
+              <thead>
+                <tr>
+                  <Th></Th>
+                  <Th></Th>
+                  <Th>{t("manage-galleries-col-id")}</Th>
+                  <Th>{t("manage-galleries-col-title")}</Th>
+                  <Th>{t("manage-galleries-col-epoch")}</Th>
+                  <Th>{t("manage-galleries-col-hostname")}</Th>
+                  <Th>{t("manage-galleries-col-theme")}</Th>
+                  <Th></Th>
+                </tr>
+              </thead>
+              <SortableContext
+                items={rows.map((g) => g.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                <tbody>
+                  {rows.map((g) => (
+                    <SortableRow key={g.id} gallery={g} />
+                  ))}
+                </tbody>
+              </SortableContext>
+            </Table>
+          </DndContext>
         </TableScroll>
       )}
     </Root>

--- a/react-app/src/lib/api-schema.ts
+++ b/react-app/src/lib/api-schema.ts
@@ -606,6 +606,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/galleries/_order": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reorder galleries (admin) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        ids: string[];
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/galleries/{galleryId}": {
         parameters: {
             query?: never;

--- a/react-app/src/lib/translations/en.json
+++ b/react-app/src/lib/translations/en.json
@@ -288,6 +288,8 @@
     "manage-gallery-type-hybrid": "Hybrid gallery",
     "manage-gallery-type-saved-filter": "Saved filter",
     "manage-gallery-epoch-today": "Today",
+    "manage-galleries-drag-handle": "Drag to reorder",
+    "manage-galleries-sort-by-id": "Sort by id",
     "manage-gallery-load-error": "Failed to load gallery.",
     "manage-gallery-save-error": "Failed to save changes",
     "manage-gallery-section-content": "Content",

--- a/react-app/src/lib/translations/fi.json
+++ b/react-app/src/lib/translations/fi.json
@@ -288,6 +288,8 @@
     "manage-gallery-type-hybrid": "Hybridigalleria",
     "manage-gallery-type-saved-filter": "Tallennettu suodatin",
     "manage-gallery-epoch-today": "Tänään",
+    "manage-galleries-drag-handle": "Vedä järjestääksesi uudelleen",
+    "manage-galleries-sort-by-id": "Järjestä tunnisteen mukaan",
     "manage-gallery-load-error": "Gallerian lataus epäonnistui.",
     "manage-gallery-save-error": "Tallennus epäonnistui",
     "manage-gallery-section-content": "Sisältö",

--- a/react-app/src/lib/translations/ja.json
+++ b/react-app/src/lib/translations/ja.json
@@ -288,6 +288,8 @@
     "manage-gallery-type-hybrid": "ハイブリッドギャラリー",
     "manage-gallery-type-saved-filter": "保存済みフィルター",
     "manage-gallery-epoch-today": "今日",
+    "manage-galleries-drag-handle": "ドラッグして並べ替え",
+    "manage-galleries-sort-by-id": "IDで並べ替え",
     "manage-gallery-load-error": "ギャラリーの読み込みに失敗しました。",
     "manage-gallery-save-error": "保存に失敗しました",
     "manage-gallery-section-content": "内容",

--- a/react-app/src/services/galleries.ts
+++ b/react-app/src/services/galleries.ts
@@ -98,4 +98,16 @@ const setIcon = async (
     })
   ) as Promise<{ icon: string }>;
 
-export default { getAll, get, update, create, remove, setIcon };
+// Apply operator-curated gallery order (#585). `ids` must cover
+// every current gallery exactly once — server rejects partial lists
+// with 422 so callers don't accidentally strand untouched galleries
+// at ordinal 0.
+const reorder = async (ids: string[]): Promise<void> => {
+  await unwrap(
+    api.POST("/api/v1/galleries/_order", {
+      body: { ids },
+    })
+  );
+};
+
+export default { getAll, get, update, create, remove, setIcon, reorder };

--- a/server/controllers/galleries-v1.ts
+++ b/server/controllers/galleries-v1.ts
@@ -145,6 +145,33 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
   );
 
   /**
+   * Apply operator-curated gallery sort order (#585). Body is an
+   * ordered list of gallery ids covering exactly the current
+   * gallery set. Admin-only. Underscore-prefix path keeps the
+   * literal segment off the slug-id namespace (`assertSlugId`
+   * rejects ids starting with anything other than [a-z0-9]).
+   */
+  fastify.post(
+    "/_order",
+    {
+      schema: {
+        tags: TAGS,
+        summary: "Reorder galleries (admin)",
+        body: Type.Object(
+          { ids: Type.Array(Type.String({ minLength: 1 })) },
+          { additionalProperties: false }
+        ),
+        security: [{ bearer: [] }],
+      },
+    },
+    async (request, reply) => {
+      await authorizer.authorizeAdmin(request.user.id);
+      await model.setGalleryOrder(request.body.ids);
+      reply.status(204).send();
+    }
+  );
+
+  /**
    * Create a new gallery.
    */
   fastify.post(

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -215,6 +215,9 @@ export default {
   loadGalleries: async () => {
     return await db.loadGalleries();
   },
+  setGalleryOrder: async (ids: string[]): Promise<void> => {
+    await db.setGalleryOrder(ids);
+  },
   createGallery: async (gallery: GalleryInput) => {
     await db.createGallery(gallery as Gallery);
   },

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -83,6 +83,7 @@ export default () => {
     deleteGroupGallery,
 
     loadGalleries,
+    setGalleryOrder,
     createGallery,
     loadGallery,
     updateGallery,
@@ -774,6 +775,7 @@ const createSavedFilter = async (filter: SavedFilter): Promise<void> => {
         hostname: "",
         defaultLanguage: sourceRow.default_language || "en",
         type: "saved_filter",
+        ordinal: 0,
       })
     );
     db.prepare(
@@ -984,6 +986,20 @@ const upsertGalleryLocalizedFields = (
 };
 const deleteGallery = async (galleryId: string) =>
   deleteById(SCHEMA.gallery, galleryId);
+
+// Apply an operator-curated gallery order (#585). Caller has
+// already validated that `ids` covers exactly the gallery id set,
+// so this just stamps each row's ordinal by position. Single
+// transaction so a half-applied reorder can't leak.
+const setGalleryOrder = async (ids: string[]): Promise<void> => {
+  const stmt = db.prepare("UPDATE gallery SET ordinal = ? WHERE id = ?");
+  const tx = db.transaction((list: string[]) => {
+    list.forEach((id, idx) => {
+      stmt.run(idx, id);
+    });
+  });
+  tx(ids);
+};
 
 const loadGalleryPhotos = async (galleryId: string, lang?: string) => {
   const schema = SCHEMA.photo;

--- a/server/db/sqlite3/migrations/025_gallery_ordinal.sql
+++ b/server/db/sqlite3/migrations/025_gallery_ordinal.sql
@@ -1,0 +1,15 @@
+-- Operator-curated gallery sort order (#585).
+--
+-- `gallery.id ASC` was the implicit sort everywhere — fine when ids
+-- are slug-shaped and roughly chronological, but the operator wants
+-- to override for the public picker / title-bar selector / admin
+-- list. New `ordinal` column drives the primary sort; id stays as
+-- the tiebreak so untouched galleries (all ordinal 0) preserve
+-- today's order exactly.
+--
+-- Bare `ALTER TABLE ADD COLUMN ... DEFAULT 0` is fine on existing
+-- rows; nothing here needs `gallery_new` rebuild dance.
+
+ALTER TABLE gallery ADD COLUMN ordinal INTEGER NOT NULL DEFAULT 0;
+
+UPDATE meta SET value='25' WHERE key='schema_version';

--- a/server/db/sqlite3/schema.ts
+++ b/server/db/sqlite3/schema.ts
@@ -69,6 +69,10 @@ export interface GalleryRow {
   // the column default.
   default_language: string;
   type: GalleryType;
+  // Operator-curated sort index (#585). Drives the primary sort
+  // for `loadGalleries`; id is the tiebreak. Untouched rows
+  // (all-zero) preserve the id-ASC order they had before.
+  ordinal: number;
 }
 export interface GalleryLocalizedRow {
   gallery_id: string;
@@ -170,6 +174,9 @@ export interface Gallery {
   // Discriminates how the gallery's photos are resolved at read
   // time. See `GalleryType`.
   type: GalleryType;
+  // Operator-curated sort index (#585). 0 by default; lower comes
+  // first. Tiebreak is gallery id ASC.
+  ordinal: number;
   // Hybrid galleries only: source gallery IDs whose photos union
   // into this one. Undefined for real and saved-filter galleries.
   sources?: string[];
@@ -467,6 +474,7 @@ export default () => {
         titleLocalized: buildLocalizedMap(localized, "title"),
         descriptionLocalized: buildLocalizedMap(localized, "description"),
         type: row.type ?? "real",
+        ordinal: row.ordinal ?? 0,
       }),
       mapInsert: (gallery: Gallery): unknown[] => [
         gallery.id,
@@ -481,6 +489,7 @@ export default () => {
         gallery.hostname,
         gallery.defaultLanguage || "en",
         gallery.type ?? "real",
+        gallery.ordinal ?? 0,
       ],
 
       buildCreateQuery: () => buildCreateQuery(SCHEMA.gallery),
@@ -763,6 +772,7 @@ const galleryMapToRow = (
   if ("defaultLanguage" in gallery)
     result.default_language = gallery.defaultLanguage;
   if ("type" in gallery) result.type = gallery.type;
+  if ("ordinal" in gallery) result.ordinal = gallery.ordinal;
   return result;
 };
 
@@ -945,9 +955,13 @@ const SCHEMA = {
       "hostname",
       "default_language",
       "type",
+      "ordinal",
     ],
     primaryKey: ["id"],
-    order: ["id ASC"],
+    // Operator-curated sort (#585) — `ordinal` is the primary key
+    // and `id` the tiebreak so all-zero (untouched) rows preserve
+    // their previous id-ASC order.
+    order: ["ordinal ASC", "id ASC"],
     mapToRow: galleryMapToRow as (data: Record<string, unknown>) => Record<string, unknown>,
   },
   gallerySavedFilter: {

--- a/server/models/gallery.ts
+++ b/server/models/gallery.ts
@@ -19,6 +19,7 @@ export default () => {
     updateGallery,
     deleteGallery,
     setGalleryIcon,
+    setGalleryOrder,
   };
 };
 
@@ -178,4 +179,34 @@ const setGalleryIcon = async (
   const iconSource = JSON.stringify({ photoId: sourcePhotoId, crop });
   await db.updateGallery(galleryId, { icon: iconPath, iconSource });
   return iconPath;
+};
+
+// Apply an operator-curated order across every visible gallery (#585).
+// The input must contain exactly the current gallery id set — no
+// missing ids (would leave them stranded at ordinal 0) and no extras
+// (typo / stale client). Ordinals are reassigned by position: 0, 1,
+// 2, … so the operator's drop-on-row gets the literal slot they
+// picked.
+const setGalleryOrder = async (ids: string[]): Promise<void> => {
+  logger.debug("Reordering galleries", { count: ids.length });
+  const galleries = (await db.loadGalleries()) as Array<{ id: string }>;
+  const existing = new Set(galleries.map((g) => g.id));
+  const seen = new Set<string>();
+  for (const id of ids) {
+    if (!existing.has(id)) {
+      throw new ValidationError("Unknown gallery id in order list", { id });
+    }
+    if (seen.has(id)) {
+      throw new ValidationError("Duplicate gallery id in order list", { id });
+    }
+    seen.add(id);
+  }
+  if (seen.size !== existing.size) {
+    const missing = [...existing].filter((id) => !seen.has(id));
+    throw new ValidationError(
+      "Order list must include every gallery exactly once",
+      { missing }
+    );
+  }
+  await db.setGalleryOrder(ids);
 };

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -790,6 +790,47 @@
         }
       }
     },
+    "/api/v1/galleries/_order": {
+      "post": {
+        "summary": "Reorder galleries (admin)",
+        "tags": [
+          "galleries"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "ids"
+                ],
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response"
+          }
+        }
+      }
+    },
     "/api/v1/galleries/{galleryId}": {
       "get": {
         "summary": "Get one gallery (with photos)",

--- a/server/tests/api/galleries.test.ts
+++ b/server/tests/api/galleries.test.ts
@@ -231,6 +231,50 @@ describe("As admin", () => {
   test("Get invalid", async () => {
     await expectGalleryUnavailable(token, "invalid");
   });
+  test("Reorder galleries (admin) → list order follows", async () => {
+    await api
+      .post("/api/v1/galleries/_order")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ ids: ["gallery3", "gallery1", "gallery2"] })
+      .expect(204);
+    const result = await getGalleries(token);
+    const ids = (result.body as Array<{ id: string }>).map((g) => g.id);
+    expect(ids).toEqual(["gallery3", "gallery1", "gallery2"]);
+    await api
+      .post("/api/v1/galleries/_order")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ ids: ["gallery1", "gallery2", "gallery3"] })
+      .expect(204);
+  });
+  test("Reorder rejects an incomplete id list (422)", async () => {
+    await api
+      .post("/api/v1/galleries/_order")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ ids: ["gallery1", "gallery2"] })
+      .expect(422);
+  });
+  test("Reorder rejects an unknown id (422)", async () => {
+    await api
+      .post("/api/v1/galleries/_order")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ ids: ["gallery1", "gallery2", "gallery3", "ghost"] })
+      .expect(422);
+  });
+  test("Reorder rejects duplicates (422)", async () => {
+    await api
+      .post("/api/v1/galleries/_order")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ ids: ["gallery1", "gallery1", "gallery2"] })
+      .expect(422);
+  });
+  test("Reorder requires admin (403 for plain user)", async () => {
+    const plainToken = await loginUser(api, "plainuser");
+    await api
+      .post("/api/v1/galleries/_order")
+      .set("Authorization", `Bearer ${plainToken}`)
+      .send({ ids: ["gallery1", "gallery2", "gallery3"] })
+      .expect(403);
+  });
 });
 
 describe("As gallery1admin", () => {

--- a/server/tests/db/sqlite3/gallery.test.ts
+++ b/server/tests/db/sqlite3/gallery.test.ts
@@ -31,6 +31,7 @@ describe("gallery CRUD", () => {
       initialView: "month",
       hostname: "^sample\\.",
       type: "real",
+      ordinal: 0,
     });
     const row = (await driver.loadGallery("g-full")) as {
       title: string;

--- a/server/tests/db/sqlite3/helper.ts
+++ b/server/tests/db/sqlite3/helper.ts
@@ -36,5 +36,6 @@ export const mkGallery = (partial: Partial<Gallery> & { id: string }): Gallery =
   hostname: "",
   defaultLanguage: "en",
   type: "real",
+  ordinal: 0,
   ...partial,
 });

--- a/server/tests/db/sqlite3/meta.test.ts
+++ b/server/tests/db/sqlite3/meta.test.ts
@@ -15,7 +15,7 @@ describe("meta", () => {
   test("loadMetas returns the baseline migration seeds", async () => {
     const metas = (await driver.loadMetas()) as Array<Record<string, string>>;
     const merged = Object.assign({}, ...metas);
-    expect(merged.schema_version).toBe("24");
+    expect(merged.schema_version).toBe("25");
     expect(merged.instance_name).toBe("");
   });
 

--- a/server/tests/db/sqlite3/migrate.test.ts
+++ b/server/tests/db/sqlite3/migrate.test.ts
@@ -33,7 +33,7 @@ describe("migrate", () => {
   test("fresh DB runs every migration and lands at the highest version", () => {
     const db = open();
     migrate(db);
-    expect(schemaVersion(db)).toBe(24);
+    expect(schemaVersion(db)).toBe(25);
     expect(tableNames(db)).toEqual(
       expect.arrayContaining([
         "gallery",
@@ -115,7 +115,7 @@ describe("migrate", () => {
 
     migrate(db);
 
-    expect(schemaVersion(db)).toBe(24);
+    expect(schemaVersion(db)).toBe(25);
     expect(gallerPhotoFkRefs(db).sort()).toEqual(["gallery", "photo"]);
     const rows = db.prepare("SELECT * FROM gallery_photo").all();
     expect(rows).toEqual([{ gallery_id: "g1", photo_id: "p1" }]);

--- a/server/tests/db/sqlite3/schema.test.ts
+++ b/server/tests/db/sqlite3/schema.test.ts
@@ -162,14 +162,15 @@ describe("Gallery", () => {
     "hostname",
     "default_language",
     "type",
+    "ordinal",
   ].join(",");
   test("Build create query", () =>
     expect(schema.gallery.buildCreateQuery()).toBe(
-      `INSERT INTO gallery (${cols}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`
+      `INSERT INTO gallery (${cols}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)`
     ));
   test("Build select by id query", () =>
     expect(schema.gallery.buildSelectByIdQuery()).toBe(
-      `SELECT ${cols} FROM gallery WHERE id = ? ORDER BY id ASC`
+      `SELECT ${cols} FROM gallery WHERE id = ? ORDER BY ordinal ASC,id ASC`
     ));
   test("Build update by id query: nothing", () =>
     expect(schema.gallery.buildUpdateByIdQuery({})).toStrictEqual({
@@ -231,11 +232,11 @@ describe("Gallery", () => {
     ));
   test("Build select all query", () =>
     expect(schema.gallery.buildSelectQuery()).toBe(
-      `SELECT ${cols} FROM gallery ORDER BY id ASC`
+      `SELECT ${cols} FROM gallery ORDER BY ordinal ASC,id ASC`
     ));
   test("Build select by condition query", () =>
     expect(schema.gallery.buildSelectQuery(["id = ?"])).toBe(
-      `SELECT ${cols} FROM gallery WHERE id = ? ORDER BY id ASC`
+      `SELECT ${cols} FROM gallery WHERE id = ? ORDER BY ordinal ASC,id ASC`
     ));
   test("Build delete all query", () =>
     expect(schema.gallery.buildDeleteQuery()).toBe("DELETE FROM gallery"));


### PR DESCRIPTION
## Summary

Closes #585. Operator-curated gallery order — drag rows on `/m/galleries` to reorder, or click the "Sort by id" button to reset. Order flows through every consumer (admin list, public picker, title-bar selector, GlobalStats Galleries section) because they all read the same `/api/v1/galleries` list endpoint.

## Server

- **Migration 025**: `ALTER TABLE gallery ADD COLUMN ordinal INTEGER NOT NULL DEFAULT 0`. No data rewrite — all-zero rows fall back to the existing id-ASC tiebreak so the visual order is unchanged until an operator drags something.
- **Schema**: `Gallery.ordinal` field; SCHEMA.gallery columns include `ordinal`; `order: ["ordinal ASC", "id ASC"]`.
- **New endpoint** `POST /api/v1/galleries/_order` (admin-only). Body `{ ids: string[] }` must cover every current gallery exactly once; partial / unknown / duplicate id lists reject with 422. Underscore-prefix path stays off the slug-id namespace (`assertSlugId` rejects ids starting with anything other than `[a-z0-9]`).
- **Model** `setGalleryOrder()` enforces cover-everything-exactly-once before calling the driver, so a stale client can't strand untouched galleries at ordinal 0.
- **Driver** runs the ordinal reassignment in one transaction.

## Frontend

- Added `@dnd-kit/core` + `@dnd-kit/sortable` + `@dnd-kit/utilities` (~30 kB raw into the lazy admin chunk that #573 split off). PointerSensor with a 4 px activation distance so row-clicks aren't interpreted as drags.
- `<SortableRow>` wraps each row with `useSortable`; the drag handle on the leftmost cell carries the listeners. `stopPropagation` on the handle cell so the drag doesn't bubble to the row's "open gallery" click.
- "Sort by id" button next to "Add gallery" — reissues a sorted PUT. Same mutation path as drag, just a different `ids` list.
- Optimistic update via `setQueryData` + `useMutation`; `onError` invalidates to revert + surfaces a notification. Success invalidates the public `["galleries"]` cache key so picker tiles + title selector pick up the new order without a page reload.
- i18n: `manage-galleries-drag-handle`, `manage-galleries-sort-by-id` (en / fi / ja).

## Test plan

- [x] `npm run typecheck && npm test && npm run lint` clean on server (898/898).
- [x] React typecheck + lint clean.
- [x] New server tests (admin): reorder round-trip → list order follows; incomplete / unknown / duplicate id list → 422; non-admin → 403.
- [x] Schema test column list + ORDER BY assertions updated for the new `ordinal` column.
- [x] Playwright on dev: `/m/galleries` shows the rows in (ordinal, id) order, drag handle on the leftmost cell, "Sort by id" button present.
- [ ] Manual smoke: drag a row → optimistic reorder; refresh page → order persists.
- [ ] Manual smoke: visit `/g` after a reorder → picker reflects the new order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)