### PR TITLE
docs: post-0.16 audit — fix stale paths, ACL model, gallery types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,13 @@ Guidance for AI coding agents (Claude Code, Cursor, Cline, Aider, …) and human
 
 ## Layout
 
-Monorepo with two long-lived subtrees plus a helper:
+Monorepo with three workspaces:
 
-- `react-app/` — front-end SPA. React 19, TypeScript, Vite, Emotion (styled), TanStack Query, react-i18next, vitest.
-- `server/` — Fastify backend. TypeScript, SQLite by default, vitest + supertest.
-- `converter/` — back-end worker that pre-processes incoming photos. Less active.
+- `react-app/` — front-end SPA. React 19, TypeScript, Vite, Emotion (styled), TanStack Query, Zustand, react-i18next, vitest.
+- `server/` — Fastify backend. TypeScript, `@fastify/type-provider-typebox`, SQLite by default, vitest + supertest.
+- `converter/` — back-end worker that pre-processes incoming photos (sharp, EXIF extraction). Less active.
 
-Top-level `bin/` has operator scripts (`instance.ts`, `gallery.ts`, `user.ts`, `access.ts`). Per-instance dirs (created by `bin/instance.ts`) live outside the repo at `<base>/<name>/`.
+Top-level `bin/` has the bootstrap script `instance.ts` (creates / doctors / upgrades a per-instance dir) and the `sync-versions.mjs` helper used by the release flow. Per-instance dirs (created by `bin/instance.ts`) live outside the repo at `<base>/<name>/`; their own `bin/` carries symlinks back into `server/bin/` (`photo`, `photo-rename`, `photo-geocode`, `gallery`, `user`, `group`, `meta`).
 
 ## Commands
 
@@ -19,11 +19,12 @@ Run inside the relevant subtree.
 | Subtree | Typecheck | Tests | Build | Dev |
 |---|---|---|---|---|
 | `react-app/` | `npm run typecheck` | `npm test` | `npm run build` | `npm run dev` (Vite, proxies `/api/*`) |
-| `server/` | `npm run typecheck` | `npm test` | `npm run build` | `npm run dev` (tsx watch, SQLite at `server/db.sqlite3`) |
+| `server/` | `npm run typecheck` | `npm test` | (no build — tsx runtime) | `npm run dev` (tsx watch, SQLite at `server/db.sqlite3`) |
+| `converter/` | `npm run typecheck` | `npm test` | (no build — tsx runtime) | `npm run dev` |
 
 Server tests use `DB_DRIVER=dummy` via the npm script, so no SQLite file is touched.
 
-Run `npm test` and `npm run typecheck` before pushing. The build step rolls up bundle sizes — worth running for visual changes that might touch chunking.
+Run `npm test`, `npm run typecheck`, and `npm run lint` (all three subtrees) before pushing — CI runs them all. The react-app build step rolls up bundle sizes — worth running for visual changes that might touch chunking.
 
 ## Cutting a release
 
@@ -33,8 +34,8 @@ The release step touches several files that need to stay in lockstep. Miss one a
 2. **Branch.** `git checkout -b release/<version>` off main.
 3. **Bump `version`** in all four `package.json` files: root, `server/`, `react-app/`, `converter/`. Same value everywhere.
 4. **Regenerate the OpenAPI dump.** `cd server && npm run docs:dump` writes `server/openapi.json` with `info.version` from `server/package.json`. Then `cd ../react-app && npm run api:codegen` regenerates `src/lib/api-schema.ts` from the new dump. Both must be committed — CI rejects a version bump without the matching regen.
-5. **Stamp CHANGELOG.** Rename `[Unreleased]` to `[<version>] - <YYYY-MM-DD>`; add a fresh empty `[Unreleased]` heading above it.
-6. **README.** Bump the install / upgrade `0.x.y` examples to the new version (search for the prior version string). Move the released milestone's bullet out of the Roadmap section into Version History with a one-paragraph release summary. Update the "what's in flight after 0.x" footer pointer.
+5. **Stamp CHANGELOG.** Rename `[Unreleased]` to `[<version>] - <YYYY-MM-DD>`; add a fresh empty `[Unreleased]` heading above it. Add a diff-link entry at the footer: `[<version>]: https://github.com/vlumi/photo-diary/compare/v<prev>...v<version>`.
+6. **README.** Bump the install / upgrade `0.x.y` examples to the new version (search for the prior version string). Move the released milestone's bullet out of the Roadmap section into Version History with a one-line release theme. Update the "what's in flight after 0.x" footer pointer.
 7. **Validate.** `npm test`, `npm run typecheck`, `npm run lint` across all three subtrees.
 8. **Open the release PR.** Title `Release <version>`. Body summarises what shipped + any milestone reorg.
 9. **After merge, tag.** `git checkout main && git pull && git tag -a v<version> -m "Release <version>" && git push origin v<version>`. GitHub auto-generates the tarball that `bin/instance.ts` examples reference.
@@ -47,7 +48,7 @@ The release step touches several files that need to stay in lockstep. Miss one a
 - **PR body paragraphs are single long lines.** No mid-paragraph hard wraps. GitHub re-flows on render.
 - **Commit messages**: short imperative title, body that explains *why* (the *what* is in the diff). Co-author trailer is fine.
 - **No PR/issue references in source comments.** They leak into OpenAPI descriptions, build artefacts, and rot over time. Put them in the commit message and PR body where they belong.
