### PR TITLE
Release 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-06-17
+
+### Frontend
+
+- Stats State and City tables localize the missing-value bucket label — previously leaked the literal `"unknown"` sentinel from the server's stats compute through `format.subdivisionName` / `format.cityName` to the table cell.
+- `stats-unknown` label values refined to locale-natural strings: `Unknown` (en), `Tuntematon` (fi), `不明` (ja); previously `N/A` on en + fi (the same string, not really localized) and `未定` (ja, "not yet decided" — imprecise).
+- Subdivision name overlay covers Estonia (15 counties), Liechtenstein (11 municipalities), and Luxembourg (12 cantons) in en + ja; Estonia in fi (Finnish exonyms with `-maa` suffix). Previously these countries resolved their state codes to the raw ISO 3166-2 string.
+
+### Operator
+
+- Dependency updates across server / converter / react-app (typebox 1.1 → 1.2, sharp 0.34 → 0.35, @fastify/compress 8 → 9, @fastify/swagger-ui 5 → 6, react-easy-crop 5 → 6, plus various patch + minor bumps); clears the vite + launch-editor advisories. The eslint 9 → 10 major is held back — eslint 10's transitive `resolve@2.0.0-next.7` ships a `node-exports-info` dep npm fails to install on this workspace, breaking `eslint-plugin-react`.
+
 ## [0.17.0] - 2026-06-16
 
 ### Admin
@@ -624,6 +636,7 @@
 
 ## Initial commit - 2020-07-04
 
+[0.17.1]: https://github.com/vlumi/photo-diary/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/vlumi/photo-diary/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/vlumi/photo-diary/compare/v0.15.2...v0.16.0
 [0.15.2]: https://github.com/vlumi/photo-diary/compare/v0.15.1...v0.15.2

--- a/SETUP.md
+++ b/SETUP.md
@@ -79,13 +79,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  0.17.0/                               #   so different instances can run different versions
+  0.17.1/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/0.17.0      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/0.17.1      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  thumbnail/        # display/<maxDim>/ subdirs auto-created on intake
@@ -112,7 +112,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.17.0
+V=0.17.1
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -127,7 +127,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.17.0/bin/instance.ts /var/photo-diary/dailybw
+/opt/photo-diary/0.17.1/bin/instance.ts /var/photo-diary/dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -159,7 +159,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.17.0/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
+/opt/photo-diary/0.17.1/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                                # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                                     # migration runner applies any schema bumps

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1"
   },
-  "version": "0.17.0"
+  "version": "0.17.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -19,7 +19,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -3282,7 +3282,7 @@
       "version": "25.9.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
       "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -3298,7 +3298,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -10277,7 +10277,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -10344,7 +10344,7 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -10913,7 +10913,7 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -11187,7 +11187,7 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -69,5 +69,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.17.0"
+  "version": "0.17.1"
 }

--- a/react-app/src/lib/translations/en.json
+++ b/react-app/src/lib/translations/en.json
@@ -563,7 +563,7 @@
 
     "stats-filters": "Filters",
 
-    "stats-unknown": "N/A",
+    "stats-unknown": "Unknown",
     "stats-other": "Other",
     "stats-other-beyond": "Other ({{n}}+)",
     "stats-more_one": "+ {{count}} more…",

--- a/react-app/src/lib/translations/fi.json
+++ b/react-app/src/lib/translations/fi.json
@@ -563,7 +563,7 @@
 
     "stats-filters": "Suodattimet",
 
-    "stats-unknown": "N/A",
+    "stats-unknown": "Tuntematon",
     "stats-other": "Muut",
     "stats-other-beyond": "Muut ({{n}}+)",
     "stats-more_one": "+ {{count}} muu…",

--- a/react-app/src/lib/translations/ja.json
+++ b/react-app/src/lib/translations/ja.json
@@ -563,7 +563,7 @@
 
     "stats-filters": "フィルター",
 
-    "stats-unknown": "未定",
+    "stats-unknown": "不明",
     "stats-other": "他",
     "stats-other-beyond": "その他（{{n}}+）",
     "stats-more_one": "+他 {{count}}件…",

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.17.0"
+    "version": "0.17.1"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -57,5 +57,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.17.0"
+  "version": "0.17.1"
 }


### PR DESCRIPTION
Patch release covering accumulated polish since 0.17.0.

## Summary

- **Stats `unknown` bucket label leak fixed.** State and City tables were rendering the literal `"unknown"` sentinel through `format.subdivisionName` / `format.cityName` instead of `t("stats-unknown")`. Chart path was already correct via `localizeUnknownKey`.
- **`stats-unknown` label values refined** — `Unknown` (en), `Tuntematon` (fi), `不明` (ja). Replaces the previous `N/A` on en + fi (same string, not really localized) and `未定` (ja, "not yet decided" — imprecise).
- **Subdivision overlays for EE / LI / LU** — Estonia (15 counties), Liechtenstein (11 municipalities), Luxembourg (12 cantons) in en + ja; Estonia in fi with `-maa` Finnish exonyms. Required after #485's `lvl4 → lvl6 / lvl7 / lvl8` fallthrough started populating state codes for those countries.
- **Dependency updates across server / converter / react-app** — `typebox` 1.1 → 1.2, `sharp` 0.34 → 0.35, `@fastify/compress` 8 → 9, `@fastify/swagger-ui` 5 → 6, `react-easy-crop` 5 → 6, `react-router-dom` 7.16 → 7.18, `i18n-iso-countries` 7.2 → 7.14, `vitest` 4.1.8 → 4.1.9, plus various patch + minor bumps. Clears the vite + launch-editor advisories. The `eslint` 9 → 10 major is held back — eslint 10's transitive `resolve@2.0.0-next.7` ships a `node-exports-info` dep npm fails to install on this workspace, breaking `eslint-plugin-react`.
- **Drive-by docs cleanup** — README Backlog pruned (most items shipped or moved to 1.0), Features rewritten + moved before Setup, Setup section split into `SETUP.md`, AGENTS access-control paragraph fixed (`:all` / `:public` sentinels were dropped by migration 012), AGENTS release flow updated for the README/SETUP split.

## Test plan

- [x] `npm test` + `typecheck` + `lint` clean across server (931) / converter (28) / react-app (998)
- [x] `npm run docs:dump` + `npm run api:codegen` clean
- [x] `npm run build` (react-app) emits same bundle shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)