### PR TITLE
Fix #217: frontend security audit pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Breaking:** the `.env` fallback path for the SPA's runtime defaults (`DEFAULT_GALLERY`, `DEFAULT_THEME`, `DEFAULT_LANGUAGE`, `INITIAL_GALLERY_VIEW`, `FIRST_WEEKDAY`, `BETA_FEATURE_<NAME>`) is gone — the `meta` table is the only source. **Upgrade step:** for each of these you currently set in `.env`, run `bin/meta.ts set instance_<key> <value>` (or edit at `/m/instance`) before upgrading past this version. The env entries are no longer read; leaving them in place silently does nothing. The new-gallery `default_language` seed now reads `instance_defaultLanguage` from the meta table (falling back to `en` when unset) instead of the env var. Closes #609.
 - New `/m/operations` admin page surfaces converter activity: recent events (intake + geocode), recent failures, and pending-queue counts (inbox files + photos awaiting geocode). Closes #495.
+- Frontend security audit pass (#217): no critical findings; OSM attribution links switched from http to https; two follow-ups filed (#647 JWT to HttpOnly cookies, #648 enable CSP).
 
 ## [0.17.1] - 2026-06-17
 

--- a/react-app/src/components/Manage/EditableMap.tsx
+++ b/react-app/src/components/Manage/EditableMap.tsx
@@ -159,7 +159,7 @@ const EditableMap = ({
         style={{ height: "100%" }}
       >
         <TileLayer
-          attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+          attribution='&amp;copy <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <RecenterOnProps lat={lat} lon={lon} positionKey={positionKey} />

--- a/react-app/src/components/MapContainer.tsx
+++ b/react-app/src/components/MapContainer.tsx
@@ -306,7 +306,7 @@ const MapContainer = ({
           <Marker position={userPosition} icon={userPositionIcon} />
         )}
         <TileLayer
-          attribution='&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+          attribution='&amp;copy <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         />
         <MarkerClusterGroup


### PR DESCRIPTION
## Summary

Frontend security audit per #217. No critical findings. One trivial inline fix (OSM attribution links http → https). Two should-fix items spun out to dedicated tickets (#647 JWT-to-cookies, #648 enable CSP).

Audit report below follows the 0.7.2 backend audit report shape: Critical / Should fix / Backlog / Clean.

## Critical

**None.** The SPA has no `dangerouslySetInnerHTML`, no `innerHTML` writes, no `console.*` calls in shipped code, no third-party analytics or tracking, no external `<script>` or `<link>` in `index.html`, no open-redirect surface (every `navigate(...)` resolves an internal path, never a URL from the query string or hash). React's default escaping covers the standard DOM-injection surface.

## Should fix

### 1. JWT tokens persisted to `localStorage` — filed as #647

The access + refresh tokens land in `localStorage[\"user\"]` via `UserModel.toJson()` in [react-app/src/components/Login.tsx:91](react-app/src/components/Login.tsx#L91), even though `lib/token.ts` describes itself as \"in-memory bearer cache.\" The `user.ts` store rehydrates them on every page load. With the 90-day refresh-token lifetime, any future XSS would buy 90 days of authenticated access via a single read of `localStorage[\"user\"]`. Fix: move tokens to HttpOnly + Secure + SameSite=Strict cookies. Details in #647.

### 2. CSP disabled — filed as #648

`server/app.ts:148` explicitly sets `contentSecurityPolicy: false`. The comment notes the default would break Emotion's runtime style injection. The 0.7.4 OSM tile-server 403 (`referrer-policy` regression) was a small foretaste of the breakage CSP would surface across every external origin the SPA touches. Enabling it cleanly is its own ticket: Emotion needs `style-src 'self' 'unsafe-inline'` or a nonce strategy; OSM tiles need `img-src 'self' https://*.tile.openstreetmap.org`; the per-instance CDN URL means the header has to be computed per request. Report-Only first, enforcing after a release. Details in #648.

### 3. OSM attribution links use `http://osm.org/copyright` — fixed inline

Two sites: [react-app/src/components/MapContainer.tsx:309](react-app/src/components/MapContainer.tsx#L309) and [react-app/src/components/Manage/EditableMap.tsx:162](react-app/src/components/Manage/EditableMap.tsx#L162). osm.org redirects to https so the user experience is unaffected, but the http:// in the attribution markup would surface as a mixed-content warning if `upgrade-insecure-requests` were ever set in CSP. One-line fix, included in this PR.

## Backlog

- **COOP/COEP cross-origin isolation.** Not needed unless we want SharedArrayBuffer (we don't). Acceptable hole.
- **Subresource Integrity.** No external scripts or styles loaded, so nothing to attach `integrity=` to. If we ever embed a third-party widget, file a ticket then.
- **`X-Content-Type-Options: nosniff`** — set by helmet on every response, but not duplicated as a `<meta http-equiv>` in `index.html`. Cosmetic; the header path is the canonical one.

## Clean

Verified-and-fine:

- **Third-party fetches.** Only OSM tile servers (`https://*.tile.openstreetmap.org`). `referrer-policy: strict-origin-when-cross-origin` is the explicit override that makes those work — see [server/app.ts:147-150](server/app.ts#L147-L150). No fonts, no scripts, no images from non-instance origins. The 0.7.4 regression is documented and not re-occurring.
- **CDN-served photos.** `config.PHOTO_ROOT_URL` is configured by `meta.instance_cdn` (admin-controlled, trusted input). Photo URLs carry no cookies / auth state and aren't expected to under same-origin or CDN deployment. The README's nginx block recommendation (`Cache-Control: public, immutable`) is consistent with the SPA's assumption that thumbnail / display URLs are stable per photo id.
- **XSS surface.** No `dangerouslySetInnerHTML`. No direct `innerHTML` writes. No URL query / hash parameters reflected into the DOM. React's auto-escape handles all rendered strings.
- **Client-side redirects.** All `navigate(...)` calls use react-router with internal paths or model-computed paths. No `window.open` to user-controlled URLs. No `window.location.href = ...` from query input. Open-redirect-clean.
- **Console hygiene.** Zero `console.*` calls in `react-app/src/` (excluding tests). Production bundle ships clean.
- **Subresource integrity.** `index.html` only references same-origin `/src/index.js` (dev) or the bundler's emitted same-origin chunks (prod). No external `<script>` or `<link>` to integrity-pin.
- **Tracking / analytics.** Zero matches for google / analytics / gtag / sentry / posthog / mixpanel / amplitude / segment / hotjar in `src/`. Per project ethos, no drift.
- **JWT lifetime + rotation.** Refresh tokens rotate on every use ([react-app/src/lib/api.ts:34-35](react-app/src/lib/api.ts#L34-L35)); parallel 401s coalesce into one in-flight refresh to avoid race-revocation. Session length is 90 days (server-side).
- **X-Robots-Tag header.** Set on every response in [server/app.ts:155-157](server/app.ts#L155-L157) — covers photo files that `robots.txt` can't reach.

## Decisions summary

| Finding | Verdict |
|---|---|
| JWT in localStorage | Should fix before 1.0 → #647 |
| CSP disabled | Backlog → #648 |
| OSM attribution http→https | Fixed inline |
| Everything else | Clean / acceptable |

Closes #217.

## Test plan

- [ ] OSM tile attribution still renders with a working link to the OSM copyright page (just visit `/g/.../<photoId>` with a photo that has GPS).
- [ ] `npm run typecheck` + `npm run lint` + `npm test` clean across all subtrees (passed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)