-- **Trust but verify.** If the user reports a bug, reproduce / read the failing code path before patching. Several recent fixes (map centering arc, Backdrop box-sizing) went through multiple wrong attempts because the symptom didn't match the actual root cause.
+- **Trust but verify.** If the user reports a bug, reproduce / read the failing code path before patching. Several recent fixes (map centering arc, Backdrop box-sizing, filter modal viewport overflow) went through multiple wrong attempts because the symptom didn't match the actual root cause.
 
 ## Code conventions
 
@@ -62,20 +63,23 @@ The release step touches several files that need to stay in lockstep. Miss one a
 
 ### Front end
 
-- `Gallery/index.tsx` is the router/dispatch component. It picks Year / Month / Photo / Stats / Empty based on URL params (`year`, `month`, `day`, `photoId`).
+- `Gallery/index.tsx` is the router/dispatch component. It picks Year / Month / Photo / Stats / Empty based on URL params (`year`, `month`, `day`, `photoId`). `Day` is not a separate view — the day slice is rendered inside Month.
 - **Photo view is a modal** rendered on top of its parent Month: when the URL has a `photoId`, `Gallery/index.tsx` mounts Month + Photo together as siblings. The Photo modal lives in `Gallery/Photo/index.tsx` with a `<Backdrop>` (dark scrim, `position: fixed; inset: 0; height: 100dvh; box-sizing: border-box; z-index: 1000`) wrapping a contained `<Frame>` (`max-width: 1400px`, rounded, drop shadow).
-- **Floating buttons** over the modal — close (`top: 8 right: 8`), fullscreen (`top: 58 left: 8` — below Navigation), info toggle (`bottom: 16 right: 16`) — all share `<FloatingButton>` style.
+- **Floating buttons** over the photo modal — close (`top: 8 right: 8`), fullscreen (`top: 58 left: 8` — below Navigation), info toggle (`bottom: 16 right: 16`) — all share `<FloatingButton>` style.
 - **Metadata** lives in `<MetadataPanel>` at the photo's bottom-right corner. Open by default on desktop, closed on mobile. Map inside is rendered only when the panel is open.
-- **Stats logic** is in `react-app/src/lib/stats.tsx`. `collectTopics` builds the per-category data; `StatsCategory.valueSortable` / `valueSortByLabel` mark which categories show the "By value / Top" toggle in their expanded modal.
+- **Filter widget** lives in `Gallery/Filters/`. `<Strip>` is the inline italic "Category: value" chunk row mounted in every Title; `<Modal>` is the centered overlay containing `<Builder>`; `<Builder>` is prop-driven (`filters`, `setFilters`, `dateRange`, `setDateRange`, `numericRanges`, `setNumericRange`, `defaultDateRange`) so the public viewer wires it to `useFiltersStore` while the saved-filter admin form wires it to local form state. Filter state lives in `stores/filters.ts`; modal open + sub-modal + landed-category live in `stores/filter-modal.ts`. `useWireNumericRanges()` returns a memoised, anchor-stripped wire shape — every server query keys + bodies the wire shape, not the raw store value.
+- **Stats logic** is in `react-app/src/lib/stats.tsx`. `collectTopics` builds the per-category data; `StatsCategory.valueSortable` / `valueSortByLabel` mark which categories show the "By value / Top" toggle in their expanded modal. `Stats/EvolutionChart.tsx` is the stacked-area trend chart with the month / year granularity toggle (`useEvolutionGranularityStore`).
 - **Title bar breadcrumb** (`Gallery/Title.tsx`) shows `🏠 › Gallery › 2024 › March › #1234`. The current view's crumb is bold and non-interactive; everything else is a link.
 - **`MapContainer`** is lazy-loaded via `MapContainer.lazy.tsx`. Callers pass an explicit `height` prop — the default 400px doesn't match the metadata panel's 160px clip, which is exactly the kind of mismatch that caused the "map north of pin" debug arc.
-- **`useKeyPress`** registers a `keydown` listener on `window` — when two mounted components handle the same key (Photo modal + underlying Month), both fire. Use a capture-phase listener with `stopImmediatePropagation` when one needs to win.
+- **Admin surface** lives under `Manage/` (`/m/*` routes), gated by `user.is_admin`. Lazy-loaded out of the main bundle. Notable: `GalleryEdit.tsx` owns the form state, `GallerySourcesSection.tsx` edits hybrid-gallery sources, `VirtualGalleryFilterSection.tsx` owns the saved-filter editor on a virtual gallery's own edit page, `SavedFiltersSection.tsx` is the parent gallery's directory of child virtual galleries.
 
 ### Server
 
