### PR TITLE
Fix #609: drop the deprecated .env fallback for SPA runtime settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Operator
+
+- **Breaking:** the `.env` fallback path for the SPA's runtime defaults (`DEFAULT_GALLERY`, `DEFAULT_THEME`, `DEFAULT_LANGUAGE`, `INITIAL_GALLERY_VIEW`, `FIRST_WEEKDAY`, `BETA_FEATURE_<NAME>`) is gone — the `meta` table is the only source. **Upgrade step:** for each of these you currently set in `.env`, run `bin/meta.ts set instance_<key> <value>` (or edit at `/m/instance`) before upgrading past this version. The env entries are no longer read; leaving them in place silently does nothing. The new-gallery `default_language` seed now reads `instance_defaultLanguage` from the meta table (falling back to `en` when unset) instead of the env var. Closes #609.
+
 ## [0.17.1] - 2026-06-17
 
 ### Frontend

--- a/SETUP.md
+++ b/SETUP.md
@@ -132,16 +132,16 @@ The `bin/instance.ts` script handles directory creation, `.env` generation (with
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
 
-The generated `.env` covers the required keys. Optional per-instance frontend defaults can be added — these flow through `/api/v1/meta` to the frontend on boot:
+The generated `.env` covers the required keys. Per-instance frontend defaults (default gallery / theme / language / initial view / first weekday / beta-feature locks) are no longer set via `.env` — set them through `/m/instance` (admin UI) or `bin/meta.ts`:
 
 ```sh
-DEFAULT_GALLERY=dailybw
-DEFAULT_THEME=grayscale
-DEFAULT_LANGUAGE=fi         # operator's primary; falls back to `en` if missing
-BETA_FEATURE_REGIONS=user   # `user` (default) | `on` | `off`
+./bin/meta.ts set instance_defaultGallery dailybw
+./bin/meta.ts set instance_defaultTheme grayscale
+./bin/meta.ts set instance_defaultLanguage fi
+./bin/meta.ts set instance_betaFeatures '{"regions":"user"}'
 ```
 
-`BETA_FEATURE_<NAME>` locks a beta feature for this instance: `on` enables it for everyone (hides the per-browser toggle), `off` disables it for everyone, `user` (default) shows the toggle in the UserMenu so each visitor can opt in. See the [server README](server/README.md#environment-variables) for the full env table.
+`betaFeatures` values are `on` (enable for everyone, hide the per-browser toggle), `off` (disable for everyone), or `user` (default — show the per-visitor toggle in the UserMenu). See the [server README](server/README.md#environment-variables) for the full env table and the [admin UI](server/README.md) for the meta-key shape.
 
 ### Starting an instance
 
@@ -277,7 +277,7 @@ Worked example. One instance (`/var/photo-diary/multi/`) serves two domains, eac
    }
    ```
 
-3. The frontend selects which gallery to land on based on the hostname the visitor used. The fallback order is: single-gallery instance → matching `hostname` regex → `DEFAULT_GALLERY` env var → the gallery-list page.
+3. The frontend selects which gallery to land on based on the hostname the visitor used. The fallback order is: single-gallery instance → matching `hostname` regex → `instance_defaultGallery` meta row → the gallery-list page.
 
 Gotchas:
 

--- a/bin/instance.ts
+++ b/bin/instance.ts
@@ -87,9 +87,8 @@ const REQUIRED_DIRS = [
 //
 // The frontend defaults (`defaultGallery` / `defaultTheme` /
 // `defaultLanguage` / `initialGalleryView` / `firstWeekday` /
-// `betaFeatures`) used to live here too, but moved to the `meta`
-// table in #513 and the .env fallback path was removed in #609.
-// Operators edit them via `/m/instance` or `bin/meta.ts`.
+// `betaFeatures`) live in the `meta` table — edit them via
+// `/m/instance` or `bin/meta.ts`.
 const REQUIRED_KEYS: RequiredKey[] = [
   // --- required: seeded on bootstrap -----------------------------------
   {
@@ -252,7 +251,7 @@ const looksLikeInstanceDir = (dir: string): boolean => {
   }
 };
 
-// --- pm2 cycle helpers (upgrade mode, #546) --------------------------------
+// --- pm2 cycle helpers (upgrade mode) --------------------------------
 interface Pm2Process {
   name: string;
   pm2_env: { status: string };

--- a/bin/instance.ts
+++ b/bin/instance.ts
@@ -85,9 +85,11 @@ const REQUIRED_DIRS = [
 // subdirectory, or the `db.sqlite3` file if you need them on a
 // different disk.
 //
-// Per-instance BETA_FEATURE_<NAME> flags aren't enumerable in
-// advance (any feature the server defines), so --edit doesn't
-// walk them — the operator sets / unsets them by hand.
+// The frontend defaults (`defaultGallery` / `defaultTheme` /
+// `defaultLanguage` / `initialGalleryView` / `firstWeekday` /
+// `betaFeatures`) used to live here too, but moved to the `meta`
+// table in #513 and the .env fallback path was removed in #609.
+// Operators edit them via `/m/instance` or `bin/meta.ts`.
 const REQUIRED_KEYS: RequiredKey[] = [
   // --- required: seeded on bootstrap -----------------------------------
   {
@@ -119,41 +121,6 @@ const REQUIRED_KEYS: RequiredKey[] = [
   // Empty value here means "leave the row absent; the server's
   // built-in default applies". The description spells out that
   // default explicitly so the operator knows what they get.
-  {
-    key: "DEFAULT_GALLERY",
-    description:
-      "Gallery to redirect to from `/g` when no other heuristic (single-gallery, hostname match) picks one (empty = let the heuristic choose)",
-    default: () => "",
-    required: false,
-  },
-  {
-    key: "DEFAULT_THEME",
-    description:
-      "Fallback theme when a gallery row has no `theme` set: blue / red / grayscale / bw / alert (empty = blue)",
-    default: () => "",
-    required: false,
-  },
-  {
-    key: "DEFAULT_LANGUAGE",
-    description:
-      "Instance-level primary language for operator-set photo / gallery metadata: en / fi / ja (empty = en)",
-    default: () => "",
-    required: false,
-  },
-  {
-    key: "INITIAL_GALLERY_VIEW",
-    description:
-      "Fallback initial view when a gallery has no `initial_view` set: year / month / day / photo (empty = year)",
-    default: () => "",
-    required: false,
-  },
-  {
-    key: "FIRST_WEEKDAY",
-    description:
-      "First day of the week in the year-view calendar grid: 0 (Sunday) or 1 (Monday) (empty = 0 / Sunday)",
-    default: () => "",
-    required: false,
-  },
   {
     key: "REVERSE_GEOCODE",
     description:

--- a/react-app/README.md
+++ b/react-app/README.md
@@ -25,18 +25,19 @@ For production, run `npm run build` from the **repo root**: it builds the react-
 
 The frontend has no build-time environment variables — one build serves every instance. Defaults live as plain values in [`src/lib/config.ts`](src/lib/config.ts) and per-instance behavior comes from the API at boot.
 
-Set these on the **server's** `.env` (per instance) to override the defaults; the server returns them through `/api/v1/meta` and the frontend applies them when the meta loads:
+Per-instance runtime defaults are edited from `/m/instance` (admin UI) or `bin/meta.ts` and stored in the server's `meta` table — the server returns them through `/api/v1/meta` and the frontend applies them when the meta loads. The keys (without their internal `instance_` prefix):
 
-- `DEFAULT_GALLERY` — gallery to redirect to from `/g` when no other heuristic (single-gallery, hostname match) picks one
-- `DEFAULT_THEME` — fallback theme when a gallery row has no `theme` set
-- `INITIAL_GALLERY_VIEW` — `year` / `month` / `day` / `photo` fallback when a gallery row has no `initial_view` set
-- `FIRST_WEEKDAY` — `0` (Sunday) or `1` (Monday); affects the year-view calendar grid
+- `defaultGallery` — gallery to redirect to from `/g` when no other heuristic (single-gallery, hostname match) picks one
+- `defaultTheme` — fallback theme when a gallery row has no `theme` set
+- `initialGalleryView` — `year` / `month` / `day` / `photo` fallback when a gallery row has no `initial_view` set
+- `firstWeekday` — `0` (Sunday) or `1` (Monday); affects the year-view calendar grid
+- `defaultLanguage` — fallback display language; seeds new galleries' `default_language` column at create time
+- `betaFeatures` — JSON-encoded `{name: "on" | "off" | "user"}` map for per-instance beta-feature locks
+- `cdn` — public URL prefix for `display/` / `thumbnail/` / `gallery-icons/`
 
-Per-gallery values (`theme`, `initial_view`, `hostname`) on each gallery row in the DB take precedence over the instance-level defaults above.
+Per-gallery values (`theme`, `initial_view`, `hostname`, `default_language`) on each gallery row in the DB take precedence over the instance-level defaults above.
 
-`PHOTO_ROOT_URL` is overridden the same way via the `instance_cdn` meta row (set with `bin/` tools or directly in the DB).
-
-`DEFAULT_LANGUAGE` is the one value that **can't** be overridden at runtime — i18next initializes at module load, before the meta fetch. Edit the literal in `config.ts` if you need a different fallback language for new visitors. Users' own selections are persisted via the `lang` localStorage key.
+The pre-0.17 `.env`-based fallback path (`DEFAULT_GALLERY`, `DEFAULT_THEME`, `DEFAULT_LANGUAGE`, `INITIAL_GALLERY_VIEW`, `FIRST_WEEKDAY`, `BETA_FEATURE_<NAME>`) was removed in #609 — upgrades from those versions need to seed the matching meta rows.
 
 Available themes: `blue`, `red`, `grayscale`, `bw`, `alert` (defined in `src/lib/theme.ts`). Supported languages: `en`, `fi`, `ja`.
 

--- a/react-app/README.md
+++ b/react-app/README.md
@@ -37,8 +37,6 @@ Per-instance runtime defaults are edited from `/m/instance` (admin UI) or `bin/m
 
 Per-gallery values (`theme`, `initial_view`, `hostname`, `default_language`) on each gallery row in the DB take precedence over the instance-level defaults above.
 
-The pre-0.17 `.env`-based fallback path (`DEFAULT_GALLERY`, `DEFAULT_THEME`, `DEFAULT_LANGUAGE`, `INITIAL_GALLERY_VIEW`, `FIRST_WEEKDAY`, `BETA_FEATURE_<NAME>`) was removed in #609 — upgrades from those versions need to seed the matching meta rows.
-
 Available themes: `blue`, `red`, `grayscale`, `bw`, `alert` (defined in `src/lib/theme.ts`). Supported languages: `en`, `fi`, `ja`.
 
 ## Internationalization (i18n)

--- a/server/README.md
+++ b/server/README.md
@@ -53,8 +53,6 @@ Two places hold instance config:
 - **`.env`** (boot-time). Read once when the server / converter process starts. Changing requires a restart. Lives here: credentials and binding (`SECRET`, `PORT`, `DB_DRIVER`, `INSTANCE_NAME`), paths (`STATIC_DIR`, `GEOCODE_DIR`), and converter daemon knobs (`REVERSE_GEOCODE`, `REVERSE_GEOCODE_EXTRA_LANGS`, `NOMINATIM_BASE_URL`, `DEBUG`).
 - **`meta` table** (runtime). Read per-request when the SPA fetches `/api/v1/meta`. Changing takes effect on the next response — no restart. Edited from `/m/instance` (admin UI) or `bin/meta.ts`. Holds the instance identity (`name`, `description`, `cdn`, `image`), the SPA's runtime defaults (`defaultGallery`, `defaultTheme`, `defaultLanguage`, `initialGalleryView`, `firstWeekday`, `betaFeatures`), and the converter's rendition ladder (`renditions`).
 
-The SPA runtime defaults *used* to live in `.env` (`DEFAULT_GALLERY` / `DEFAULT_THEME` / `DEFAULT_LANGUAGE` / `INITIAL_GALLERY_VIEW` / `FIRST_WEEKDAY` / `BETA_FEATURE_<NAME>`); they migrated to the `meta` table in #513 and the `.env` fallback path was removed in #609. Upgrades from pre-0.17 instances need to seed the matching `meta` rows (`bin/meta.ts set instance_<key> <value>`); the env entries are no longer read.
-
 ### Fixed-by-convention paths
 
 The SQLite DB file and the photo repository are no longer configurable via env vars — they live at fixed locations relative to the server's working directory (which is the **instance directory** when launched via `start-prod.sh`):

--- a/server/README.md
+++ b/server/README.md
@@ -39,8 +39,6 @@ Read at startup from a `.env` file in the **current working directory** (which i
 | `NODE_ENV` | | `prod` | `dev` / `prod` / `test`. Set by the npm scripts; don't override unless you know why. |
 | `DEBUG` | | `false` | When truthy, enables verbose logger output. |
 | `STATIC_DIR` | | `<source>/build` | Path to the bundled frontend. Resolved relative to the server's source file by default; override if you build into a non-standard location. |
-| `DEFAULT_GALLERY`, `DEFAULT_THEME`, `DEFAULT_LANGUAGE`, `INITIAL_GALLERY_VIEW`, `FIRST_WEEKDAY` | | — | **Deprecated, scheduled for removal by 1.0.** Per-instance frontend defaults, now editable from `/m/instance` (the corresponding `meta` table row wins over the env value when set). Still honoured as a fallback for instances that haven't seeded the meta rows. See the boot-time vs. runtime split note below. |
-| `BETA_FEATURE_<NAME>` | | `user` | **Deprecated, scheduled for removal by 1.0.** Per-instance lock for a beta feature, now editable from `/m/instance` via the `betaFeatures` meta row. `user` (default) shows the per-browser toggle in the UserMenu; `on` forces the feature on for everyone and hides the toggle; `off` forces it off. One env var per feature — e.g. `BETA_FEATURE_REGIONS=on`. |
 | `REVERSE_GEOCODE` | | `false` | When set (any truthy value), the converter reverse-geocodes new photos with coords at intake. Opt-in by default — coordinates are sent to Nominatim. `photo-geocode.ts` honours this flag by default; pass `--force` to bypass for one-off backfills. |
 | `REVERSE_GEOCODE_EXTRA_LANGS` | | — | Comma-separated extra languages to fetch on top of English (e.g. `ja,fi`). Each adds one 1 RPS Nominatim call per photo at intake. `photo-geocode.ts` uses the same default. |
 | `NOMINATIM_BASE_URL` | | `https://nominatim.openstreetmap.org` | Override to point at a self-hosted Nominatim. |
@@ -53,9 +51,9 @@ The SQLite DB file and the photo repository are **not** configured via env vars 
 Two places hold instance config:
 
 - **`.env`** (boot-time). Read once when the server / converter process starts. Changing requires a restart. Lives here: credentials and binding (`SECRET`, `PORT`, `DB_DRIVER`, `INSTANCE_NAME`), paths (`STATIC_DIR`, `GEOCODE_DIR`), and converter daemon knobs (`REVERSE_GEOCODE`, `REVERSE_GEOCODE_EXTRA_LANGS`, `NOMINATIM_BASE_URL`, `DEBUG`).
-- **`meta` table** (runtime). Read per-request when the SPA fetches `/api/v1/meta`. Changing takes effect on the next response — no restart. Edited from `/m/instance` (admin UI) or `bin/meta.ts`. Holds the instance identity (`name`, `description`, `cdn`, `image`) and the SPA's runtime defaults (`defaultGallery`, `defaultTheme`, `defaultLanguage`, `initialGalleryView`, `firstWeekday`, `betaFeatures`).
+- **`meta` table** (runtime). Read per-request when the SPA fetches `/api/v1/meta`. Changing takes effect on the next response — no restart. Edited from `/m/instance` (admin UI) or `bin/meta.ts`. Holds the instance identity (`name`, `description`, `cdn`, `image`), the SPA's runtime defaults (`defaultGallery`, `defaultTheme`, `defaultLanguage`, `initialGalleryView`, `firstWeekday`, `betaFeatures`), and the converter's rendition ladder (`renditions`).
 
-The SPA runtime defaults *used* to live in `.env`; they migrated to the `meta` table in #513. The `.env` keys still work as a fallback (the server logs a deprecation line on startup when any are set) but the path is scheduled for removal by 1.0 — seed the meta rows via the admin UI and drop the env entries.
+The SPA runtime defaults *used* to live in `.env` (`DEFAULT_GALLERY` / `DEFAULT_THEME` / `DEFAULT_LANGUAGE` / `INITIAL_GALLERY_VIEW` / `FIRST_WEEKDAY` / `BETA_FEATURE_<NAME>`); they migrated to the `meta` table in #513 and the `.env` fallback path was removed in #609. Upgrades from pre-0.17 instances need to seed the matching `meta` rows (`bin/meta.ts set instance_<key> <value>`); the env entries are no longer read.
 
 ### Fixed-by-convention paths
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -210,37 +210,8 @@ app.setNotFoundHandler(async (request, reply) => {
   throw new NotFoundError();
 });
 
-// `.env` keys that moved into the `meta` table in #513. The
-// admin UI at `/m/instance` reads / writes the meta row; setting
-// the env var still works as a fallback for instances that
-// haven't seeded the meta rows yet, but the env path is
-// scheduled for removal by 1.0 — log a one-line deprecation on
-// startup so the operator notices.
-const DEPRECATED_ENV_KEYS = [
-  "DEFAULT_GALLERY",
-  "DEFAULT_THEME",
-  "DEFAULT_LANGUAGE",
-  "INITIAL_GALLERY_VIEW",
-  "FIRST_WEEKDAY",
-];
-
-const warnDeprecatedEnvKeys = (): void => {
-  const set = DEPRECATED_ENV_KEYS.filter((k) => !!process.env[k]);
-  const beta = Object.keys(process.env).filter(
-    (k) => k.startsWith("BETA_FEATURE_") && process.env[k]
-  );
-  if (set.length === 0 && beta.length === 0) return;
-  const all = [...set, ...beta];
-  logger.info(
-    `Deprecated .env keys in use: ${all.join(", ")}. ` +
-      "These moved to the `meta` table (edit via /m/instance or " +
-      "`bin/meta.ts`). The .env path is scheduled for removal by 1.0."
-  );
-};
-
 export const init = async () => {
   logger.debug("Initialize app start");
-  warnDeprecatedEnvKeys();
   await tokensV1.init();
   await galleriesV1.init();
   await savedFiltersV1.init();

--- a/server/controllers/meta-v1.ts
+++ b/server/controllers/meta-v1.ts
@@ -42,38 +42,6 @@ const cleanMeta = (meta: Record<string, unknown>): Record<string, unknown> => {
     }, {});
 };
 
-// Per-instance frontend defaults from the server's `process.env`.
-// Each key is optional; the SPA falls back to `lib/config.ts`.
-const envDefaults = (): Record<string, unknown> => {
-  const out: Record<string, unknown> = {};
-  const {
-    DEFAULT_GALLERY,
-    DEFAULT_THEME,
-    DEFAULT_LANGUAGE,
-    INITIAL_GALLERY_VIEW,
-    FIRST_WEEKDAY,
-  } = process.env;
-  if (DEFAULT_GALLERY) out.defaultGallery = DEFAULT_GALLERY;
-  if (DEFAULT_THEME) out.defaultTheme = DEFAULT_THEME;
-  if (DEFAULT_LANGUAGE) out.defaultLanguage = DEFAULT_LANGUAGE;
-  if (INITIAL_GALLERY_VIEW) out.initialGalleryView = INITIAL_GALLERY_VIEW;
-  if (FIRST_WEEKDAY) out.firstWeekday = FIRST_WEEKDAY;
-  // `BETA_FEATURE_<NAME>=user|on|off` → betaFeatures[name] = mode.
-  // `<NAME>` is upper-snake; underscores collapse to camelCase so the
-  // env value maps onto the client's `BetaFeature` keys (`regions`,
-  // `focalLengthEquiv`, …). Single-word names like REGIONS still
-  // round-trip unchanged.
-  const envToCamel = (s: string): string =>
-    s.toLowerCase().replace(/_([a-z])/g, (_, c) => c.toUpperCase());
-  const beta: Record<string, string> = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (!key.startsWith("BETA_FEATURE_") || !value) continue;
-    beta[envToCamel(key.slice("BETA_FEATURE_".length))] = value;
-  }
-  if (Object.keys(beta).length > 0) out.betaFeatures = beta;
-  return out;
-};
-
 // Mutation routes lock `key` to the schema-seeded public-facing set
 // (matches `bin/meta.ts`'s default key list, minus the `instance_`
 // prefix the row gets stored under). `schema_version` and other
@@ -108,14 +76,14 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       },
     },
     async () => {
-      // Public, no authorization needed. `.env` defaults are the
-      // fallback for keys with no meta row; once a row is written
-      // (via admin UI / bin/meta.ts) it wins for that key. The
-      // flipped merge order vs. the pre-#513 behaviour is the
-      // whole point — operators expect admin-UI edits to take
-      // effect, not be silently shadowed by an unset env var.
+      // Public, no authorization needed. Each meta key's value comes
+      // from the `meta` table; unset keys fall through to the SPA's
+      // bundled defaults in `lib/config.ts`. The legacy `.env`
+      // fallback path (DEFAULT_GALLERY / DEFAULT_THEME / …) was
+      // removed in #609 — operators set runtime defaults via
+      // `/m/instance` or `bin/meta.ts`.
       const meta = await model.getMetas();
-      return { ...envDefaults(), ...cleanMeta(meta) };
+      return cleanMeta(meta);
     }
   );
 

