### PR TITLE
Remove photo modal zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Global Stats (`/stats`, admin) gains feature parity with the gallery-scoped Stats: the Evolution chart now renders inside any trendable category's modal across the whole instance, sharing the same granularity toggle and palette. Closes #602.
 - Per-photo visibility: photos gain a "Private" switch in PhotoDrawer; `/m/photos` bulk multi-select gains "Set private…" and "Set public…" actions; the `/m/access` table grows a per-gallery "Private" column granting `can_see_private` to view-only viewers (editors implicit); and the public Photo modal shows a "Private" badge to viewers who can see it. Closes #480.
 - Editor-tier "Manage this photo" / "Set as gallery icon" buttons on the public Photo modal — gated by `user.isGalleryEditor(galleryId)` instead of `isAdmin`. The pencil now opens the editor as an overlay modal in-place over the public Photo view, so admins / editors don't have to navigate away from `/g/` to fix metadata; the drawer keeps an "Open in Manage" link out to `/m/photos/<id>` for the full admin context. `e` keyboard shortcut toggles the editor while the photo is open. Closes #575.
+- Photo modal zoom (wheel + pinch + `+`/`-`/`0` keys, plus the click-drag-to-pan it gated) removed; srcset now hands the browser a higher-resolution variant per viewport so the zoom-into-detail use-case is covered without the bespoke transform plumbing. Carousel branching collapses to a single code path.
 
 ### Server
 

--- a/react-app/src/components/Gallery/Photo/Content.tsx
+++ b/react-app/src/components/Gallery/Photo/Content.tsx
@@ -5,20 +5,13 @@ import config from "../../../lib/config";
 
 import type { Gallery } from "../../../models/GalleryModel";
 import type { Photo } from "../../../models/PhotoModel";
-import type { ZoomState } from "./index";
 
-// flex-start so the matte sits just below the Navigation bar
-// with minimal top breathing; padding-bottom keeps room at the
-// bottom for the floating info button.
-// `min-width: 0` to escape the flex-item default `min-width: auto`,
-// which would let Root grow to fit the photo Frame's explicit width.
-// Without this, opening the modal on a viewport wider than the
-// modal's 1400 max-width causes a ResizeObserver feedback loop:
-// initial render uses window-sized fallback dimensions → Frame is
-// wider than Slide → Root grows past Slide → ResizeObserver fires
-// → Content recomputes smaller → Frame shrinks → Root shrinks →
-// loop, ~16 px per frame, until it converges on 1400. Visible as
-// a multi-frame "photo opens stretched then shrinks" animation.
+// flex-start so the matte sits just below the Navigation bar with
+// minimal top breathing; padding-bottom keeps room at the bottom
+// for the floating info button. `min-width: 0` escapes the flex-
+// item default `min-width: auto`; without it Root grows to fit the
+// photo Frame's explicit width and the parent ResizeObserver
+// re-converges via a multi-frame "stretch then shrink" animation.
 const Root = styled.div`
   flex-grow: 1;
   min-width: 0;
@@ -42,7 +35,6 @@ const Frame = styled("span", {
   width: ${(props) => props.$width}px;
   height: ${(props) => props.$height}px;
 `;