-- Fastify routes under `server/src/routes/`, models under `server/src/models/`, typed errors in the route layer (don't return plain strings).
-- Pluggable DB via `DB_DRIVER` env (`sqlite` default, `dummy` for tests). Driver implementations in `server/src/db/`.
-- Access control: gallery IDs include slug pseudo-galleries `:all`, `:public`, `:private`. The `access` table grants per-user levels (`viewer`, `editor`, `admin`).
+- Fastify routes under `server/controllers/*-v1.ts`, models under `server/models/`, typed errors in `server/lib/errors.ts` (don't return plain strings). Layout is flat — no `src/` subdirectory.
+- Pluggable DB via `DB_DRIVER` env (`sqlite3` for prod, `dummy` for tests). Driver implementations in `server/db/sqlite3/` and `server/db/dummy/`; the public surface is `server/db/index.ts`.
+- **Access control.** Two columns carry the model: `user.is_admin` (global admin bypasses every per-gallery check) and `is_editor` on `user_gallery` / `group_gallery` (gallery-editor tier). A `user_gallery` or `group_gallery` row with `is_editor=0` is a view-only grant. The effective access is the union of direct rows, group-derived rows, and `:guest`'s rows. The wildcard target `:all` matches every real gallery; the only live pseudo-gallery sentinel.
+- **Gallery types.** `gallery.type` is `real` (default), `hybrid` (union of source galleries via `virtual_gallery_source` — sources must be real, no chained virtuals), or `saved_filter` (one source + a stored `{filter, dateRange, numericRanges}` baseline in `gallery_saved_filter`). The driver's `resolveGalleryRef` does the dispatch — every read path (load photos / counts / neighbors / filter values) routes through it.
+- **Filter wire shape.** `filter` (discrete FilterShape), `dateRange`, and `numericRanges` are the three predicates threaded through every read body. Evaluated by `matchesFilter` / `matchesDateRange` / `matchesNumericRanges` in `server/lib/photo-filter-eval.ts`. Saved-filter galleries apply the same predicates as a baseline before the request-side ones.
 - JWT auth via `jose`; sessions are 90 days. Rotating a user's `secret` invalidates all their tokens.
 
 ## Footguns (from recent debug arcs)
@@ -83,9 +87,11 @@ The release step touches several files that need to stay in lockstep. Miss one a
 - **Backticks inside Emotion `css\`\`` template literals** close the string prematurely. Use plain CSS comments (`/* ... */`) without backtick references.
 - **`position: fixed; inset: 0` with explicit `height: 100dvh` + `padding`** needs `box-sizing: border-box` — otherwise the explicit height + padding stack and the element extends past viewport (caused the InfoButton "4px below screen" bug).
 - **react-leaflet's `<MapContainer>` props (`center`, `zoom`, `bounds`) are initial-setup-only.** Subsequent prop changes don't move the view. Use `useMap()` + `setView`/`fitBounds` (with `animate: false` to avoid panning surprises).
-- **`useKeyPress` fires per registration on `window`.** If multiple mounted components handle the same key, both fire. Capture phase + `stopImmediatePropagation` is the escape hatch.
+- **`useKeyPress` fires per registration on `window`.** If multiple mounted components handle the same key, both fire. Capture phase + `stopImmediatePropagation` is the escape hatch — and when both listeners use capture phase, the earlier-registered one wins, so a stacked modal needs an explicit "is the inner modal open" check to defer (see `FilterModal` ↔ Builder's `subModalKey`).
 - **Locking `document.body.style.overflow = "hidden"`** removes the scrollbar gutter — content under the lock reflows ~15px wider. `html { scrollbar-gutter: stable; }` reserves the space.
-- **Server tests need every supertest call awaited.** Unawaited requests linger past the test, race with `afterAll(close)`, and surface as intermittent `ECONNRESET` in CI.
+- **Modal content that intrinsically demands width** (a long unbreakable chip label, an inline-flex value chunk) pushes flex items past `max-width: 100%` because `min-width: auto` is the default. Cap modal `<Frame>` with `max-width: min(<px>, calc(100vw - 40px))`, set `overflow-x: hidden` on the frame, and use `overflow-wrap: anywhere` + `white-space: normal` + `display: inline-block` on chips so the text actually wraps.
+- **Server tests need every supertest call awaited.** Unawaited requests linger past the test, race with `afterAll(close)`, and surface as intermittent `ECONNRESET` / "Parse Error: Expected HTTP/, RTSP/ or ICE/" in CI.
+- **TypeBox schemas with `additionalProperties: false`** reject unknown fields. Client-only state (like the filter widget's `numericRanges[cat].anchor`) must be stripped before serialising to the wire — see `toWireNumericRanges`.
 
 ## When in doubt
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Live examples: [dailybw.misaki.fi](https://dailybw.misaki.fi) and [papusama.misa
 
 Key features include:
 
-- Calendar-based views (year, month, day, photo)
+- Calendar-based views (year, month, photo)
   - Including map from embedded GPS information
 - Comprehensive photo statistics (time, gear, exposure settings, etc.)
 - Fast browsing — per-view fetch narrowed by the active filter, cached client-side so filter toggles update in place
@@ -44,7 +44,7 @@ The three pieces communicate via the shared filesystem and SQLite DB rather than
 Quickstart for a single personal instance. For the full production layout (multi-version code under `/opt/`, per-instance dirs under `/var/`, nginx vhosts, atomic upgrades, backup) see [Multi-Instance Deployment](#multi-instance-deployment) below; for an in-repo dev setup without an instance dir at all, see [Dev Mode](#dev-mode).
 
 1. **Prerequisites + install.** Node.js 22 or newer (npm 10+ recommended for workspaces) and [pm2](https://pm2.keymetrics.io/) installed globally (`npm install -g pm2`) — the per-instance `start-prod.sh` scripts and the `bin/instance.ts` upgrade / `--cycle` flows shell out to it. From the repo root, `npm run setup` installs every workspace ([server](server), [converter](converter), [react-app](react-app)) and builds the frontend into [server](server)/`build/`.
-2. **Bootstrap the instance directory** with [`bin/instance.ts`](bin/instance.ts). It creates the dir tree (`photos/{inbox,original,display,thumbnail}/`), generates `.env` with a fresh random `SECRET`, links `code` to this checkout, and surfaces operator shortcuts at `<instance>/bin/{photo,gallery,user,access}.ts`:
+2. **Bootstrap the instance directory** with [`bin/instance.ts`](bin/instance.ts). It creates the dir tree (`photos/{inbox,original,display,thumbnail}/`), generates `.env` with a fresh random `SECRET`, links `code` to this checkout, and surfaces operator shortcuts at `<instance>/bin/{photo,photo-rename,photo-geocode,gallery,user,group,meta}.ts`:
 
    ```sh
    ./bin/instance.ts <name> --base <parent-dir>
@@ -63,8 +63,8 @@ Quickstart for a single personal instance. For the full production layout (multi
 
    ```sh
    ./bin/user.ts passwd <user> <password>
+   ./bin/user.ts make-admin <user>
    ./bin/gallery.ts <gallery-id> --title "<Title>"
-   ./bin/access.ts level <user> :all admin
    ```
 
 5. **Set the instance `cdn`** — the public URL that serves `display/`, `thumbnail/`, and `gallery-icons/` (typically the same nginx host):
@@ -338,17 +338,17 @@ The `bin/instance.ts` upgrade flow already creates `db.sqlite3.pre-<version>` sn
 | Converter logs "Invalid photo-repository directory structure" | The `photos/{inbox,original,display,thumbnail}/` subdirs aren't all present — re-run `./bin/instance.ts <name>` (or `bin/instance.ts <name>` from the code root) to recreate any missing ones (idempotent). |
 | `no such table: …` after upgrade | A migration didn't apply. Check `sqlite3 db.sqlite3 "SELECT value FROM meta WHERE key='schema_version'"` and the server log on startup for "Applying N DB migration(s)". |
 | Frontend loads but `/api/v1/galleries` 401s | The user's token expired or the `SECRET` changed across restarts — login again. |
-| Map widget missing where you expected it | The `hide_map` cascade is hiding it; check with `./bin/access.ts list` (filter to `--user <id>` or `--gallery <id>` if needed) and the privacy doc in the server README. |
+| Map widget missing where you expected it | The `hide_map` cascade is hiding it; inspect a user's resolved grants with `./bin/user.ts access <user>` and see the privacy doc in the server README. |
 
 ## Features
 
 - Photos are segmented into galleries
   - Each photo can be in any number of galleries
-  - Single level – no nesting
+  - Real galleries are a flat namespace — photo membership is direct, not nested
   - One gallery view at a time
-  - Special galleries for more abstract concepts
-    - :all includes all photos
-    - :public includes all photos added to galleries
+  - Virtual galleries compose existing galleries without copying photo rows
+    - Saved-filter galleries — a filter snapshot baked onto a parent gallery, addressed at `/m/g/<id>` like any other gallery
+    - Hybrid galleries — union of one or more real galleries' photos, resolved live at read time (sources must be real galleries; chained virtual sources aren't supported)
   - Hostname-based default gallery selection — and `Host`-bound admin/read scope: a request to a hostname matching one or more `gallery.hostname` patterns is narrowed to that set, both reads and admin writes (cross-gallery work is unreachable from a virtual host)
 - SPA view
   - Fast transition between views — per-view server fetch, TanStack Query cache, in-place refresh on filter toggles
@@ -358,7 +358,6 @@ The `bin/instance.ts` upgrade flow already creates `db.sqlite3.pre-<version>` sn
     - Pre-load previous/next photo
   - Year view – Calendar with heat-mapped days
   - Month view – Thumbnails grouped by date
-  - Day view – Thumbnails
   - Single photo view – Maximize to visible space, with photo properties
 - Statistics view
   - General statistics
@@ -379,17 +378,8 @@ The `bin/instance.ts` upgrade flow already creates `db.sqlite3.pre-<version>` sn
 - Authorization
   - Restricted access to galleries and functionality
     - No access restrictions planned for the actual photo content, which may be in a CDN
-  - Multiple access levels
-    - No access
-    - View access
-    - Admin access
-  - Access levels granted by scope
-    - Global scope (:all)
-    - Public scope (:public)
-    - Gallery scope
-  - Default access level
-    - Through guest user (:guest), inherited by all users
-    - Inheritance may be overridden by broadening or narrowing access
+  - Per-gallery viewer / editor grants on users and groups; `user.is_admin` for instance-wide admin
+  - Default access via the `:guest` user — every user inherits its grants, and individual users can broaden or narrow that baseline
 
 ### Beta features
 

--- a/react-app/README.md
+++ b/react-app/README.md
@@ -53,28 +53,37 @@ Country names come from [`i18n-iso-countries`](https://www.npmjs.com/package/i18
 - `src/index.tsx` — entry, mounts `<App>` inside `React.StrictMode`
 - `src/App.tsx` — routes (`react-router-dom` 7), top menu, country-locale registration, persisted-user bootstrap
 - `src/components/` — UI components
-  - `Gallery/` — gallery shell + `Year/Month/Day/Photo/Filters/Stats` sub-views
-  - `MapContainer.tsx` — Leaflet map wrapper used by the various Footer components
-  - `TopMenu.tsx`, `Login.tsx`, `Logout.tsx` — auth-aware top bar
+  - `Gallery/` — gallery shell + `Year/Month/Photo/Filters/Stats` sub-views (Day was folded into Month in 0.10)
+  - `Manage/` — admin surface: `Galleries`, `Users`, `Groups`, `Access`, `GalleryEdit`/`GalleryForm`, `GalleryAccess`, `Photos`, `PhotoDrawer`, `Dashboard`
+  - `GlobalStats/` — instance-wide stats view
+  - `MapContainer.tsx` (+ `.lazy.tsx`) — Leaflet wrapper, lazy-loaded across consumers
+  - `TopMenu.tsx`, `Login.tsx`, `UserMenu.tsx` — auth-aware top bar
 - `src/models/` — `PhotoModel`, `GalleryModel`, `UserModel` (functional constructors returning typed closures)
 - `src/services/` — thin `fetch` wrappers around the server's `/api/v1/*` endpoints
-- `src/lib/` — pure helpers (`calendar`, `collection`, `color`, `config`, `filter`, `format`, `i18n`, `stats`, `theme`, `keypress`, `scroll`, `token`, `api`)
+- `src/lib/` — pure helpers and hooks (`api`, `api-schema`, `calendar`, `collection`, `color`, `config`, `country-sentinel`, `crop-factors.json`, `filter`, `format`, `host-scope` / `use-host-scope`, `i18n`, `id-shape`, `keypress`, `stats` / `stats-adapter`, `theme`, `token`, `uniqueValues`, `useBodyScrollLock`, `useFilteredCalendar`, `useMediaQuery`)
   - `stats.tsx` is the largest module — aggregates photo statistics into chart-ready data and table rows
+  - `api-schema.ts` is regenerated from the server's OpenAPI dump via `npm run api:codegen`; don't edit by hand
+- `src/stores/` — Zustand stores (filter, dateRange, numericRanges, etc.); `useWireNumericRanges` strips the client-only anchor field before wire submission
 - `src/setupTests.ts` — vitest setup (registers `@testing-library/jest-dom` matchers)
 
 ## Bundle shape
 
-Production build produces four JS chunks plus a single small entry CSS file and one large per-chunk CSS file for the map:
+Production build splits across many chunks (Manage admin views, GalleryForm, Photos drawer, etc. are individually lazy). Approximate current sizes — rerun `npm run build` for ground truth:
 
 | Chunk | Raw | gzipped | What |
 | --- | --- | --- | --- |
-| `index-*.js` (main) | ~429 kB | ~136 kB | React + react-dom, react-router, i18next, i18n-iso-countries runtime, Emotion, our `src/` code (gallery shell + calendar views) |
-| `MapContainer-*.js` | ~198 kB | ~60 kB | Leaflet + react-leaflet + leaflet.markercluster — shared lazy chunk loaded on first map render |
-| `Stats-*.js` | ~210 kB | ~72 kB | chart.js + react-chartjs-2 + the stats-aggregation src — loaded on `/g/:id/stats` only |
-| `Photo-*.js` | ~7 kB | ~3 kB | single-photo view src — loaded when opening a photo |
-| `en-*.js` / `fi-*.js` / `ja-*.js` | ~4–6 kB | ~2–3 kB | country-name dictionaries from `i18n-iso-countries`, one chunk per language, fetched when that language is first activated |
+| `index-*.js` (main) | ~361 kB | ~108 kB | React + react-dom, react-router, i18next, i18n-iso-countries runtime, Zustand, our `src/` code (gallery shell + calendar views) |
+| `Stats-*.js` | ~234 kB | ~79 kB | chart.js + react-chartjs-2 + the stats-aggregation src — loaded on `/g/:id/stats` only |
+| `api-*.js` | ~192 kB | ~56 kB | shared openapi-fetch typed client + generated `api-schema.ts` |
+| `marker-icon-2x-*.js` + `MapContainer-*.js` | ~200 kB | ~62 kB | Leaflet + react-leaflet + leaflet.markercluster — shared lazy chunk loaded on first map render |
+| `Photo-*.js` | ~140 kB | ~45 kB | single-photo view src — loaded when opening a photo |
+| `Galleries-*.js` | ~50 kB | ~16 kB | Manage admin Galleries list |
+| `emotion-styled.browser.esm-*.js` | ~40 kB | ~16 kB | Emotion styled runtime |
+| `GalleryForm-*.js` | ~34 kB | ~10 kB | gallery create/edit form (real / hybrid / saved-filter) |
+| `Photos-*.js` | ~33 kB | ~10 kB | Manage admin Photos drawer |
+| `en-*.js` / `fi-*.js` / `ja-*.js` | ~3–17 kB | ~2–7 kB | country-name dictionaries from `i18n-iso-countries`, one chunk per language, fetched on first activation |
 | `index-*.css` (main) | ~0.4 kB | ~0.2 kB | global tokens + body resets from `App.css` (see "CSS approach" below) |
-| `MapContainer-*.css` | ~17 kB | ~7 kB | leaflet + markercluster stylesheets, follows the MapContainer JS chunk |
+| `MapContainer-*.css` + `marker-icon-2x-*.css` | ~17 kB | ~7 kB | leaflet + markercluster stylesheets, follow the MapContainer JS chunks |
 
 Code-splitting boundaries live in [`components/Gallery/index.tsx`](src/components/Gallery/index.tsx) (`Stats` + `Photo` via `React.lazy`) and [`components/MapContainer.lazy.tsx`](src/components/MapContainer.lazy.tsx) (a wrapper that swaps every `MapContainer` import for one shared lazy chunk so leaflet is downloaded only when a map actually renders). Suspense boundaries in each consumer give the map a fixed-height placeholder so the page doesn't reflow when the chunk arrives.
 

--- a/server/README.md
+++ b/server/README.md
@@ -6,7 +6,7 @@ This server implements the RESTful API of the Photo Diary
 
 - [Node.js](https://nodejs.org) 22 or newer; npm 10+ recommended
 - Dependencies (see `package.json` for the full list)
-  - [Express](https://expressjs.com/) 5
+  - [Fastify](https://fastify.dev/) 5 with `@fastify/type-provider-typebox` — routes are TypeBox-validated and the OpenAPI dump comes from the same schemas
   - [better-sqlite3](https://github.com/WiseLibs/better-sqlite3) for the default SQLite driver
   - [jose](https://github.com/panva/jose) for JWT signing/verification
   - [tsx](https://github.com/privatenumber/tsx) as the TypeScript runtime (no separate build step)
@@ -76,13 +76,13 @@ cd /var/photo-diary/dailybw
 ./bin/<name>.ts [options]   # via the per-instance bin/ symlinks created by instance.ts
 ```
 
-The per-instance `bin/` directory (`<instance>/bin/{photo,photo-rename,photo-geocode,gallery,user,access,meta}.ts`) is populated by `bin/instance.ts` on init and refreshed on doctor / upgrade runs — each is a symlink into `<instance>/code/server/bin/`. `instance.ts` itself is deliberately not shortcut-symlinked here: bootstrap / upgrade always wants the specific code version (`/opt/photo-diary/<version>/bin/instance.ts <name>`), and the doctor re-run is rare enough that `./code/bin/instance.ts <name> --base <parent>` is fine. The `.ts` extension is kept on the symlinks (rather than bare names) so editors recognise them as TS source and apply the server's tsconfig via realpath.
+The per-instance `bin/` directory (`<instance>/bin/{photo,photo-rename,photo-geocode,gallery,user,group,meta}.ts`) is populated by `bin/instance.ts` on init and refreshed on doctor / upgrade runs — each is a symlink into `<instance>/code/server/bin/`. `instance.ts` itself is deliberately not shortcut-symlinked here: bootstrap / upgrade always wants the specific code version (`/opt/photo-diary/<version>/bin/instance.ts <name>`), and the doctor re-run is rare enough that `./code/bin/instance.ts <name> --base <parent>` is fine. The `.ts` extension is kept on the symlinks (rather than bare names) so editors recognise them as TS source and apply the server's tsconfig via realpath.
 
 #### `instance.ts <name> [--base <dir>] [--fix]`
 
 Bootstrap, doctor, or upgrade a Photo Diary instance directory in one command. Default base is `/var/photo-diary`. Mode is auto-detected from existing state:
 
-- **New** — creates the directory tree, generates `.env` with a fresh random `SECRET`, creates a `code` symlink pointing at this script's own code root, and creates the per-instance `bin/{photo,gallery,group,user,meta}.ts` shortcuts.
+- **New** — creates the directory tree, generates `.env` with a fresh random `SECRET`, creates a `code` symlink pointing at this script's own code root, and creates the per-instance `bin/{photo,photo-rename,photo-geocode,gallery,user,group,meta}.ts` shortcuts.
 - **Doctor** — instance exists, `code` already points at this script's root. Reports missing `.env` keys with `✓`/`✗` markers. Refreshes any missing `bin/` shortcuts. Add `--fix` to append defaults to `.env`.
 - **Upgrade** — `code` points at a different version. Backs up the DB to `db.sqlite3.pre-<new-version>` and flips the symlink. Refreshes `bin/` shortcuts.
 
@@ -109,7 +109,7 @@ Examples:
 
 ```sh
 ./bin/user.ts make-admin alice                    # alice becomes global admin
-./bin/user.ts grant :guest :all                   # public visitors can view everything
+./bin/user.ts grant :guest dailybw                # public visitors can view the dailybw gallery
 ./bin/user.ts grant bob travel --editor           # bob can edit photos in the travel gallery
 ./bin/user.ts hide-map :guest dailybw hide        # hide map for guests on one gallery
 ./bin/user.ts access alice                        # what alice can actually see / edit, and why
@@ -232,9 +232,9 @@ A user's effective access is the union of:
 2. The `group_gallery` rows of every group they belong to (`user_group` join).
 3. `:guest`'s grants — the anonymous-visitor floor. Even a logged-in user with no direct or group grants still gets whatever `:guest` is allowed.
 
-The sentinel gallery **`:all`** is a wildcard target — a grant of `(subject, :all, …)` applies to every real gallery the instance owns. Use it for "anyone authenticated can view everything" patterns (`./bin/user.ts grant :guest :all`).
+There's no wildcard grant target — `gallery_id` on `user_gallery` / `group_gallery` is always a real gallery ID. (The old `:all` / `:public` pseudo-galleries were retired in migration 012, which promoted `(user, :all, admin)` rows to the new `user.is_admin` flag and fanned `:public` grants out to per-gallery rows.) "Anyone-can-see" patterns are expressed by granting on each specific gallery — typically as `:guest` rows, so every user inherits them.
 
-The `hide_map` column on `user_gallery` / `group_gallery` is an independent per-row override of the gallery's map-visibility default — three states (hide / show / inherit-from-gallery) that resolve through the same cascade as the access grant.
+The `hide_map` column on `user_gallery` / `group_gallery` is an independent per-row override of the gallery's map-visibility default — three states (hide / show / inherit-from-gallery) that resolve through the same cascade as the access grant. The cascade uses the sentinel target `:all` as a "per-user default" row inside `hide_map` only (it's not a grantable gallery target).
 
 The authorization primitives live in [`server/lib/authorizer.ts`](lib/authorizer.ts):
 
@@ -283,11 +283,26 @@ A bracketed `[unscoped]` suffix means the route is also rejected on hostname-bou
   - `GET` — Galleries the caller can see **[user]** (filtered by access map)
   - `POST` — Create a gallery **[admin]**
   - `GET ../:galleryId` — Read a gallery + its photos **[gallery/view]**
-  - `PUT ../:galleryId` — Update gallery settings **[gallery/editor]** (editors cannot set `hostname`)
+  - `PUT ../:galleryId` — Update gallery settings; non-empty `sources` stamps the gallery hybrid, empty reverts to real **[gallery/editor]** (editors cannot set `hostname`)
   - `DELETE ../:galleryId` — Delete a gallery **[admin]**
   - `PUT ../:galleryId/icon` — Crop + render the gallery icon from one of its photos **[gallery/editor]**
+  - `POST ../:galleryId/stats` — Aggregated stats for the gallery; body `{filter?, dateRange?, numericRanges?, lang?}` **[gallery/view]**
+  - `POST ../:galleryId/stats/evolution` — Per-bucket time-series for a trendable category; same body shape plus `category` **[gallery/view]**
+  - `GET ../:galleryId/filters` / `POST` — List + create saved filters that source from this gallery **[gallery/editor]**
+  - `GET ../:galleryId/filters/:filterId` / `PUT` / `DELETE` — Read / update / delete a saved filter **[gallery/editor]**
+- `/gallery-photos`
+  - `GET ../:galleryId` — List photos in a gallery **[gallery/view]**
+  - `POST ../:galleryId/query` — Per-view filtered fetch (year/month/day scope + filter + dateRange + numericRanges) **[gallery/view]**
+  - `POST ../:galleryId/counts` — Per-day photo counts for the Year heatmap **[gallery/view]**
+  - `POST ../:galleryId/neighbors` — Prev / next / first / last photos within the filtered set **[gallery/view]**
+  - `POST ../:galleryId/filter-values` — Filter widget universe + filter-aware counts per category **[gallery/view]**
+  - `GET ../:galleryId/:photoId` — One photo by id within a gallery context **[gallery/view]**
+  - `GET ../:galleryId/by-original-filename/:filename` — Pre-rename / camera-filename fallback **[gallery/view]**
+  - `PUT ../:galleryId/:photoId` — Link a photo into a gallery **[admin]**
+  - `DELETE ../:galleryId/:photoId` — Unlink **[gallery/editor]**
 - `/photos`
   - `GET` — Cross-gallery photo list (paginated, filterable) **[admin]**
+  - `POST ../query` — Cross-gallery filtered fetch (same body shape as the gallery-scoped flavour) **[admin]**
   - `GET ../:photoId` — Read a single photo **[gallery/view]** on any gallery it's linked to (orphans require **[admin]**)
   - `PUT ../:photoId` — Update photo data (title, location, exposure, …) **[gallery/editor]** on any gallery it's linked to (orphans **[admin]**)
   - `POST ../:photoId/regeocode` — Clear `geocoded_*` columns and drop a coord sidecar for the converter daemon **[gallery/editor]** on any of the photo's galleries
@@ -295,57 +310,17 @@ A bracketed `[unscoped]` suffix means the route is also rejected on hostname-bou
   - `GET ../audit-counts` — Per-predicate tallies for the dashboard tiles **[admin]**
   - `GET ../year-months` — Per-(year, month) bucket counts for the filter timeline **[admin]**
   - `DELETE ../:photoId` — Delete a photo row **[admin]**
-- `/gallery-photos`
-  - `PUT ../:galleryId/:photoId` — Link a photo into a gallery **[admin]**
-  - `DELETE ../:galleryId/:photoId` — Unlink **[gallery/editor]**
+- `/stats` **[unscoped]**
+  - `POST` — Cross-gallery aggregated stats; admin-only **[admin]**
+- `/filter-values` **[unscoped]**
+  - `POST` — Cross-gallery filter widget universe + counts; admin-only **[admin]**
 
 The OpenAPI dump at `/api/v1/docs` (or `server/openapi.json` checked in) is the authoritative request / response shape for every route.
 
 ### Entities
 
-TBD
-
-- `session`
-- `user`
-- `galleries`
-- `gallery`
-- `photos`
-- `photo`
+Wire shapes are generated from TypeBox-validated route handlers. See [server/openapi.json](openapi.json) (or `/api/v1/docs` on a running instance) for the authoritative schemas.
 
 ## Internal API
 
-### DB API
-
-- Meta
-  - `loadMetas()` – Load all metadata
-  - `createMeta(user)` – Create a metadata with the given properties
-  - `loadMeta(key)` – Load the metadata
-  - `updateMeta(key, meta)` – Update the metadata with the new properties
-  - `deleteMeta(key)` – Delete the metadata
-- User
-  - `loadUsers()` – Load all users
-  - `createUser(user)` – Create a user with the given properties
-  - `loadUser(userId)` – Load the user
-  - `updateUser(userId, user)` – Update the user with the new properties
-  - `deleteUser(userId)` – Delete the user
-- ACL
-  - `loadUserAccessControl(userId)` – Load ACL for the user, with default values from :guest
-- Gallery
-  - `loadGalleries()` – Load all galleries
-  - `createGallery(gallery)` – Create a gallery with the properties
-  - `loadGallery(galleryId)` – Load the gallery
-  - `updateGallery(galleryId, gallery)` – Update the gallery with the new properties
-  - `deleteGallery(galleryId)` – Delete the gallery
-- Gallery-Photo
-  - `loadGalleryPhotos(galleryId)` – Load all photos linked to the gallery
-  - `linkGalleryPhoto(galleryIds, photoIds)` – Link the photo to galleries
-  - `loadGalleryPhoto(galleryId, photoId)` – Load the photo in the gallery context
-  - `unlinkGalleryPhoto(galleryId, photoId)` Unlink the photo from the gallery
-  - `unlinkAllPhotos(galleryId)` – Unlink all photos from the gallery
-  - `unlinkAllGalleries(photoId)` – Unlink the photo from all galleries
-- Photo
-  - `loadPhotos()` – Load all photos
-  - `createPhoto(photo)` – Create a photo with the properties
-  - `loadPhoto(photoId)` – Load the photo
-  - `updatePhoto(photoId, photo)` – Update the photo with the new properties
-  - `deletePhoto(photoId)` – Delete the photo
+The DB layer abstracts over driver implementations (`server/db/sqlite3/`, `server/db/dummy/`). The public surface is the union of methods exported from [server/db/index.ts](db/index.ts) — those are the calls models invoke. Driver internals (SQL, prepared statements, helper functions like `applyBaseline` for saved-filter galleries) live inside each driver subdirectory.


### PR DESCRIPTION
## Summary

Every committed .md got out of sync with the post-0.16 codebase. Pass over each one and reconcile.

- **server/README.md** still claimed Express 5 — the #571 swap to Fastify had never been reflected. Updated the Requirements line, expanded the RESTful resources list to cover stats / evolution / gallery-photos query / counts / neighbors / filter-values plus the unscoped admin /stats and /filter-values endpoints. Replaced the stale `grant :guest :all` example and surrounding paragraph: migration 012 dropped `:all` / `:public` from `user_gallery`, and `grant` rejects pseudo-gallery ids via `requireRealGalleryId`. `:all` survives only as a `hide_map` sentinel.
- **AGENTS.md** was pointing at `server/src/routes/`, claiming an `access` table with viewer/editor/admin levels, and listing `access.ts` among the per-instance shortcuts. Layout is flat (`server/{controllers,lib,models,db}`), the ACL model is `user.is_admin` + `is_editor` on `user_gallery` / `group_gallery`, and the shortcut set is `{photo,photo-rename,photo-geocode,gallery,user,group,meta}`. Added pointers for the filter widget, Manage admin surface, gallery types, filter wire shape, and recent debug-arc footguns (nested-modal Esc capture stacking, modal content overflow, TypeBox additionalProperties).
- **README.md** still listed Day as a separate gallery sub-view (folded into Month in 0.10), invoked the long-deleted `./bin/access.ts level` and `./bin/access.ts list`, advertised `:all` / `:public` as browsable special galleries, described the access model as "no / view / admin" levels granted by `:all` / `:public` / gallery scope, and asserted the gallery namespace had no nesting (true for real galleries, but virtual galleries do compose). Replaced the access-control description with the real two-flag model, retired the pseudo-gallery list, split the gallery section into real vs. virtual (saved-filter + hybrid).
- **react-app/README.md** was missing the Manage admin surface entirely, had a stale `Year/Month/Day/Photo` sub-view list, named modules that don't exist (`scroll`) while omitting many that do (Zustand stores, host-scope hooks, country-sentinel, id-shape, etc.), and quoted bundle sizes from before the Manage code split. Refreshed Structure, expanded the lib/ inventory, rebuilt the Bundle shape table from a current `npm run build`.
- Hybrid galleries described as "union/intersection/difference" in README and AGENTS were inflated: migration 020 says "union of one or more real galleries' photos" and the controller forbids chained virtual sources. Both occurrences narrowed to "union, sources must be real". Filed #600 on the 2.0 milestone for the set-operation extension as a future possibility.

## Test plan

- [ ] Skim each touched .md against the current code paths and command surfaces
- [ ] Confirm `./bin/user.ts access` example resolves (the replacement for `./bin/access.ts list`)
- [ ] Confirm bundle-shape table matches a fresh `cd react-app && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)