### PR TITLE
Fix #557, #537: instance.ts admin-bootstrap prompt + --edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,18 @@
 
 - Global Stats (`/stats`, admin) gains feature parity with the gallery-scoped Stats: the Evolution chart now renders inside any trendable category's modal across the whole instance, sharing the same granularity toggle and palette. Closes #602.
 - Per-photo visibility: photos gain a "Private" switch in PhotoDrawer; `/m/photos` bulk multi-select gains "Set private…" and "Set public…" actions; the `/m/access` table grows a per-gallery "Private" column granting `can_see_private` to view-only viewers (editors implicit); and the public Photo modal shows a "Private" badge to viewers who can see it. Closes #480.
-- Editor-tier "Manage this photo" / "Set as gallery icon" buttons on the public Photo modal — gated by `user.isGalleryEditor(galleryId)` instead of `isAdmin`. Editors reach the PhotoDrawer via `/m/photos/<id>?gallery=<g>` and land on a drawer-only shell (the cross-gallery grid + bulk actions stay admin-only). Closes #575.
+- Editor-tier "Manage this photo" / "Set as gallery icon" buttons on the public Photo modal — gated by `user.isGalleryEditor(galleryId)` instead of `isAdmin`. The pencil now opens the editor as an overlay modal in-place over the public Photo view, so admins / editors don't have to navigate away from `/g/` to fix metadata; the drawer keeps an "Open in Manage" link out to `/m/photos/<id>` for the full admin context. `e` keyboard shortcut toggles the editor while the photo is open. Closes #575.
 
 ### Server
 
 - New `POST /api/v1/stats/evolution` (admin, unscoped) returns per-bucket year-month series across every gallery, mirroring `/galleries/:id/stats/evolution`.
 - `photo` gains an `is_private` flag and `user_gallery` / `group_gallery` gain `can_see_private`; every gallery read path (list, query, counts, neighbors, filter-values, gallery+photo, stats, evolution) excludes private photos unless the resolved viewer is admin, gallery-editor, or holds a direct/inherited `can_see_private` grant on the gallery they're viewing. The flag flips through the existing `PUT /api/v1/photos/:photoId` (gallery-editor on any of the photo's galleries). `bin/user.ts grant --private-view`, `bin/group.ts grant --private-view`, and `bin/photo.ts private/public <id>` are the CLI flavours.
 - `GET /api/v1/photos/:photoId` opens to gallery-editors on at least one of the photo's galleries (same gate as PUT) so the editor-tier "Manage this photo" button can reach the drawer. The list endpoint `GET /api/v1/photos` stays admin-only — cross-gallery browse remains an admin surface.
+
+### Operator
+
+- `bin/instance.ts` prompts on a TTY after a fresh bootstrap to create the first admin user (Y/n; defaults to yes, username `admin`); `--auto` and non-TTY runs fall back to the printed instructions. Closes #557.
+- `bin/instance.ts --edit` walks every configurable `.env` key, shows the current value, prompts for a new one (default = keep). SECRET is read-only — rotating it invalidates every active session. Requires a TTY. Closes #537 (the standalone slice; the full prompt fan-out for `new` / `--fix` lands alongside #265's Postgres driver).
 
 ## [0.16.0] - 2026-06-13
 

--- a/bin/instance.ts
+++ b/bin/instance.ts
@@ -37,7 +37,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { confirm } from "@inquirer/prompts";
+import { confirm, input } from "@inquirer/prompts";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
@@ -47,6 +47,10 @@ interface RequiredKey {
   key: string;
   description: string;
   default: (ctx: { instanceDir: string; name: string }) => string;
+  // False for keys an operator should not be re-prompted for in
+  // --edit mode (notably SECRET — rotating it invalidates every
+  // session). Defaults true.
+  editable?: boolean;
 }
 
 // ---- constants -----------------------------------------------------------
@@ -83,6 +87,7 @@ const REQUIRED_KEYS: RequiredKey[] = [
     key: "SECRET",
     description: "HMAC secret for JWT tokens — keep this stable per instance",
     default: () => randomBytes(32).toString("hex"),
+    editable: false,
   },
   {
     key: "DB_DRIVER",
@@ -260,6 +265,12 @@ const argv = yargs(hideBin(process.argv))
           type: "boolean",
           default: false,
         })