-// Centred + clipped so the scaled image stays under the matte.
 const ImageClip = styled.span`
   display: flex;
   align-items: center;
@@ -51,32 +43,13 @@ const ImageClip = styled.span`
   height: 100%;
   overflow: hidden;
 `;
-// touch-action:none stops the browser's default pinch/pan from
-// fighting our touch handlers; will-change:transform keeps the
-// scale/pan on the GPU compositor.
-//
-// width / height come from the `<img>`'s HTML attributes (numbers
-// in CSS pixels, set by callers). Previous attempt at templating
-// them into the CSS rendered as `width: 800;` (no unit) which the
-// browser silently dropped, then fell back to the HTML attrs —
-// "worked" by accident. Letting the HTML attrs drive the box keeps
-// the aspect-ratio reservation the browser builds from them, which
-// is what stops the frame from popping into place when the source
-// image lands.
-const Image = styled("img", {
-  shouldForwardProp: (prop) =>
-    prop !== "$scale" && prop !== "$x" && prop !== "$y" && prop !== "$grabbing",
-})<{ $scale: number; $x: number; $y: number; $grabbing: boolean }>`
+// HTML width/height attrs drive the box so the browser builds the
+// aspect-ratio reservation from them — keeps the frame from
+// popping when the source bytes land.
+const Image = styled.img`
   flex-shrink: 0;
-  transform: translate(${(props) => props.$x}px, ${(props) => props.$y}px)
-    scale(${(props) => props.$scale});
-  transform-origin: center center;
-  will-change: transform;
-  cursor: ${(props) =>
-    props.$scale > 1 ? (props.$grabbing ? "grabbing" : "grab") : "auto"};
   user-select: none;
   -webkit-user-drag: none;
-  touch-action: none;
 `;
 
 const calculateWidth = (
@@ -102,71 +75,19 @@ const calculateHeight = (
   return Math.floor(maxWidth / photoRatio);
 };
 
-// Clamp pan per axis so the scaled image's edge can't cross into
-// the frame. If frame ≥ scaledImage on that axis, no pan at all.
-const clampOffset = (
-  offset: number,
-  scaledImageDim: number,
-  frameContentDim: number
-): number => {
-  if (scaledImageDim <= frameContentDim) return 0;
-  const limit = (scaledImageDim - frameContentDim) / 2;
-  return Math.max(-limit, Math.min(limit, offset));
-};
-
-const WHEEL_STEP = 1.1;
-const MIN_SCALE = 1;
-const MAX_SCALE = 8;
-const clampScale = (s: number) => Math.max(MIN_SCALE, Math.min(MAX_SCALE, s));
-
-const touchDistance = (a: React.Touch, b: React.Touch): number =>
-  Math.hypot(b.clientX - a.clientX, b.clientY - a.clientY);
-
-// Cursor/pinch-anchored zoom: shift the translate so that the point at
-// `anchorOffset` (relative to the frame center, in screen pixels) ends
-// up over the same image pixel after the scale change. Derivation:
-//   cursor = frameCenter + (pixel - imageCenter) * s + (tx, ty)
-// solving for (tx', ty') at the new scale s' with the same pixel gives
-//   (tx', ty') = anchorOffset * (1 - s'/s) + (tx, ty) * (s'/s)
-const anchoredTranslate = (
-  anchorOffset: number,
-  oldTranslate: number,
-  oldScale: number,
-  newScale: number
-): number => {
-  const k = newScale / oldScale;
-  return anchorOffset * (1 - k) + oldTranslate * k;
-};
-
 interface Props {
   gallery: Gallery;
   year: number;
   month: number;
   day: number;
   photo: Photo;
-  zoom: ZoomState;
-  setZoom: React.Dispatch<React.SetStateAction<ZoomState>>;
 }
 
-const Content = ({
-  gallery,
-  year,
-  month,
-  day,
-  photo,
-  zoom,
-  setZoom,
-}: Props): React.ReactElement => {
+const Content = ({ photo }: Props): React.ReactElement => {
   // Measure the actual container, not the viewport — the modal
   // Frame caps at 1400px so wide-screen landscapes would overshoot.
-  //
-  // useLayoutEffect (not useEffect) so the corrective measurement
-  // runs before the first paint. Without that, the initial render
-  // uses the full-viewport fallback (window.innerWidth/Height),
-  // paints the photo stretched to the modal's full extent, and only
-  // shrinks on the next frame when the effect runs — visible as a
-  // brief stretch-then-shrink animation when opening the modal from
-  // the Month view.
+  // useLayoutEffect runs the corrective measurement before paint so
+  // the initial render doesn't flash the fallback dimensions.
   const rootRef = React.useRef<HTMLDivElement | null>(null);
   const [dimensions, setDimensions] = React.useState({
     width: window.innerWidth,
@@ -185,23 +106,6 @@ const Content = ({
     return () => observer.disconnect();
   }, []);
 
-  const dragRef = React.useRef<{
-    startClientX: number;
-    startClientY: number;
-    baseX: number;
-    baseY: number;
-  } | null>(null);
-  const pinchRef = React.useRef<{
-    startDistance: number;
-    startScale: number;
-    startX: number;
-    startY: number;
-    midViewportX: number;
-    midViewportY: number;
-  } | null>(null);
-  const frameRef = React.useRef<HTMLSpanElement | null>(null);
-  const [grabbing, setGrabbing] = React.useState(false);
-
   const photoRatio = photo.ratio();
   const browserScale = window.visualViewport?.scale ?? 1;
   // FRAME_CHROME = the photo frame's matte+border (10 padding +
@@ -216,8 +120,6 @@ const Content = ({
   const maxAvailHeight =
     (dimensions.height - FRAME_CHROME - ROOT_PADDING_V) * browserScale;
   const maxRatio = maxAvailWidth / maxAvailHeight;
-  // Image keeps its fit dimensions at every zoom; transform: scale
-  // does the visual zoom on top.
   const imageWidth = calculateWidth(
     photoRatio,
     maxAvailWidth,
@@ -230,41 +132,6 @@ const Content = ({
     maxAvailWidth,
     maxRatio
   );
-  // Frame stays at fit dimensions; ImageClip clips the scaled image.
-  const frameWidth = imageWidth;
-  const frameHeight = imageHeight;
-
-  // Ref so the once-registered wheel handler reads fresh values.
-  const sizeRef = React.useRef({ imageWidth, imageHeight });
-  sizeRef.current = { imageWidth, imageHeight };
-
-  // React's `wheel` listeners are passive by default — register
-  // natively so e.preventDefault() works.
-  React.useEffect(() => {
-    const el = frameRef.current;
-    if (!el) return;
-    const onWheel = (e: WheelEvent) => {
-      e.preventDefault();
-      const factor = e.deltaY < 0 ? WHEEL_STEP : 1 / WHEEL_STEP;
-      const rect = el.getBoundingClientRect();
-      const anchorX = e.clientX - rect.left - rect.width / 2;
-      const anchorY = e.clientY - rect.top - rect.height / 2;
-      setZoom((z) => {
-        const nextScale = clampScale(z.scale * factor);
-        if (nextScale === z.scale) return z;
-        const nextX = anchoredTranslate(anchorX, z.x, z.scale, nextScale);
-        const nextY = anchoredTranslate(anchorY, z.y, z.scale, nextScale);
-        const sz = sizeRef.current;
-        return {
-          scale: nextScale,
-          x: clampOffset(nextX, sz.imageWidth * nextScale, sz.imageWidth),
-          y: clampOffset(nextY, sz.imageHeight * nextScale, sz.imageHeight),
-        };
-      });
-    };
-    el.addEventListener("wheel", onWheel, { passive: false });
-    return () => el.removeEventListener("wheel", onWheel);
-  }, [setZoom]);
 
   const renditions = photo.renditions();
   const naturalWidthFor = (maxDim: number): number =>
@@ -278,128 +145,9 @@ const Content = ({
     .map((dim) => `${urlFor(dim)} ${naturalWidthFor(dim)}w`)
     .join(", ");
 
-  const handleMouseDown = (e: React.MouseEvent<HTMLImageElement>) => {
-    if (zoom.scale <= 1) return;
-    e.preventDefault();
-    dragRef.current = {
-      startClientX: e.clientX,
-      startClientY: e.clientY,
-      baseX: zoom.x,
-      baseY: zoom.y,
-    };
-    setGrabbing(true);
-  };
-  const handleMouseMove = (e: React.MouseEvent<HTMLImageElement>) => {
-    if (!dragRef.current) return;
-    const dx = e.clientX - dragRef.current.startClientX;
-    const dy = e.clientY - dragRef.current.startClientY;
-    setZoom((z) => ({
-      scale: z.scale,
-      x: clampOffset(
-        dragRef.current!.baseX + dx,
-        imageWidth * z.scale,
-        frameWidth
-      ),
-      y: clampOffset(
-        dragRef.current!.baseY + dy,
-        imageHeight * z.scale,
-        frameHeight
-      ),
-    }));
-  };
-  const handleMouseUp = () => {
-    setGrabbing(false);
-    dragRef.current = null;
-  };
-  const handleMouseLeave = () => {
-    if (dragRef.current) {
-      setGrabbing(false);
-      dragRef.current = null;
-    }
-  };
-
-  // Two fingers → pinch zoom, anchored at the midpoint between fingers.
-  // One finger when already zoomed → drag-to-pan.
-  // One finger at scale 1 → no-op here; parent <Swipeable> handles
-  // swipe-to-next/prev.
-  const handleTouchStart = (e: React.TouchEvent<HTMLImageElement>) => {
-    if (e.touches.length === 2) {
-      const t1 = e.touches[0];
-      const t2 = e.touches[1];
-      pinchRef.current = {
-        startDistance: touchDistance(t1, t2),
-        startScale: zoom.scale,
-        startX: zoom.x,
-        startY: zoom.y,
-        midViewportX: (t1.clientX + t2.clientX) / 2,
-        midViewportY: (t1.clientY + t2.clientY) / 2,
-      };
-      dragRef.current = null;
-    } else if (e.touches.length === 1 && zoom.scale > 1) {
-      const t = e.touches[0];
-      dragRef.current = {
-        startClientX: t.clientX,
-        startClientY: t.clientY,
-        baseX: zoom.x,
-        baseY: zoom.y,
-      };
-    }
-  };
-  const handleTouchMove = (e: React.TouchEvent<HTMLImageElement>) => {
-    if (e.touches.length === 2 && pinchRef.current) {
-      const newDistance = touchDistance(e.touches[0], e.touches[1]);
-      const nextScale = clampScale(
-        pinchRef.current.startScale *
-          (newDistance / pinchRef.current.startDistance)
-      );
-      const rect = frameRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      const anchorX = pinchRef.current.midViewportX - rect.left - rect.width / 2;
-      const anchorY = pinchRef.current.midViewportY - rect.top - rect.height / 2;
-      const nextX = anchoredTranslate(
-        anchorX,
-        pinchRef.current.startX,
-        pinchRef.current.startScale,
-        nextScale
-      );
-      const nextY = anchoredTranslate(
-        anchorY,
-        pinchRef.current.startY,
-        pinchRef.current.startScale,
-        nextScale
-      );
-      setZoom({
-        scale: nextScale,
-        x: clampOffset(nextX, imageWidth * nextScale, imageWidth),
-        y: clampOffset(nextY, imageHeight * nextScale, imageHeight),
-      });
-    } else if (e.touches.length === 1 && dragRef.current) {
-      const t = e.touches[0];
-      const dx = t.clientX - dragRef.current.startClientX;
-      const dy = t.clientY - dragRef.current.startClientY;
-      setZoom((z) => ({
-        scale: z.scale,
-        x: clampOffset(
-          dragRef.current!.baseX + dx,
-          imageWidth * z.scale,
-          frameWidth
-        ),
-        y: clampOffset(
-          dragRef.current!.baseY + dy,
-          imageHeight * z.scale,
-          frameHeight
-        ),
-      }));
-    }
-  };
-  const handleTouchEnd = (e: React.TouchEvent<HTMLImageElement>) => {
-    if (e.touches.length < 2) pinchRef.current = null;
-    if (e.touches.length === 0) dragRef.current = null;
-  };
-
   return (
     <Root ref={rootRef}>
-      <Frame ref={frameRef} $width={frameWidth} $height={frameHeight}>
+      <Frame $width={imageWidth} $height={imageHeight}>
         <ImageClip>
           <Image
             src={path}
@@ -408,18 +156,6 @@ const Content = ({
             alt={photo.id()}
             width={imageWidth}
             height={imageHeight}
-            $scale={zoom.scale}
-            $x={zoom.x}
-            $y={zoom.y}
-            $grabbing={grabbing}
-            onMouseDown={handleMouseDown}
-            onMouseMove={handleMouseMove}
-            onMouseUp={handleMouseUp}
-            onMouseLeave={handleMouseLeave}
-            onTouchStart={handleTouchStart}
-            onTouchMove={handleTouchMove}
-            onTouchEnd={handleTouchEnd}
-            onTouchCancel={handleTouchEnd}
             draggable={false}
           />
         </ImageClip>

--- a/react-app/src/components/Gallery/Photo/index.tsx
+++ b/react-app/src/components/Gallery/Photo/index.tsx
@@ -217,21 +217,12 @@ const AuthorOverlay = styled.div`
   text-overflow: ellipsis;
   white-space: nowrap;
 `;
-// Flex column that gives Content a stable parent size. Without this
-// Content's flex-grow has no flex parent and the ResizeObserver feeds
-// back into itself, shrinking the photo to nothing.
-const Body = styled.div`
-  flex: 1 1 auto;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-`;
-// Used while zoom == 1: a 3-slide carousel (prev / current / next)
-// dragged horizontally so the user sees the neighbour peeking from
-// the edge as they swipe. The Frame above clips overflow so slides
-// extending past the Frame are hidden until peeked into view.
-// touch-action: none — the carousel captures both axes (horizontal
-// for nav, vertical for swipe-down-to-close).
+// 3-slide carousel (prev / current / next) dragged horizontally so
+// the user sees the neighbour peeking from the edge as they swipe.
+// The Frame above clips overflow so slides extending past the Frame
+// are hidden until peeked into view. touch-action: none — the
+// carousel captures both axes (horizontal for nav, vertical for
+// swipe-down-to-close).
 const CarouselViewport = styled.div`
   flex: 1 1 auto;
   min-height: 0;
@@ -257,24 +248,6 @@ const Slide = styled.div`
   display: flex;
   flex-direction: column;
 `;
-
-// Zoom state lives here so Swipeable is bypassed while zoomed
-// (drag-to-pan would otherwise fire swipe-to-next/prev) and so
-// photo navigation resets the zoom cleanly.
-const ZOOM_STEP = 1.2;
-const MIN_SCALE = 1;
-const MAX_SCALE = 8;
-const clampScale = (s: number) => Math.max(MIN_SCALE, Math.min(MAX_SCALE, s));
-export interface ZoomState {
-  scale: number;
-  x: number;
-  y: number;
-}
-const ZOOM_RESET: ZoomState = { scale: 1, x: 0, y: 0 };
-// Adjacent (peeking) slides render a Content too so the user sees the
-// real prev/next photo while dragging. They never zoom — pass a stable
-// no-op setZoom so React's prop-equality reuses memo'd children.
-const noopSetZoom: React.Dispatch<React.SetStateAction<ZoomState>> = () => {};
 
 // iOS Safari only supports the Fullscreen API on <video>.
 const fullscreenSupported = (): boolean =>
@@ -309,7 +282,6 @@ const Photo = ({
   // metadata. The "Open in Manage" link inside still takes them
   // to the full /m/photos/<id> surface when they want it.
   const [inlineEditOpen, setInlineEditOpen] = React.useState(false);
-  const [zoom, setZoom] = React.useState<ZoomState>(ZOOM_RESET);
   const [isFullscreen, setIsFullscreen] = React.useState(
     typeof document !== "undefined" && !!document.fullscreenElement
   );
@@ -331,24 +303,10 @@ const Photo = ({
 
   const { t } = useTranslation();
 
-  React.useEffect(() => {
-    setZoom(ZOOM_RESET);
-  }, [photo.id()]);
-
   useKeyPress("i", () => setShowMetadata((s) => !s));
   useKeyPress("e", () => {
     if (canManage) setInlineEditOpen((open) => !open);
   });
-  useKeyPress("+", () =>
-    setZoom((z) => ({ ...z, scale: clampScale(z.scale * ZOOM_STEP) }))
-  );
-  useKeyPress("=", () =>
-    setZoom((z) => ({ ...z, scale: clampScale(z.scale * ZOOM_STEP) }))
-  );
-  useKeyPress("-", () =>
-    setZoom((z) => ({ ...z, scale: clampScale(z.scale / ZOOM_STEP) }))
-  );
-  useKeyPress("0", () => setZoom(ZOOM_RESET));
 
   // 3-slide carousel: track rests at -1/3 so the middle slide
   // (current photo) is centred in the viewport. Sliding right exposes
@@ -657,81 +615,61 @@ const Photo = ({
             {t("photo-private-badge")}
           </PrivacyBadge>
         )}
-        {zoom.scale === 1 ? (
-          <CarouselViewport>
-            <Track
-              drag
-              dragDirectionLock
-              dragConstraints={{
-                // Constraints are absolute pixel offsets from the
-                // Track's translate origin. The Track rests at
-                // motion.x = -window.innerWidth (the -33.3333% of its
-                // 300% width that centres slot 1). Range: TRACK_NEXT
-                // (-2W) ↔ TRACK_PREV (0). At edges, lock at rest so
-                // the empty slot can't be pulled into view.
-                left: nextPhoto ? -2 * window.innerWidth : -window.innerWidth,
-                right: prevPhoto ? 0 : -window.innerWidth,
-                top: 0,
-                bottom: window.innerHeight,
-              }}
-              dragElastic={0.3}
-              dragMomentum={false}
-              animate={trackControls}
-              initial={{ x: TRACK_REST, y: 0 }}
-              onDragEnd={handleDragEnd}
-            >
-              <Slide>
-                {prevPhoto && (
-                  <Content
-                    gallery={gallery}
-                    year={prevPhoto.ymd()[0]}
-                    month={prevPhoto.ymd()[1]}
-                    day={prevPhoto.ymd()[2]}
-                    photo={prevPhoto}
-                    zoom={ZOOM_RESET}
-                    setZoom={noopSetZoom}
-                  />
-                )}
-              </Slide>
-              <Slide>
+        <CarouselViewport>
+          <Track
+            drag
+            dragDirectionLock
+            dragConstraints={{
+              // Constraints are absolute pixel offsets from the
+              // Track's translate origin. The Track rests at
+              // motion.x = -window.innerWidth (the -33.3333% of its
+              // 300% width that centres slot 1). Range: TRACK_NEXT
+              // (-2W) ↔ TRACK_PREV (0). At edges, lock at rest so
+              // the empty slot can't be pulled into view.
+              left: nextPhoto ? -2 * window.innerWidth : -window.innerWidth,
+              right: prevPhoto ? 0 : -window.innerWidth,
+              top: 0,
+              bottom: window.innerHeight,
+            }}
+            dragElastic={0.3}
+            dragMomentum={false}
+            animate={trackControls}
+            initial={{ x: TRACK_REST, y: 0 }}
+            onDragEnd={handleDragEnd}
+          >
+            <Slide>
+              {prevPhoto && (
                 <Content
                   gallery={gallery}
-                  year={year}
-                  month={month}
-                  day={day}
-                  photo={photo}
-                  zoom={zoom}
-                  setZoom={setZoom}
+                  year={prevPhoto.ymd()[0]}
+                  month={prevPhoto.ymd()[1]}
+                  day={prevPhoto.ymd()[2]}
+                  photo={prevPhoto}
                 />
-              </Slide>
-              <Slide>
-                {nextPhoto && (
-                  <Content
-                    gallery={gallery}
-                    year={nextPhoto.ymd()[0]}
-                    month={nextPhoto.ymd()[1]}
-                    day={nextPhoto.ymd()[2]}
-                    photo={nextPhoto}
-                    zoom={ZOOM_RESET}
-                    setZoom={noopSetZoom}
-                  />
-                )}
-              </Slide>
-            </Track>
-          </CarouselViewport>
-        ) : (
-          <Body>
-            <Content
-              gallery={gallery}
-              year={year}
-              month={month}
-              day={day}
-              photo={photo}
-              zoom={zoom}
-              setZoom={setZoom}
-            />
-          </Body>
-        )}
+              )}
+            </Slide>
+            <Slide>
+              <Content
+                gallery={gallery}
+                year={year}
+                month={month}
+                day={day}
+                photo={photo}
+              />
+            </Slide>
+            <Slide>
+              {nextPhoto && (
+                <Content
+                  gallery={gallery}
+                  year={nextPhoto.ymd()[0]}
+                  month={nextPhoto.ymd()[1]}
+                  day={nextPhoto.ymd()[2]}
+                  photo={nextPhoto}
+                />
+              )}
+            </Slide>
+          </Track>
+        </CarouselViewport>
         {showMetadata && (
           <MetadataPanel
             gallery={gallery}


### PR DESCRIPTION
## Summary

Wheel / pinch / `+` / `-` / `0` zoom + the click-drag-to-pan it gated are gone from the Photo modal. The renditions ladder you just landed (#615 + the follow-up) hands the browser a higher-resolution variant via `srcset` whenever the viewport gets bigger, so the "zoom in for detail" use case is covered by simply enabling more rendition sizes in `/m/instance` — the bespoke transform plumbing isn't earning its keep anymore.

**`Photo/index.tsx`** drops `ZoomState`, `ZOOM_RESET`, `ZOOM_STEP`, `clampScale`, `noopSetZoom`, the per-photo zoom-reset effect, the four `useKeyPress` handlers (`+` / `=` / `-` / `0`), and the `zoom.scale === 1` branching. The `CarouselViewport` becomes the only path; the `Body` styled-component (only used in the zoomed branch) goes away.

**`Photo/Content.tsx`** drops the wheel `useEffect`, mouse / touch / pinch handlers, the `clampOffset` / `anchoredTranslate` / `touchDistance` helpers, the `$scale` / `$x` / `$y` / `$grabbing` styled-component props, and the `frameRef` + `dragRef` + `pinchRef` + `grabbing` state. The `Image` styled-component collapses to a plain `img` (`flex-shrink: 0` + `user-select: none` for ergonomics, nothing else); the browser's aspect-ratio reservation from the HTML width/height attrs still keeps the frame from popping when the source bytes land.

Net: 3 files changed, 73 insertions, 398 deletions.

## Test plan

- [ ] Open the photo modal — image renders at fit dimensions, no scroll-wheel scaling, no pinch.
- [ ] Carousel swipe-to-next/prev + swipe-down-to-close still work (the carousel was the `zoom.scale === 1` branch — should be the only branch now).
- [ ] `+` / `-` / `0` / `=` keys are inert in the photo modal (no console warning either).
- [ ] On a high-DPR display with a wider rendition in the meta key, the `<img>` picks the larger source per `srcset` — i.e. the use case the zoom previously served is preserved at the platform level.
- [ ] `npm test` / `npm run typecheck` / `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)