--- a/server/controllers/meta-v1.ts
+++ b/server/controllers/meta-v1.ts
@@ -78,10 +78,8 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
     async () => {
       // Public, no authorization needed. Each meta key's value comes
       // from the `meta` table; unset keys fall through to the SPA's
-      // bundled defaults in `lib/config.ts`. The legacy `.env`
-      // fallback path (DEFAULT_GALLERY / DEFAULT_THEME / …) was
-      // removed in #609 — operators set runtime defaults via
-      // `/m/instance` or `bin/meta.ts`.
+      // bundled defaults in `lib/config.ts`. Operators set runtime
+      // defaults via `/m/instance` or `bin/meta.ts`.
       const meta = await model.getMetas();
       return cleanMeta(meta);
     }

--- a/server/db/sqlite3/schema.ts
+++ b/server/db/sqlite3/schema.ts
@@ -69,8 +69,8 @@ export interface GalleryRow {
   // Operator-set primary language for the canonical `title` /
   // `description` columns. Always set since migration 022 — NULLs
   // backfill to 'en' on upgrade, and new galleries take the value
-  // from `.env DEFAULT_LANGUAGE` (server create path) or 'en' as
-  // the column default.
+  // from the `instance_defaultLanguage` meta row (server create
+  // path) or 'en' as the column default.
   default_language: string;
   type: GalleryType;
   // Operator-curated sort index (#585). Drives the primary sort

--- a/server/lib/meta-keys.ts
+++ b/server/lib/meta-keys.ts
@@ -17,10 +17,9 @@
 //    — DB-backed, edited via the admin UI or `bin/meta.ts`.
 // 2. SPA runtime defaults (`defaultGallery` / `defaultTheme` /
 //    `defaultLanguage` / `initialGalleryView` / `firstWeekday` /
-//    `betaFeatures`). These used to live in `.env`; the meta row
-//    became the source of truth in #513 and the `.env` fallback
-//    path was removed in #609. Unset keys fall through to the
-//    SPA's bundled defaults in `lib/config.ts`.
+//    `betaFeatures`). The meta row is the source of truth; unset
+//    keys fall through to the SPA's bundled defaults in
+//    `lib/config.ts`.
 //
 // `betaFeatures` is stored as a JSON-encoded `{name: "on" | "off"
 // | "user"}` map so the per-feature opt-in shape survives the

--- a/server/lib/meta-keys.ts
+++ b/server/lib/meta-keys.ts
@@ -14,14 +14,13 @@
 // Two flavours sit in the same key namespace:
 //
 // 1. Instance identity rows (`name`, `description`, `cdn`, `image`)
-//    — purely DB-backed, edited via the admin UI or `bin/meta.ts`.
-// 2. SPA runtime defaults previously set in `.env`
-//    (`defaultGallery` / `defaultTheme` / `defaultLanguage` /
-//    `initialGalleryView` / `firstWeekday` / `betaFeatures`).
-//    Setting a meta row for one of these wins over the matching
-//    `.env` value at request time, so an admin can change behaviour
-//    without restarting the server. The `.env` values stay as a
-//    fallback for instances that don't seed the meta rows yet.
+//    — DB-backed, edited via the admin UI or `bin/meta.ts`.
+// 2. SPA runtime defaults (`defaultGallery` / `defaultTheme` /
+//    `defaultLanguage` / `initialGalleryView` / `firstWeekday` /
+//    `betaFeatures`). These used to live in `.env`; the meta row
+//    became the source of truth in #513 and the `.env` fallback
+//    path was removed in #609. Unset keys fall through to the
+//    SPA's bundled defaults in `lib/config.ts`.
 //
 // `betaFeatures` is stored as a JSON-encoded `{name: "on" | "off"
 // | "user"}` map so the per-feature opt-in shape survives the

--- a/server/models/gallery.ts
+++ b/server/models/gallery.ts
@@ -105,10 +105,8 @@ const createGallery = async (gallery: { id: string } & Record<string, any>) => {
   assertSlugId(gallery.id);
   logger.debug("Creating gallery", { id: gallery.id });
   // Seed the gallery's primary language from the instance-level
-  // `defaultLanguage` meta row when the caller didn't specify one
-  // (operator's preference at the instance level becomes the seed
-  // for every new gallery), with `en` as the final fallback. The
-  // pre-#513 `.env DEFAULT_LANGUAGE` fallback was removed in #609.
+  // `defaultLanguage` meta row when the caller didn't specify one,
+  // with `en` as the final fallback.
   if (!gallery.defaultLanguage) {
     const metas = await db.loadMetas();
     gallery.defaultLanguage = metas.instance_defaultLanguage || "en";
@@ -200,7 +198,7 @@ const setGalleryIcon = async (
   return iconPath;
 };
 
-// Apply an operator-curated order across every visible gallery (#585).
+// Apply an operator-curated order across every visible gallery.
 // The input must contain exactly the current gallery id set — no
 // missing ids (would leave them stranded at ordinal 0) and no extras
 // (typo / stale client). Ordinals are reassigned by position: 0, 1,

--- a/server/models/gallery.ts
+++ b/server/models/gallery.ts
@@ -104,13 +104,14 @@ const applyVirtualSources = async (
 const createGallery = async (gallery: { id: string } & Record<string, any>) => {
   assertSlugId(gallery.id);
   logger.debug("Creating gallery", { id: gallery.id });
-  // Default the gallery's primary language from `.env DEFAULT_LANGUAGE`
-  // when the caller didn't specify one — operator's preference at the
-  // instance level becomes the seed for every new gallery, with `en`
-  // as the final fallback. Existing galleries opt in by setting their
-  // own value through the admin UI / API.
+  // Seed the gallery's primary language from the instance-level
+  // `defaultLanguage` meta row when the caller didn't specify one
+  // (operator's preference at the instance level becomes the seed
+  // for every new gallery), with `en` as the final fallback. The
+  // pre-#513 `.env DEFAULT_LANGUAGE` fallback was removed in #609.
   if (!gallery.defaultLanguage) {
-    gallery.defaultLanguage = process.env.DEFAULT_LANGUAGE || "en";
+    const metas = await db.loadMetas();
+    gallery.defaultLanguage = metas.instance_defaultLanguage || "en";
   }
   const sources = gallery.sources as string[] | undefined;
   await db.createGallery(gallery);

--- a/server/tests/api/meta.test.ts
+++ b/server/tests/api/meta.test.ts
@@ -137,11 +137,11 @@ describe("SPA runtime defaults (#513)", () => {
     expectMeta(result, "defaultTheme", "grayscale");
   });
 
-  test("Meta row wins over env default (merge order)", async () => {
-    // The test fixture's process.env doesn't set DEFAULT_THEME, so
-    // env contributes nothing here; the meta row is the only
-    // source. Once a row exists, GET returns it under the same key
-    // envDefaults() would use, with no double-key collision.
+  test("Meta row is the source of truth for SPA runtime defaults", async () => {
+    // The `.env` fallback path (envDefaults) was removed in #609 —
+    // the meta row is now the only source. Unset keys fall through
+    // to the SPA's bundled defaults in `lib/config.ts` (handled
+    // client-side, not by this endpoint).
     await api
       .post("/api/v1/meta")
       .set("Authorization", `Bearer ${token}`)

--- a/server/tests/api/meta.test.ts
+++ b/server/tests/api/meta.test.ts
@@ -121,7 +121,7 @@ describe("As admin", () => {
       .expect(400));
 });
 
-describe("SPA runtime defaults (#513)", () => {
+describe("SPA runtime defaults", () => {
   let token: string;
   beforeEach(async () => {
     token = await loginUser(api, "admin");
@@ -138,9 +138,8 @@ describe("SPA runtime defaults (#513)", () => {
   });
 
   test("Meta row is the source of truth for SPA runtime defaults", async () => {
-    // The `.env` fallback path (envDefaults) was removed in #609 —
-    // the meta row is now the only source. Unset keys fall through
-    // to the SPA's bundled defaults in `lib/config.ts` (handled
+    // The meta row is the only source; unset keys fall through to
+    // the SPA's bundled defaults in `lib/config.ts` (handled
     // client-side, not by this endpoint).
     await api
       .post("/api/v1/meta")


### PR DESCRIPTION
After #513 (0.17) the SPA's runtime defaults moved into the `meta` table. The matching `.env` keys still worked as a fallback, with a deprecation line logged at startup. With 0.18 in flight, drop the fallback path.

## Removed

- `envDefaults()` helper + call site in `GET /api/v1/meta`. Endpoint now returns the meta table verbatim; unset keys fall through to the SPA's bundled defaults in `react-app/src/lib/config.ts`.
- `DEPRECATED_ENV_KEYS` + `warnDeprecatedEnvKeys()` in `server/app.ts`.
- Optional `DEFAULT_GALLERY` / `DEFAULT_THEME` / `DEFAULT_LANGUAGE` / `INITIAL_GALLERY_VIEW` / `FIRST_WEEKDAY` rows from `bin/instance.ts`'s configurable-key list.

## Changed

- `createGallery()` now seeds an unspecified `defaultLanguage` from `instance_defaultLanguage` (meta row, via `db.loadMetas()`) instead of `process.env.DEFAULT_LANGUAGE`, falling back to 'en'.
- `server/README.md` env-vars table loses the deprecated rows; runtime-vs-boot-time section rewritten without the transition history.
- `react-app/README.md` Configuration rewritten around meta keys.
- `SETUP.md` post-bootstrap step shows `bin/meta.ts set` instead of `.env` snippets.

## Upgrade note

Operators on pre-0.17 instances need to seed the matching meta rows (`bin/meta.ts set instance_<key> <value>`) before upgrading past this version — the env keys are no longer read.

## Test plan

- [x] `npm test` server (931) / converter (28) / react-app (998) — all green
- [x] `npm run typecheck` + `npm run lint` clean across all three
- [x] New `createGallery` path tested via the existing gallery-create test that exercises `defaultLanguage` seeding

🤖 Generated with [Claude Code](https://claude.com/claude-code)