+        .option("edit", {
+          describe:
+            "Walk every configurable .env key, show the current value, prompt for a new one (default = keep). For a config-review / tweak pass on an existing instance. Requires a TTY. SECRET is read-only — rotating it invalidates every active session.",
+          type: "boolean",
+          default: false,
+        })
         .option("quiet", {
           describe:
             "Suppress informational output; errors and warnings still surface. For scripted re-runs.",
@@ -294,10 +305,12 @@ const argv = yargs(hideBin(process.argv))
 const positional = argv.dir as string | undefined;
 const nameFlag = argv.name as string | undefined;
 const fix = argv.fix;
+const edit = argv.edit as boolean;
 const quiet = argv.quiet;
 const auto = argv.auto as boolean;
 const printOnly = argv["print-only"] as boolean;
 const cycle = argv.cycle as boolean;
+const isTTY = !!process.stdin.isTTY && !!process.stdout.isTTY;
 
 const log: typeof console.log = (...args) => {
   if (!quiet) console.log(...args);
@@ -421,6 +434,50 @@ if (mode === "new") {
     setEnvKey(envPath, "INSTANCE_NAME", nameFlag);
     log(`✓ Set INSTANCE_NAME=${nameFlag} in .env`);
   }
+
+  // --edit: walk every editable key, current value as default,
+  // write the diff back. Requires a TTY (the rest of the script
+  // is non-interactive so headless re-runs can't accidentally
+  // snag the prompt). Runs after --fix's append so the operator
+  // never edits a missing key by hand on the first pass.
+  if (edit) {
+    if (!isTTY) {
+      console.error(
+        "Error: --edit requires a TTY (interactive terminal). Re-run from a shell."
+      );
+      process.exit(1);
+    }
+    const refreshed = parseEnv(fs.readFileSync(envPath, "utf8"));
+    log();
+    log("Editing .env values (Enter keeps the current value):");
+    const changes: string[] = [];
+    for (const spec of REQUIRED_KEYS) {
+      if (spec.editable === false) {
+        log(`  · ${spec.key} (read-only, current value preserved)`);
+        continue;
+      }
+      const current = refreshed[spec.key] ?? "";
+      const next = await input({
+        message: `${spec.key}:`,
+        default: current,
+      });
+      const trimmed = next.trim();
+      if (trimmed !== current) {
+        setEnvKey(envPath, spec.key, trimmed);
+        changes.push(spec.key);
+      }
+    }
+    if (changes.length > 0) {
+      log(`✓ Updated .env: ${changes.join(", ")}`);
+    } else {
+      log("✓ No changes.");
+    }
+    log();
+    log(
+      "Restart the instance to pick up the new values (pm2 cycle, or `./bin/instance.ts <dir> --cycle`)."
+    );
+    process.exit(0);
+  }
 }
 
 // 4. Upgrade flow: back up the DB before flipping the symlink
@@ -542,13 +599,14 @@ log("Tools:");
 // 7. Next steps
 log();
 if (mode === "new") {
-  log("Instance ready. Next:");
+  log("Instance ready.");
+  await maybeCreateAdmin();
+  log();
+  log("Next:");
   log(`  cd ${instanceDir}`);
   log("  ./code/server/bin/start-prod.sh");
   log("  ./code/converter/bin/start-prod.sh");
-  log("  ./bin/user.ts passwd <username> <password>");
   log(`  ./bin/gallery.ts create ${instanceName} --title "${instanceName}"`);
-  log("  ./bin/user.ts make-admin <username>");
 } else if (mode === "upgrade") {
   await runPm2Cycle("upgrade");
 } else {
@@ -556,6 +614,70 @@ if (mode === "new") {
   if (cycle) {
     log();
     await runPm2Cycle("restart");
+  }
+}
+
+// New-mode bootstrap completes without a global-admin user — the
+// SPA's manage surface stays locked until one exists. Offer to
+// create one right here so the operator doesn't have to walk back
+// through the printed-instructions path. Skips on `--auto` and
+// non-TTY runs (CI / batch), falling back to the printed steps.
+async function maybeCreateAdmin(): Promise<void> {
+  if (auto || !isTTY) {
+    log();
+    log("Create your first admin user when ready:");
+    log("  ./bin/user.ts passwd <username>");
+    log("  ./bin/user.ts make-admin <username>");
+    return;
+  }
+  log();
+  const create = await confirm({
+    message: "Create an admin user now?",
+    default: true,
+  });
+  if (!create) {
+    log();
+    log("Create one later with:");
+    log("  ./bin/user.ts passwd <username>");
+    log("  ./bin/user.ts make-admin <username>");
+    return;
+  }
+  const username = (
+    await input({
+      message: "Admin username:",
+      default: "admin",
+    })
+  ).trim();
+  if (!username) {
+    console.warn("Empty username — skipping admin creation.");
+    return;
+  }
+  // Spawn the routine operator scripts with cwd=instanceDir so they
+  // pick up the just-created `.env` (DB path is fixed at <cwd>/db.sqlite3,
+  // SECRET / DB_DRIVER live in `.env`). user.ts's `passwd` prompts for
+  // the password interactively when omitted — instance.ts never holds
+  // the cleartext. inherit stdio so the prompt actually shows.
+  const userBin = path.join(instanceDir, "bin", "user.ts");
+  const passwdResult = spawnSync(userBin, ["passwd", username], {
+    cwd: instanceDir,
+    stdio: "inherit",
+  });
+  if (passwdResult.status !== 0) {
+    console.warn(
+      `passwd ${username} exited with status ${passwdResult.status ?? "?"} — skipping make-admin.`
+    );
+    return;
+  }
+  const adminResult = spawnSync(userBin, ["make-admin", username], {
+    cwd: instanceDir,
+    stdio: "inherit",
+  });
+  if (adminResult.status === 0) {
+    log(`✓ Admin user "${username}" created.`);
+  } else {
+    console.warn(
+      `make-admin ${username} exited with status ${adminResult.status ?? "?"}.`
+    );
   }
 }
 

--- a/bin/instance.ts
+++ b/bin/instance.ts
@@ -47,6 +47,12 @@ interface RequiredKey {
   key: string;
   description: string;
   default: (ctx: { instanceDir: string; name: string }) => string;
+  // True for keys an empty bootstrap must seed (writeEnvFile +
+  // --fix's missing-row report read this). False = optional
+  // .env knob: bootstrap leaves the row absent, the server's
+  // own default applies; --edit still walks it so an operator
+  // can opt in. Defaults true.
+  required?: boolean;
   // False for keys an operator should not be re-prompted for in
   // --edit mode (notably SECRET — rotating it invalidates every
   // session). Defaults true.
@@ -67,32 +73,111 @@ const REQUIRED_DIRS = [
   "photos/thumbnail",
 ];
 
-// Required .env keys for a working instance. The DB file (`db.sqlite3`) and
-// photo root (`photos/`) are no longer configurable — they're fixed relative
-// to the instance directory (the CWD when the server/converter run via
-// start-prod.sh). Symlink the instance dir, the `photos/` subdirectory, or
-// the `db.sqlite3` file if you need them on a different disk.
+// Configurable .env keys. `required: true` keys are seeded on
+// bootstrap and reported by --fix when missing; `required: false`
+// keys are opt-in (the server has a built-in default) but still
+// walked by --edit. The DB file (`db.sqlite3`) and photo root
+// (`photos/`) are no longer configurable — they're fixed relative
+// to the instance directory (the CWD when the server/converter
+// run via start-prod.sh). Symlink the instance dir, the `photos/`
+// subdirectory, or the `db.sqlite3` file if you need them on a
+// different disk.
+//
+// Per-instance BETA_FEATURE_<NAME> flags aren't enumerable in
+// advance (any feature the server defines), so --edit doesn't
+// walk them — the operator sets / unsets them by hand.
 const REQUIRED_KEYS: RequiredKey[] = [
+  // --- required: seeded on bootstrap -----------------------------------
   {
     key: "INSTANCE_NAME",
     description: "pm2 process name; converter gets `<name>-converter`",
     default: ({ name }) => name,
+    required: true,
   },
   {
     key: "PORT",
     description: "HTTP port the server listens on (nginx proxies to this)",
     default: () => "4200",
+    required: true,
   },
   {
     key: "SECRET",
     description: "HMAC secret for JWT tokens — keep this stable per instance",
     default: () => randomBytes(32).toString("hex"),
+    required: true,
     editable: false,
   },
   {
     key: "DB_DRIVER",
     description: "DB driver",
     default: () => "sqlite3",
+    required: true,
+  },
+  // --- optional: server has built-in defaults --------------------------
+  // Empty value here means "leave the row absent; the server's
+  // built-in default applies". The description spells out that
+  // default explicitly so the operator knows what they get.
+  {
+    key: "DEFAULT_GALLERY",
+    description:
+      "Gallery to redirect to from `/g` when no other heuristic (single-gallery, hostname match) picks one (empty = let the heuristic choose)",
+    default: () => "",
+    required: false,
+  },
+  {
+    key: "DEFAULT_THEME",
+    description:
+      "Fallback theme when a gallery row has no `theme` set: blue / red / grayscale / bw / alert (empty = blue)",
+    default: () => "",
+    required: false,
+  },
+  {
+    key: "DEFAULT_LANGUAGE",
+    description:
+      "Instance-level primary language for operator-set photo / gallery metadata: en / fi / ja (empty = en)",
+    default: () => "",
+    required: false,
+  },
+  {
+    key: "INITIAL_GALLERY_VIEW",
+    description:
+      "Fallback initial view when a gallery has no `initial_view` set: year / month / day / photo (empty = year)",
+    default: () => "",
+    required: false,
+  },
+  {
+    key: "FIRST_WEEKDAY",
+    description:
+      "First day of the week in the year-view calendar grid: 0 (Sunday) or 1 (Monday) (empty = 0 / Sunday)",
+    default: () => "",
+    required: false,
+  },
+  {
+    key: "REVERSE_GEOCODE",
+    description:
+      "Reverse-geocode new photos with coords at intake via Nominatim — truthy = on; opt-in because coordinates leave the host (empty = off)",
+    default: () => "",
+    required: false,
+  },
+  {
+    key: "REVERSE_GEOCODE_EXTRA_LANGS",
+    description:
+      "Comma-separated extra languages to fetch on top of English (e.g. `ja,fi`); each adds one 1 RPS Nominatim call per photo at intake (empty = English only)",
+    default: () => "",
+    required: false,
+  },
+  {
+    key: "NOMINATIM_BASE_URL",
+    description:
+      "Override to point at a self-hosted Nominatim (empty = https://nominatim.openstreetmap.org)",
+    default: () => "",
+    required: false,
+  },
+  {
+    key: "DEBUG",
+    description: "Verbose logger output when truthy (empty = off)",
+    default: () => "",
+    required: false,
   },
 ];
 
@@ -136,9 +221,11 @@ const resolveSymlinkTarget = (link: string): string | null => {
 };
 
 const writeEnvFile = (filePath: string, ctx: { instanceDir: string; name: string }): void => {
-  const lines = REQUIRED_KEYS.map(({ key, description, default: d }) => {
-    return `# ${description}\n${key}=${d(ctx)}\n`;
-  });
+  const lines = REQUIRED_KEYS.filter((k) => k.required !== false).map(
+    ({ key, description, default: d }) => {
+      return `# ${description}\n${key}=${d(ctx)}\n`;
+    }
+  );
   fs.writeFileSync(filePath, lines.join("\n"));
 };
 
@@ -147,7 +234,9 @@ const appendMissingKeys = (
   existing: Record<string, string>,
   ctx: { instanceDir: string; name: string }
 ): string[] => {
-  const missing = REQUIRED_KEYS.filter(({ key }) => !existing[key]);
+  const missing = REQUIRED_KEYS.filter(
+    ({ key, required }) => required !== false && !existing[key]
+  );
   if (missing.length === 0) return [];
   const additions = missing
     .map(({ key, description, default: d }) => `# ${description}\n${key}=${d(ctx)}\n`)
@@ -416,7 +505,9 @@ if (mode === "new") {
   log(`✓ Created ${envPath} (with a fresh random SECRET)`);
 } else {
   const existing = parseEnv(fs.readFileSync(envPath, "utf8"));
-  const missing = REQUIRED_KEYS.filter(({ key }) => !existing[key]);
+  const missing = REQUIRED_KEYS.filter(
+    ({ key, required }) => required !== false && !existing[key]
+  );
   if (missing.length === 0) {
     log("✓ .env present and complete");
   } else if (fix) {
@@ -449,13 +540,17 @@ if (mode === "new") {
     }
     const refreshed = parseEnv(fs.readFileSync(envPath, "utf8"));
     log();
-    log("Editing .env values (Enter keeps the current value):");
+    log(
+      "Editing .env values (Enter keeps the current value; empty value clears the row)."
+    );
+    log();
     const changes: string[] = [];
     for (const spec of REQUIRED_KEYS) {
       if (spec.editable === false) {
         log(`  · ${spec.key} (read-only, current value preserved)`);
         continue;
       }
+      log(`  ${spec.description}`);
       const current = refreshed[spec.key] ?? "";
       const next = await input({
         message: `${spec.key}:`,

--- a/server/README.md
+++ b/server/README.md
@@ -78,12 +78,12 @@ cd /var/photo-diary/dailybw
 
 The per-instance `bin/` directory (`<instance>/bin/{photo,photo-rename,photo-geocode,gallery,user,group,meta}.ts`) is populated by `bin/instance.ts` on init and refreshed on doctor / upgrade runs — each is a symlink into `<instance>/code/server/bin/`. `instance.ts` itself is deliberately not shortcut-symlinked here: bootstrap / upgrade always wants the specific code version (`/opt/photo-diary/<version>/bin/instance.ts <name>`), and the doctor re-run is rare enough that `./code/bin/instance.ts <name> --base <parent>` is fine. The `.ts` extension is kept on the symlinks (rather than bare names) so editors recognise them as TS source and apply the server's tsconfig via realpath.
 
-#### `instance.ts <name> [--base <dir>] [--fix]`
+#### `instance.ts <name> [--base <dir>] [--fix] [--edit]`
 
 Bootstrap, doctor, or upgrade a Photo Diary instance directory in one command. Default base is `/var/photo-diary`. Mode is auto-detected from existing state:
 
-- **New** — creates the directory tree, generates `.env` with a fresh random `SECRET`, creates a `code` symlink pointing at this script's own code root, and creates the per-instance `bin/{photo,photo-rename,photo-geocode,gallery,user,group,meta}.ts` shortcuts.
-- **Doctor** — instance exists, `code` already points at this script's root. Reports missing `.env` keys with `✓`/`✗` markers. Refreshes any missing `bin/` shortcuts. Add `--fix` to append defaults to `.env`.
+- **New** — creates the directory tree, generates `.env` with a fresh random `SECRET`, creates a `code` symlink pointing at this script's own code root, and creates the per-instance `bin/{photo,photo-rename,photo-geocode,gallery,user,group,meta}.ts` shortcuts. On a TTY (and unless `--auto` is passed) prompts to create the first admin user via `./bin/user.ts passwd <username>` + `./bin/user.ts make-admin <username>` so the SPA's manage surface is reachable without walking through the printed instructions.
+- **Doctor** — instance exists, `code` already points at this script's root. Reports missing `.env` keys with `✓`/`✗` markers. Refreshes any missing `bin/` shortcuts. Add `--fix` to append defaults to `.env`. Add `--edit` to walk every configurable `.env` key, show the current value, and prompt for a new one (Enter keeps it) — config-review / tweak pass without re-reading `.env` by hand. `SECRET` is read-only in this mode; rotate it manually only when you intentionally want to invalidate every session.
 - **Upgrade** — `code` points at a different version. Backs up the DB to `db.sqlite3.pre-<new-version>` and flips the symlink. Refreshes `bin/` shortcuts.
 
 #### `user.ts <subcommand> …`


### PR DESCRIPTION
## Summary

Two small operator-ergonomics wins for `bin/instance.ts`, bundled because they share the file + the prompt-layer scaffolding.

### #557: admin-bootstrap prompt

New-mode bootstrap finishes with the SPA's manage surface locked, because there's no admin user yet — the operator has to walk through the printed instructions (`./bin/user.ts passwd …` + `./bin/user.ts make-admin …`) before they can actually use the instance. After the "Instance ready" banner, prompt on a TTY: "Create an admin user now? (Y/n)" (default yes, username default `admin`). Spawns `./bin/user.ts passwd <username>` (which prompts for the password itself — `instance.ts` never holds the cleartext) and `./bin/user.ts make-admin <username>`, both with `cwd=instanceDir`. `--auto` and non-TTY runs fall back to today's printed instructions.

### #537: `--edit` (standalone slice)

Walks every configurable `.env` key on an existing instance, shows the current value as the default, prompts for a new one (Enter keeps it). Writes the diff through the existing `setEnvKey`. Requires a TTY — errors out off-TTY so CI / piped-input runs stay predictable.

`SECRET` is marked `editable: false` on the `RequiredKey` row (rotating it invalidates every active session, so the operator opts in manually). The broader prompt fan-out across `new` / `--fix` waits for the Postgres driver (#265) where the driver branch makes prompts genuinely useful.

## Test plan

- [ ] `cd server && npm run typecheck && npm run lint && npm test`
- [ ] Manual: `bin/instance.ts /tmp/test-instance --auto` → bootstraps without prompts, prints the "Create admin later" instructions.
- [ ] Manual: `bin/instance.ts /tmp/test-instance2` on a TTY → prompts "Create an admin user now?" → answer yes → username prompt → `user.ts passwd` runs and prompts for password → `user.ts make-admin` flips the flag.
- [ ] Manual: `bin/instance.ts /tmp/test-instance --edit` on a TTY → walks PORT / INSTANCE_NAME / DB_DRIVER prompts with current value as default, marks SECRET read-only.
- [ ] Manual: `bin/instance.ts /tmp/test-instance --edit < /dev/null` → errors with "Error: --edit requires a TTY".

🤖 Generated with [Claude Code](https://claude.com/claude-code)