### PR TITLE
Fix #612: Esc-up navigation in /m/* admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Admin
 
 - New `/m/instance` page edits the instance's identity (`name`, `description`, `cdn`, `image`) and the SPA's runtime defaults (`defaultGallery`, `defaultTheme`, `defaultLanguage`, `initialGalleryView`, `firstWeekday`, `betaFeatures`). The SPA defaults previously lived only in `.env` and required a server restart; they're now stored in the `meta` table, take effect on the SPA's next `/meta` fetch, and the `meta` row wins over the matching env value when both are set. The `.env` path remains as a fallback for instances that haven't seeded the meta rows yet — server logs a one-line deprecation on startup when any deprecated key is in use, and the env path is scheduled for removal by 1.0. The SPA now also waits for `/meta` before applying any theme, so the brief blue-flash before a grayscale-themed gallery loaded goes away. Closes #513.
+- Esc anywhere in `/m/*` navigates one step up the breadcrumb (matches the public Photo modal's Esc). `/m/g/<id>` → `/m/galleries`, `/m/users/<id>` → `/m/users`, etc.; `/m` is a no-op. Stacked modals (filter widget, bulk-action picker, icon cropper, login / change-password / theme-picker pop-ups, the in-place PhotoDrawer) keep their Esc-closes-me behaviour by intercepting via capture-phase listeners with `stopImmediatePropagation`. Closes #612.
 
 ### Frontend
 

--- a/react-app/src/components/ChangePasswordModal.tsx
+++ b/react-app/src/components/ChangePasswordModal.tsx
@@ -56,11 +56,15 @@ const ChangePasswordModal = (): React.ReactElement | null => {
 
   React.useEffect(() => {
     if (!isOpen) return;
+    // Capture-phase + stopImmediatePropagation: see LoginModal.
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") close();
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      close();
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
   }, [isOpen, close]);
 
   if (!isOpen) return null;

--- a/react-app/src/components/LoginModal.tsx
+++ b/react-app/src/components/LoginModal.tsx
@@ -76,11 +76,17 @@ const LoginModal = (): React.ReactElement | null => {
 
   React.useEffect(() => {
     if (!isOpen) return;
+    // Capture-phase + stopImmediatePropagation so closing this
+    // modal doesn't also trigger the Manage shell's Esc-up
+    // navigation (#612) when it's opened from /m/*.
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") close();
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      close();
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
   }, [isOpen, close]);
 
   if (!isOpen) return null;

--- a/react-app/src/components/Manage/BulkActions.tsx
+++ b/react-app/src/components/Manage/BulkActions.tsx
@@ -449,11 +449,17 @@ const BulkActions = ({
 
   React.useEffect(() => {
     if (pending.kind === "none") return;
+    // Capture-phase + stopImmediatePropagation so closing the bulk
+    // modal doesn't also trigger the Manage shell's Esc-up
+    // navigation (#612).
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeModal();
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      closeModal();
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
   }, [pending.kind, closeModal]);
 
   const runSequentially = async (fn: (id: string) => Promise<void>) => {

--- a/react-app/src/components/Manage/CountrySelect.tsx
+++ b/react-app/src/components/Manage/CountrySelect.tsx
@@ -149,14 +149,21 @@ const CountrySelect = ({
         setOpen(false);
       }
     };
+    // Capture-phase + stopImmediatePropagation so the dropdown
+    // intercepts Esc before the Manage shell's Esc-up handler
+    // (#612) navigates the user out of /m/users/<id>/etc. when
+    // they were just trying to close this dropdown.
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      setOpen(false);
     };
     document.addEventListener("pointerdown", onPointer);
-    document.addEventListener("keydown", onKey);
+    document.addEventListener("keydown", onKey, true);
     return () => {
       document.removeEventListener("pointerdown", onPointer);
-      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("keydown", onKey, true);
     };
   }, [open]);
 

--- a/react-app/src/components/Manage/IconCropper.tsx
+++ b/react-app/src/components/Manage/IconCropper.tsx
@@ -176,11 +176,18 @@ const IconCropper = ({
   const [error, setError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
+    // Capture-phase + stopImmediatePropagation so closing the
+    // crop modal doesn't also trigger the Manage shell's Esc-up
+    // navigation (#612).
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !busy) onClose();
+      if (e.key !== "Escape") return;
+      if (busy) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      onClose();
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
   }, [busy, onClose]);
 
   const onBackdropClick = (event: React.MouseEvent) => {

--- a/react-app/src/components/Manage/index.tsx
+++ b/react-app/src/components/Manage/index.tsx
@@ -335,6 +335,11 @@ const Manage = (): React.ReactElement => {
   React.useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
+      // Autorepeat protection: holding Esc briefly fires keydown
+      // again every ~30ms and would skip multiple levels per
+      // tap. `e.repeat` is true on the autorepeat events; the
+      // first keydown of a press has it false.
+      if (e.repeat) return;
       const parent = parentManagePath(location.pathname);
       if (!parent) return;
       e.preventDefault();

--- a/react-app/src/components/Manage/index.tsx
+++ b/react-app/src/components/Manage/index.tsx
@@ -33,6 +33,24 @@ const GLOBAL_MANAGE_PATHS = [
   "/m/instance",
 ];
 
+// Resolve the "go up one step" target for Esc-up navigation.
+// Mostly strip-last-segment; the one asymmetry is `/m/g/<id>` →
+// `/m/galleries` (the list lives at `/m/galleries`, not `/m/g`).
+// Returns null when there's nowhere to go (top-level `/m`, or an
+// unfamiliar path that doesn't look like /m/*).
+export const parentManagePath = (pathname: string): string | null => {
+  // Strip trailing slash for uniform matching.
+  const path = pathname.replace(/\/$/, "");
+  if (path === "/m" || !path.startsWith("/m/")) return null;
+  // `/m/g/<id>` → `/m/galleries` (list isn't `/m/g`).
+  if (/^\/m\/g\/[^/]+$/.test(path)) return "/m/galleries";
+  // Strip the last segment.
+  const idx = path.lastIndexOf("/");
+  const parent = idx > 0 ? path.slice(0, idx) : "/m";
+  // Don't escape `/m`.
+  return parent.startsWith("/m") ? parent : "/m";
+};
+
 const Root = styled.div`
   padding: 0 5px;
 `;
@@ -305,6 +323,26 @@ const Manage = (): React.ReactElement => {
     () => buildCrumbs(location.pathname, t, resolved, { galleryId }),
     [location.pathname, t, resolved, galleryId]
   );
+
+  // Esc-up: Esc anywhere in /m/* navigates to the parent path,
+  // matching the public Photo modal's "close this, return to the
+  // previous view" behaviour. Bubble phase on purpose — stacked
+  // modals (FilterModal, the in-place PhotoDrawer, future
+  // dirty-form prompts) already register capture-phase listeners
+  // with `stopImmediatePropagation`, so they win and we never
+  // navigate while one of them is open. When nothing closer
+  // wants the event, the shell handles it.
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const parent = parentManagePath(location.pathname);
+      if (!parent) return;
+      e.preventDefault();
+      navigate(parent);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [location.pathname, navigate]);
 
   const body = !user ? (
     <NoticeBody>{t("manage-not-logged-in")}</NoticeBody>

--- a/react-app/src/components/Manage/parentManagePath.test.ts
+++ b/react-app/src/components/Manage/parentManagePath.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import { parentManagePath } from "./index";
+
+describe("parentManagePath", () => {
+  test("nested edit pages strip the last segment", () => {
+    expect(parentManagePath("/m/g/abc/access")).toBe("/m/g/abc");
+    expect(parentManagePath("/m/users/alice")).toBe("/m/users");
+    expect(parentManagePath("/m/groups/staff")).toBe("/m/groups");
+    expect(parentManagePath("/m/photos/img.jpg")).toBe("/m/photos");
+    expect(parentManagePath("/m/galleries/new")).toBe("/m/galleries");
+    expect(parentManagePath("/m/users/new")).toBe("/m/users");
+    expect(parentManagePath("/m/groups/new")).toBe("/m/groups");
+  });
+
+  test("/m/g/<id> maps to /m/galleries (asymmetric route shape)", () => {
+    expect(parentManagePath("/m/g/dailybw")).toBe("/m/galleries");
+    expect(parentManagePath("/m/g/abc-123")).toBe("/m/galleries");
+  });
+
+  test("first-level pages go to /m", () => {
+    expect(parentManagePath("/m/galleries")).toBe("/m");
+    expect(parentManagePath("/m/users")).toBe("/m");
+    expect(parentManagePath("/m/groups")).toBe("/m");
+    expect(parentManagePath("/m/access")).toBe("/m");
+    expect(parentManagePath("/m/photos")).toBe("/m");
+    expect(parentManagePath("/m/instance")).toBe("/m");
+  });
+
+  test("/m and non-/m paths are no-ops", () => {
+    expect(parentManagePath("/m")).toBe(null);
+    expect(parentManagePath("/m/")).toBe(null);
+    expect(parentManagePath("/g/dailybw")).toBe(null);
+    expect(parentManagePath("/")).toBe(null);
+    expect(parentManagePath("")).toBe(null);
+  });
+
+  test("trailing slash is normalised", () => {
+    expect(parentManagePath("/m/galleries/")).toBe("/m");
+    expect(parentManagePath("/m/g/abc/")).toBe("/m/galleries");
+    expect(parentManagePath("/m/g/abc/access/")).toBe("/m/g/abc");
+  });
+});

--- a/react-app/src/components/ThemePickerModal.tsx
+++ b/react-app/src/components/ThemePickerModal.tsx
@@ -91,11 +91,15 @@ const ThemePickerModal = (): React.ReactElement | null => {
 
   React.useEffect(() => {
     if (!isOpen) return;
+    // Capture-phase + stopImmediatePropagation: see LoginModal.
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") close();
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      close();
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
   }, [isOpen, close]);
 
   if (!isOpen) return null;

--- a/react-app/src/components/UserMenu.tsx
+++ b/react-app/src/components/UserMenu.tsx
@@ -149,14 +149,20 @@ const UserMenu = (): React.ReactElement => {
         setIsOpen(false);
       }
     };
+    // Capture-phase + stopImmediatePropagation so closing this
+    // dropdown doesn't also trigger the Manage shell's Esc-up
+    // navigation (#612) when opened from /m/*.
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setIsOpen(false);
+      if (e.key !== "Escape") return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      setIsOpen(false);
     };
     document.addEventListener("pointerdown", onPointer);
-    document.addEventListener("keydown", onKey);
+    document.addEventListener("keydown", onKey, true);
     return () => {
       document.removeEventListener("pointerdown", onPointer);
-      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("keydown", onKey, true);
     };
   }, [isOpen]);
 


### PR DESCRIPTION
## Summary

Esc anywhere in \`/m/*\` now navigates one step up the breadcrumb, matching the public Photo modal's Esc behaviour. `/m/g/<id>` → `/m/galleries`, `/m/users/<id>` → `/m/users`, `/m/photos/<id>` → `/m/photos`, `/m/instance` → `/m`, etc. `/m` itself is a no-op.

The Manage shell carries a bubble-phase keydown listener that computes the parent path via a small `parentManagePath` helper. The strip-last-segment rule covers most cases; the one asymmetry is `/m/g/<id>` → `/m/galleries` (the list lives at `/m/galleries`, not at `/m/g`). A unit test locks every documented mapping.

## Stacked modals

Modals inside or above `/m/*` that close on Esc had been using bubble-phase listeners. Both they and the shell would have fired off one Esc press: modal closes _and_ shell navigates. Upgraded those to capture-phase + `stopImmediatePropagation` so the modal intercepts first and the shell never sees the event while a modal is open:

- `BulkActions` (the `/m/photos` bulk-action modal)
- `IconCropper` (gallery icon crop)
- `CountrySelect` dropdown
- `LoginModal`, `ChangePasswordModal`, `ThemePickerModal`, `UserMenu` (top-level modals reachable from any route)

Filter widget, Photo modal, TableModal, SummaryModal, in-place PhotoDrawer all already used capture-phase via prior work — no change.

## Out of scope

- Dirty-form prompts. Pages that want "are you sure?" before leaving can add their own capture-phase listener following the same pattern. Default behaviour: Esc-up navigates without prompt, matching browser back / breadcrumb click.

Closes #612.

## Test plan

- [ ] `cd react-app && npm run typecheck && npm run lint && npm test`
- [ ] Manual: from `/m/g/<id>/access`, Esc → `/m/g/<id>` → Esc → `/m/galleries` → Esc → `/m` → Esc no-op.
- [ ] Manual: open BulkActions edit-fields modal in `/m/photos`, Esc → modal closes, still on `/m/photos`.
- [ ] Manual: open UserMenu dropdown anywhere in `/m/*`, Esc → dropdown closes, page unchanged.
- [ ] Manual: open in-place PhotoDrawer (`e`) on a public photo, Esc → drawer closes, photo modal stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)