### PR TITLE
Fix #602: Evolution chart parity in Global Stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Frontend
+
+- Global Stats (`/stats`, admin) gains feature parity with the gallery-scoped Stats: the Evolution chart now renders inside any trendable category's modal across the whole instance, sharing the same granularity toggle and palette. Closes #602.
+
+### Server
+
+- New `POST /api/v1/stats/evolution` (admin, unscoped) returns per-bucket year-month series across every gallery, mirroring `/galleries/:id/stats/evolution`.
+
 ## [0.16.0] - 2026-06-13
 
 ### Frontend

--- a/react-app/src/components/Gallery/Stats/Category.tsx
+++ b/react-app/src/components/Gallery/Stats/Category.tsx
@@ -199,6 +199,7 @@ interface Props {
   topic: StatsTopic;
   category: StatsCategory;
   galleryId?: string;
+  globalScope?: boolean;
   filters: FiltersT;
   setFilters: (filters: FiltersT) => void;
   theme: ActiveTheme;
@@ -210,6 +211,7 @@ const Category = ({
   topic,
   category,
   galleryId,
+  globalScope = false,
   filters,
   setFilters,
   theme,
@@ -286,6 +288,7 @@ const Category = ({
           topic={topic}
           category={category}
           galleryId={galleryId}
+          globalScope={globalScope}
           filters={filters}
           setFilters={setFilters}
           theme={theme}

--- a/react-app/src/components/Gallery/Stats/EvolutionChart.tsx
+++ b/react-app/src/components/Gallery/Stats/EvolutionChart.tsx
@@ -110,7 +110,11 @@ const goldenCoprimeStride = (n: number): number => {
 };
 
 interface Props {
-  galleryId: string;
+  // Exactly one of galleryId / globalScope must be set. galleryId
+  // routes the fetch through /galleries/:id/stats/evolution;
+  // globalScope routes through the admin-only /stats/evolution.
+  galleryId?: string;
+  globalScope?: boolean;
   categoryKey: string;
   categoryTitle: string;
   theme: ActiveTheme;
@@ -168,6 +172,7 @@ const aggregateByYear = (
 
 const EvolutionChart = ({
   galleryId,
+  globalScope = false,
   categoryKey,
   categoryTitle,
   theme,
@@ -186,25 +191,34 @@ const EvolutionChart = ({
     [filters]
   );
   const serverCategory = CATEGORY_KEY_TO_SERVER[categoryKey];
+  const scopeKey = galleryId ?? (globalScope ? "__global__" : undefined);
   const { data, isLoading } = useQuery({
     queryKey: [
-      "gallery-stats-evolution",
-      galleryId,
+      "stats-evolution",
+      scopeKey,
       serverCategory,
       serverFilters,
       dateRange,
       wireNumericRanges,
     ],
     queryFn: () =>
-      statsService.getGalleryEvolution(
-        galleryId,
-        serverCategory,
-        serverFilters,
-        undefined,
-        dateRange,
-        wireNumericRanges
-      ),
-    enabled: !!serverCategory,
+      galleryId
+        ? statsService.getGalleryEvolution(
+            galleryId,
+            serverCategory,
+            serverFilters,
+            undefined,
+            dateRange,
+            wireNumericRanges
+          )
+        : statsService.getGlobalEvolution(
+            serverCategory,
+            serverFilters,
+            undefined,
+            dateRange,
+            wireNumericRanges
+          ),
+    enabled: !!serverCategory && !!scopeKey,
     placeholderData: keepPreviousData,
   });
 

--- a/react-app/src/components/Gallery/Stats/TableModal.tsx
+++ b/react-app/src/components/Gallery/Stats/TableModal.tsx
@@ -104,6 +104,7 @@ interface Props {
   topic: StatsTopic;
   category: StatsCategory;
   galleryId?: string;
+  globalScope?: boolean;
   filters: FiltersT;
   setFilters: (filters: FiltersT) => void;
   theme: ActiveTheme;
@@ -116,6 +117,7 @@ const TableModal = ({
   topic,
   category,
   galleryId,
+  globalScope = false,
   filters,
   setFilters,
   theme,
@@ -205,9 +207,10 @@ const TableModal = ({
         </Header>
         <ScrollArea>
           <Charts category={category} sortMode={sortMode} />
-          {galleryId && isTrendable(category.key) && (
+          {(galleryId || globalScope) && isTrendable(category.key) && (
             <EvolutionChart
               galleryId={galleryId}
+              globalScope={globalScope}
               categoryKey={category.key}
               categoryTitle={category.title}
               theme={theme}

--- a/react-app/src/components/Gallery/Stats/Topic.tsx
+++ b/react-app/src/components/Gallery/Stats/Topic.tsx
@@ -55,6 +55,7 @@ const Categories = styled.section`
 interface Props {
   topic: StatsTopic;
   galleryId?: string;
+  globalScope?: boolean;
   filters: FiltersT;
   setFilters: (filters: FiltersT) => void;
   theme: ActiveTheme;
@@ -65,6 +66,7 @@ interface Props {
 const Topic = ({
   topic,
   galleryId,
+  globalScope = false,
   filters,
   setFilters,
   theme,
@@ -81,6 +83,7 @@ const Topic = ({
             topic={topic}
             category={category}
             galleryId={galleryId}
+            globalScope={globalScope}
             filters={filters}
             setFilters={setFilters}
             theme={theme}

--- a/react-app/src/components/Gallery/Stats/index.tsx
+++ b/react-app/src/components/Gallery/Stats/index.tsx
@@ -223,6 +223,7 @@ const Stats = ({
             key={topic.key}
             topic={topic}
             galleryId={galleryId}
+            globalScope={globalScope}
             filters={filters}
             setFilters={setFilters}
             theme={theme}

--- a/react-app/src/lib/api-schema.ts
+++ b/react-app/src/lib/api-schema.ts
@@ -2733,6 +2733,72 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/stats/evolution": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Per-bucket time-series for a trendable category across all galleries (admin) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": {
+                        category: string;
+                        filter?: {
+                            [key: string]: {
+                                [key: string]: (string | number | boolean | null)[];
+                            };
+                        };
+                        dateRange?: {
+                            from?: string;
+                            to?: string;
+                        };
+                        numericRanges?: {
+                            [key: string]: {
+                                min?: number;
+                                max?: number;
+                            };
+                        };
+                        lang?: string;
+                    };
+                };
+            };
+            responses: {
+                /** @description Default Response */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": {
+                            yearMonths: string[];
+                            buckets: {
+                                [key: string]: {
+                                    counts: number[];
+                                    cumulative: number[];
+                                };
+                            };
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/filter-values": {
         parameters: {
             query?: never;

--- a/react-app/src/services/stats.ts
+++ b/react-app/src/services/stats.ts
@@ -68,9 +68,23 @@ const getGalleryEvolution = async (
     })
   );
 
+const getGlobalEvolution = async (
+  category: string,
+  filter: ServerFilters,
+  lang?: string,
+  dateRange?: DateRange,
+  numericRanges?: NumericRanges
+) =>
+  unwrap(
+    api.POST("/api/v1/stats/evolution", {
+      body: { category, filter, dateRange, numericRanges, lang },
+    })
+  );
+
 export default {
   getGalleryStats,
   getGlobalStats,
   getGlobalFilterValues,
   getGalleryEvolution,
+  getGlobalEvolution,
 };

--- a/server/controllers/stats-v1.ts
+++ b/server/controllers/stats-v1.ts
@@ -191,6 +191,31 @@ const globalPlugin: FastifyPluginAsyncTypebox = async (fastify) => {
       );
     }
   );
+
+  fastify.post(
+    "/evolution",
+    {
+      schema: {
+        tags: TAGS,
+        summary:
+          "Per-bucket time-series for a trendable category across all galleries (admin)",
+        body: EvolutionBody,
+        response: { 200: EvolutionResponse },
+        security: [{ bearer: [] }],
+      },
+    },
+    async (request) => {
+      requireUnscoped(request);
+      await authorizer.authorizeAdmin(request.user.id);
+      return await model.getGlobalEvolution(
+        request.body.category,
+        request.body.filter as FilterShape | undefined,
+        request.body.lang,
+        request.body.dateRange as DateRange | undefined,
+        request.body.numericRanges as NumericRanges | undefined
+      );
+    }
+  );
 };
 
 export default { init, galleryPlugin, globalPlugin };

--- a/server/models/stats.ts
+++ b/server/models/stats.ts
@@ -44,6 +44,7 @@ export default () => ({
   getGalleryStats,
   getGalleryEvolution,
   getGlobalStats,
+  getGlobalEvolution,
   getGlobalFilterValues,
 });
 
@@ -160,6 +161,25 @@ const getGlobalFilterValues = async (
     dateRange,
     numericRanges
   );
+};
+
+const getGlobalEvolution = async (
+  category: string,
+  filter?: FilterShape,
+  lang?: string,
+  dateRange?: DateRange,
+  numericRanges?: NumericRanges
+): Promise<EvolutionResult> => {
+  const loaded = (await db.loadPhotos(lang)) as Photo[];
+  const photos =
+    isDateRangeUnbounded(dateRange) && isNumericRangesUnbounded(numericRanges)
+      ? loaded
+      : loaded.filter(
+        (p) =>
+          matchesDateRange(dateRange, p) &&
+            matchesNumericRanges(numericRanges, p)
+      );
+  return buildEvolution(photos, category, filter);
 };
 
 const getGlobalStats = async (

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -4768,6 +4768,145 @@
         }
       }
     },
+    "/api/v1/stats/evolution": {
+      "post": {
+        "summary": "Per-bucket time-series for a trendable category across all galleries (admin)",
+        "tags": [
+          "stats"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "category"
+                ],
+                "properties": {
+                  "category": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "filter": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "dateRange": {
+                    "type": "object",
+                    "properties": {
+                      "from": {
+                        "type": "string",
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                      },
+                      "to": {
+                        "type": "string",
+                        "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "numericRanges": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "properties": {
+                        "min": {
+                          "type": "number"
+                        },
+                        "max": {
+                          "type": "number"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "lang": {
+                    "type": "string",
+                    "minLength": 2,
+                    "maxLength": 8
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "yearMonths",
+                    "buckets"
+                  ],
+                  "properties": {
+                    "yearMonths": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "buckets": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object",
+                        "required": [
+                          "counts",
+                          "cumulative"
+                        ],
+                        "properties": {
+                          "counts": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            }
+                          },
+                          "cumulative": {
+                            "type": "array",
+                            "items": {
+                              "type": "number"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/filter-values": {
       "post": {
         "summary": "Filter pill universe across all galleries (admin)",

--- a/server/tests/api/stats.test.ts
+++ b/server/tests/api/stats.test.ts
@@ -301,6 +301,63 @@ describe("global (cross-gallery)", () => {
   });
 });
 
+describe("global evolution (cross-gallery)", () => {
+  const postGlobalEvolution = async (
+    token: string | undefined,
+    body: Record<string, unknown> = { category: "country" },
+    status = 200
+  ) =>
+    api
+      .post("/api/v1/stats/evolution")
+      .set("Authorization", `Bearer ${token}`)
+      .send(body)
+      .expect(status);
+
+  test("admin: returns yearMonths + bucket series across every gallery", async () => {
+    const token = await loginUser(api, "admin");
+    const res = await postGlobalEvolution(token);
+    expect(Array.isArray(res.body.yearMonths)).toBe(true);
+    expect(res.body.buckets).toBeDefined();
+    // Fixture spans jp + nl + fi across all 5 photos including the orphan.
+    expect(Object.keys(res.body.buckets).sort()).toEqual(["fi", "jp", "nl"]);
+    for (const series of Object.values(res.body.buckets) as Array<{
+      counts: number[];
+      cumulative: number[];
+    }>) {
+      expect(series.counts.length).toBe(res.body.yearMonths.length);
+      expect(series.cumulative.length).toBe(res.body.yearMonths.length);
+    }
+  });
+
+  test("filter narrows the buckets cross-gallery", async () => {
+    const token = await loginUser(api, "admin");
+    const res = await postGlobalEvolution(token, {
+      category: "country",
+      filter: { general: { country: ["jp"] } },
+    });
+    expect(Object.keys(res.body.buckets)).toEqual(["jp"]);
+  });
+
+  test("guest blocked → 403", async () => {
+    await api
+      .post("/api/v1/stats/evolution")
+      .send({ category: "country" })
+      .expect(403);
+  });
+
+  test("non-admin → 403", async () => {
+    const token = await loginUser(api, "plainuser");
+    await postGlobalEvolution(token, { category: "country" }, 403);
+  });
+
+  test("unknown category → empty buckets (graceful)", async () => {
+    const token = await loginUser(api, "admin");
+    const res = await postGlobalEvolution(token, { category: "nope" });
+    expect(res.body.yearMonths).toEqual([]);
+    expect(res.body.buckets).toEqual({});
+  });
+});
+
 describe("unknown bucket", () => {
   test("photos with empty fields bucket under 'unknown'", async () => {
     const token = await loginUser(api, "admin");


### PR DESCRIPTION
## Summary

GlobalStats already reused Gallery's Stats / Filters / MapModal, so the only gap to feature parity was the Evolution chart. The chart was gated to gallery scope in two places: the backend lacked a cross-gallery flavour of the evolution endpoint, and `TableModal` hid the chart whenever its `galleryId` prop was absent.

Added `POST /api/v1/stats/evolution` (admin-only, unscoped) and the matching `getGlobalEvolution` model method that walks `db.loadPhotos` the same way `getGlobalStats` does. The compute path itself is the existing `buildEvolution` — evolution buckets never reference photo gallery membership, so the global flavour drops the gallery-link decoration that `getGlobalStats` needs for `byGallery`.

Frontend: `EvolutionChart` now takes either `galleryId` or `globalScope` and routes through the matching service. `TableModal` keeps the trendable-category check but renders the chart when either scope is set. `Category` / `Topic` / `Stats` thread the new prop through; GlobalStats already passes `globalScope`, so the chart lights up there too.

Closes #602.

## Test plan

- [ ] `cd server && npm test` — covers admin success, filter narrowing, guest 403, non-admin 403, unknown-category empty
- [ ] `cd server && npm run typecheck && npm run lint`
- [ ] `cd react-app && npm test && npm run typecheck && npm run lint`
- [ ] Manual: open Global Stats (`/stats`), expand a trendable category (e.g. country, camera, focal length), verify the Evolution stacked-area chart renders with month / year granularity toggle
- [ ] Manual: gallery-scoped Stats still shows the Evolution chart in the same modals (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)