### PR TITLE
Fix #647: JWT tokens to HttpOnly cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Breaking:** the `.env` fallback path for the SPA's runtime defaults (`DEFAULT_GALLERY`, `DEFAULT_THEME`, `DEFAULT_LANGUAGE`, `INITIAL_GALLERY_VIEW`, `FIRST_WEEKDAY`, `BETA_FEATURE_<NAME>`) is gone — the `meta` table is the only source. **Upgrade step:** for each of these you currently set in `.env`, run `bin/meta.ts set instance_<key> <value>` (or edit at `/m/instance`) before upgrading past this version. The env entries are no longer read; leaving them in place silently does nothing. The new-gallery `default_language` seed now reads `instance_defaultLanguage` from the meta table (falling back to `en` when unset) instead of the env var. Closes #609.
 - New `/m/operations` admin page surfaces converter activity: recent events (intake + geocode), recent failures, and pending-queue counts (inbox files + photos awaiting geocode). Closes #495.
 - Frontend security audit pass (#217): no critical findings; OSM attribution links switched from http to https; two follow-ups filed (#647 JWT to HttpOnly cookies, #648 enable CSP).
+- Auth tokens now travel as HttpOnly cookies (`pd_access`, `pd_refresh`; `Secure`, `SameSite=Lax`) instead of being persisted by the SPA. Closes #647. The Authorization-bearer path and the body-token return values stay in place for one cycle so cached SPA bundles and pre-cutover localStorage carry-over cleanly migrate themselves; both are slated for removal before 1.0 (follow-ups filed).
 
 ## [0.17.1] - 2026-06-17
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1418,6 +1418,26 @@
         "readable-stream": "^4.5.2"
       }
     },
+    "node_modules/@fastify/cookie": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/cookie/-/cookie-11.0.2.tgz",
+      "integrity": "sha512-GWdwdGlgJxyvNv+QcKiGNevSspMQXncjMZ1J8IvuDQk0jvkzgWWZFNC2En3s+nHndZBGV8IbLwOI/sxCZw/mzA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.0",
+        "fastify-plugin": "^5.0.0"
+      }
+    },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
@@ -11353,6 +11373,7 @@
       "license": "MIT",
       "dependencies": {
         "@fastify/compress": "^9.0.0",
+        "@fastify/cookie": "^11.0.2",
         "@fastify/helmet": "^13.0.2",
         "@fastify/static": "^9.1.3",
         "@fastify/swagger": "^9.7.0",

--- a/react-app/src/components/ChangePassword.tsx
+++ b/react-app/src/components/ChangePassword.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from "react-i18next";
 import usersService from "../services/users";
 
 import { HttpError } from "../lib/api";
-import token from "../lib/token";
 import { useUserStore, useNotificationsStore } from "../stores";
 
 const Form = styled.form`
@@ -73,27 +72,12 @@ const ChangePassword = ({ onSuccess }: Props): React.ReactElement => {
     }
     setSubmitting(true);
     try {
-      const { accessToken, refreshToken } = await usersService.changePassword(
-        current,
-        next
-      );
-      // Swap in the new pair so subsequent requests stay authenticated
-      // under the rotated secret (and the new session row). All other
-      // sessions for this user were revoked server-side as part of the
-      // change — this device gets a fresh pair to stay signed in.
-      token.setTokens(accessToken, refreshToken);
-      const stored = window.localStorage.getItem("user");
-      if (stored) {
-        try {
-          const parsed = JSON.parse(stored);
-          parsed.token = accessToken;
-          parsed.refreshToken = refreshToken;
-          window.localStorage.setItem("user", JSON.stringify(parsed));
-        } catch {
-          // Corrupt localStorage — nothing we can do here; the next
-          // 401 handler will catch any downstream issue.
-        }
-      }
+      await usersService.changePassword(current, next);
+      // The server rotated this device's session secret + refreshed
+      // the auth cookies as part of the change. All other sessions
+      // for this user were revoked, so any other open tabs / devices
+      // will hit the next-request 401 → re-login flow. No client-side
+      // token bookkeeping needed.
       setError(undefined);
       onSuccess?.();
       notify("success", t("change-password-success"));

--- a/react-app/src/components/Login.tsx
+++ b/react-app/src/components/Login.tsx
@@ -12,6 +12,13 @@ import { HttpError } from "../lib/api";
 import token from "../lib/token";
 import { useUserStore, useNotificationsStore } from "../stores";
 
+// The server's POST /api/v1/tokens response still echoes the access +
+// refresh tokens in the body for the legacy SPA's localStorage path.
+// New SPAs ignore them — only the just-decoded `id` + `isAdmin` claims
+// from the access token go into the user store (no token persistence).
+// `data.accessToken` is still pulled out below as the source for that
+// decode; nothing else looks at it.
+
 const Form = styled.form`
   display: flex;
   flex-direction: column;
@@ -76,18 +83,18 @@ const Login = ({ onSuccess, autoFocus = true }: Props): React.ReactElement => {
       // We trust the just-issued access token (the server signed it; we
       // got it back from the response body). `decodeJwt` parses the
       // claims without verifying the signature — verification happens
-      // server-side on every subsequent request via `verifyToken`.
+      // server-side on every subsequent request via `verifyToken`. The
+      // server also set HttpOnly cookies on the response; subsequent
+      // calls travel under those, the SPA never reads them.
       const userData = jose.decodeJwt(data.accessToken) as unknown as {
         id: string;
         isAdmin?: boolean;
       };
-      const user = UserModel(
-        { ...userData, editorGalleries: data.editorGalleries },
-        data.accessToken,
-        data.refreshToken
-      );
+      const user = UserModel({
+        ...userData,
+        editorGalleries: data.editorGalleries,
+      });
 
-      token.setTokens(data.accessToken, data.refreshToken);
       window.localStorage.setItem("user", user.toJson());
       setUser(user);
       // Drop any access-derived data we cached under the previous (guest or
@@ -104,11 +111,11 @@ const Login = ({ onSuccess, autoFocus = true }: Props): React.ReactElement => {
       // attach an inline confirmation to.
       notify("success", t("login-success", { userId: user.id() }));
     } catch (err) {
-      token.clearTokens();
       // Only the `user` key is auth state — the `lang` preference and
       // anything else live alongside but aren't tied to login, so the
       // previous `localStorage.clear()` here was a privacy/UX overreach.
       window.localStorage.removeItem("user");
+      token.stripLegacyTokens();
       setUser(undefined);
       // 429 is the only failure mode whose specific cause is useful to
       // surface — `Too many failed attempts` is actionable (wait + try

--- a/react-app/src/components/UserMenu.tsx
+++ b/react-app/src/components/UserMenu.tsx
@@ -169,19 +169,17 @@ const UserMenu = (): React.ReactElement => {
   const handleLogout = () => {
     setIsOpen(false);
     // Server-side revoke first so the session row is gone before we
-    // throw away the refresh token. Fire-and-forget — local state is
-    // cleared regardless of whether the network call succeeds, so a
-    // user offline / mid-rotation can still log out locally.
-    const refreshToken = token.getRefreshToken();
-    if (refreshToken) {
-      tokenService.logout(refreshToken).catch(() => {});
-    }
-    // Order matters: clear the bearer before `setUser` so the React
-    // re-render's queries don't fire with the just-revoked token.
+    // throw away local state. The server identifies the session via
+    // the refresh cookie and clears both auth cookies in the response.
+    // Fire-and-forget — local state is cleared regardless of whether
+    // the network call succeeds, so a user offline can still log out
+    // locally.
+    tokenService.logout().catch(() => {});
     // localStorage is narrowed to the `user` key so the `lang`
-    // preference survives.
-    token.clearTokens();
+    // preference survives. `stripLegacyTokens` covers the case where a
+    // legacy refresh token is still hanging around.
     window.localStorage.removeItem("user");
+    token.stripLegacyTokens();
     setUser(undefined);
     // Drop access-derived caches so the re-render fetches the guest
     // view instead of leaving the previous user's galleries / map

--- a/react-app/src/lib/api-schema.ts
+++ b/react-app/src/lib/api-schema.ts
@@ -263,7 +263,7 @@ export interface paths {
             requestBody: {
                 content: {
                     "application/json": {
-                        refreshToken: string;
+                        refreshToken?: string;
                     };
                 };
             };

--- a/react-app/src/lib/api.ts
+++ b/react-app/src/lib/api.ts
@@ -100,6 +100,17 @@ const expireLocalAuth = () => {
   useLoginModalStore.getState().open(i18n.t("session-expired"));
 };
 
+// Legacy carry-over: on bundle load, if the user has a refresh token
+// in localStorage from a pre-cookie SPA, post it once so the server
+// sets the cookies and we strip the legacy fields. Fire-and-forget —
+// the 401-refresh path covers the same case lazily if this somehow
+// fails, but doing it upfront avoids the awkward "looks logged in
+// but next protected call 401s" gap on first load post-upgrade.
+// Removable pre-1.0 alongside #650.
+if (token.legacyRefreshToken()) {
+  void refreshOnce();
+}
+
 client.use({
   // Mid-session 401 handler with refresh fallback. If a request comes
   // back 401 and a refresh succeeds (cookie or legacy localStorage),

--- a/react-app/src/lib/api.ts
+++ b/react-app/src/lib/api.ts
@@ -3,6 +3,7 @@ import createClient from "openapi-fetch";
 import type { paths } from "./api-schema";
 import token from "./token";
 import i18n from "./i18n";
+import UserModel from "../models/UserModel";
 import {
   useUserStore,
   useLoginModalStore,
@@ -12,15 +13,12 @@ import {
 // Single typed client for the entire server API. The `paths` type is
 // generated from the committed `server/openapi.json` (CI verifies the
 // committed JSON matches the live route schemas, so this stays in
-// lockstep). Auth is attached via openapi-fetch middleware so callers
-// don't have to thread the Authorization header through every call.
-// openapi-fetch resolves request URLs via the WHATWG `URL` constructor,
-// which requires an absolute base. The previous `fetch("/api/v1/…")`
-// usage worked because the browser implicitly resolved against the
-// current page origin; openapi-fetch hands the URL constructor a string
-// directly. Using `window.location.origin` matches the implicit resolution
-// — same-origin requests in production, jsdom's `http://localhost:3000`
-// in vitest, with no per-environment plumbing.
+// lockstep).
+//
+// Auth travels as HttpOnly cookies — `credentials: "include"` makes
+// the browser attach them to every same-origin call. Logout / 401
+// refresh / login responses set or clear the cookies server-side; the
+// SPA never reads them.
 //
 // `fetch` is passed as a thunk that re-reads `globalThis.fetch` on every
 // call. Without this, createClient would capture the original `fetch`
@@ -28,54 +26,62 @@ import {
 // `globalThis.fetch = mock` wouldn't reach the client.
 const client = createClient<paths>({
   baseUrl: window.location.origin,
-  fetch: (input) => globalThis.fetch(input),
+  fetch: (input: RequestInfo | URL, init?: RequestInit) =>
+    globalThis.fetch(input, { ...init, credentials: "include" }),
 });
 
-// Refresh tokens rotate on every use, so two parallel refresh calls
-// with the same token would race and the loser would be revoked.
-// Coalesce concurrent 401s into one in-flight refresh attempt.
-let refreshInFlight: Promise<string | undefined> | undefined;
-const refreshOnce = async (): Promise<string | undefined> => {
+// Refresh requests rotate the refresh cookie, so two parallel attempts
+// would race and the loser would see its rotated token rejected.
+// Coalesce concurrent 401s into one in-flight refresh.
+let refreshInFlight: Promise<boolean> | undefined;
+const refreshOnce = async (): Promise<boolean> => {
   if (refreshInFlight) return refreshInFlight;
-  const current = token.getRefreshToken();
-  if (!current) return undefined;
   refreshInFlight = (async () => {
     try {
+      // Legacy carry-over: if the user has a refresh token in
+      // localStorage from a pre-cookie SPA, post it explicitly so the
+      // server can rotate and set cookies. Once cookies are in place,
+      // strip the legacy token from localStorage so this branch is
+      // taken at most once per user. Removable pre-1.0.
+      const legacy = token.legacyRefreshToken();
+      const body = legacy ? JSON.stringify({ refreshToken: legacy }) : "{}";
       const response = await globalThis.fetch(
         `${window.location.origin}/api/v1/tokens/refresh`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ refreshToken: current }),
+          credentials: "include",
+          body,
         }
       );
-      if (!response.ok) return undefined;
-      const data = (await response.json()) as {
-        accessToken: string;
-        refreshToken: string;
-        editorGalleries: string[];
-      };
-      token.setTokens(data.accessToken, data.refreshToken);
-      // Mirror the new pair into the stored user blob so a reload picks
-      // it up too. The user record's other fields stay as they were,
-      // except editorGalleries which the server resolves freshly on
-      // every refresh (catches grant changes between refreshes).
-      const stored = window.localStorage.getItem("user");
-      if (stored) {
-        try {
-          const parsed = JSON.parse(stored);
-          parsed.token = data.accessToken;
-          parsed.refreshToken = data.refreshToken;
-          parsed.editorGalleries = data.editorGalleries;
-          window.localStorage.setItem("user", JSON.stringify(parsed));
-        } catch {
-          // Corrupt localStorage — ignore; in-memory tokens are
-          // already updated above.
+      if (!response.ok) return false;
+      if (legacy) token.stripLegacyTokens();
+      // editorGalleries can drift between refreshes (grant changes
+      // mid-session). Mirror the server's fresh value into the user
+      // store + localStorage so the UI's editor-tier tile set stays
+      // accurate.
+      try {
+        const data = (await response.json()) as {
+          editorGalleries?: string[];
+        };
+        if (Array.isArray(data.editorGalleries)) {
+          const current = useUserStore.getState().user;
+          if (current) {
+            const rebuilt = UserModel({
+              id: current.id() as string,
+              isAdmin: current.isAdmin(),
+              editorGalleries: data.editorGalleries,
+            });
+            useUserStore.getState().setUser(rebuilt);
+            window.localStorage.setItem("user", rebuilt.toJson());
+          }
         }
+      } catch {
+        // Body wasn't JSON-shaped — cookies still rotated, ignore.
       }
-      return data.accessToken;
+      return true;
     } catch {
-      return undefined;
+      return false;
     } finally {
       refreshInFlight = undefined;
     }
@@ -84,7 +90,7 @@ const refreshOnce = async (): Promise<string | undefined> => {
 };
 
 const expireLocalAuth = () => {
-  token.clearTokens();
+  token.stripLegacyTokens();
   window.localStorage.removeItem("user");
   useUserStore.getState().setUser(undefined);
   // Close any other modal that might be open (e.g. change-password mid-
@@ -95,40 +101,29 @@ const expireLocalAuth = () => {
 };
 
 client.use({
-  onRequest({ request }) {
-    const config = token.createConfig();
-    const headers = (config.headers ?? {}) as Record<string, string>;
-    Object.entries(headers).forEach(([name, value]) => {
-      request.headers.set(name, value);
-    });
-    return request;
-  },
-  // Mid-session 401 handler with refresh fallback. If a request that
-  // *had* an Authorization header comes back 401 and we have a refresh
-  // token in hand, try to refresh once and retry the original request
-  // with the new access token. On refresh failure, fall through to the
-  // pre-existing "clear state + open login modal" flow.
-  // Requests without an Authorization header (login attempts, guest
-  // browsing) are ignored — Login's `catch` handles those inline.
+  // Mid-session 401 handler with refresh fallback. If a request comes
+  // back 401 and a refresh succeeds (cookie or legacy localStorage),
+  // retry the original. On refresh failure, fall through to the
+  // "clear state + open login modal" flow.
   async onResponse({ request, response }) {
     if (response.status !== 401) return;
-    if (!request.headers.get("authorization")) return;
     // The refresh endpoint itself doesn't get a refresh attempt — that
-    // would loop. Falling through to the login modal is the right
-    // behaviour when refresh itself fails.
+    // would loop. Login attempts (POST /tokens with no prior session)
+    // surface as 401 too; let them through to the login flow's catch.
     if (request.url.endsWith("/api/v1/tokens/refresh")) {
       expireLocalAuth();
       return;
     }
-    const newAccess = await refreshOnce();
-    if (!newAccess) {
+    if (request.method === "POST" && request.url.endsWith("/api/v1/tokens")) {
+      return;
+    }
+    const ok = await refreshOnce();
+    if (!ok) {
       expireLocalAuth();
       return;
     }
-    // Retry the original request with the freshly-minted access token.
-    const retry = new Request(request);
-    retry.headers.set("Authorization", `bearer ${newAccess}`);
-    return await globalThis.fetch(retry);
+    // Retry the original request — cookies are now refreshed.
+    return await globalThis.fetch(request);
   },
 });
 

--- a/react-app/src/lib/token.test.ts
+++ b/react-app/src/lib/token.test.ts
@@ -1,27 +1,86 @@
+import { beforeEach, vi } from "vitest";
+
 import token from "./token";
 
-test("setTokens + clearTokens + createConfig", () => {
-  token.setTokens("at", "rt");
-  expect(token.createConfig()).toStrictEqual({
-    headers: { Authorization: "bearer at" },
+const STORAGE_KEY = "user";
+
+// jsdom + node 26 doesn't expose `window.localStorage` by default; stub
+// a tiny in-memory store for the duration of the test file (mirrors
+// the pattern in `stores/theme-preference.test.ts`).
+const memoryStorage = (): Storage => {
+  let store: Record<string, string> = {};
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear: () => {
+      store = {};
+    },
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+  };
+};
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", memoryStorage());
+});
+
+test("legacyRefreshToken returns the refresh token from a legacy user blob", () => {
+  window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ id: "u1", token: "at", refreshToken: "rt", isAdmin: false })
+  );
+  expect(token.legacyRefreshToken()).toBe("rt");
+});
+
+test("legacyRefreshToken returns undefined when there's no user blob", () => {
+  expect(token.legacyRefreshToken()).toBeUndefined();
+});
+
+test("legacyRefreshToken returns undefined when the blob has no refresh field", () => {
+  window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ id: "u1", isAdmin: false })
+  );
+  expect(token.legacyRefreshToken()).toBeUndefined();
+});
+
+test("legacyRefreshToken returns undefined when the blob is corrupt", () => {
+  window.localStorage.setItem(STORAGE_KEY, "not json");
+  expect(token.legacyRefreshToken()).toBeUndefined();
+});
+
+test("stripLegacyTokens removes the token + refreshToken fields", () => {
+  window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      id: "u1",
+      token: "at",
+      refreshToken: "rt",
+      isAdmin: true,
+      editorGalleries: ["g1"],
+    })
+  );
+  token.stripLegacyTokens();
+  const after = JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}");
+  expect(after).toStrictEqual({
+    id: "u1",
+    isAdmin: true,
+    editorGalleries: ["g1"],
   });
-  expect(token.getAccessToken()).toBe("at");
-  expect(token.getRefreshToken()).toBe("rt");
+});
 
-  token.clearTokens();
-  expect(token.createConfig()).toStrictEqual({});
-  expect(token.getAccessToken()).toBeUndefined();
-  expect(token.getRefreshToken()).toBeUndefined();
-
-  // Setting only the access token still works (the refresh-token half
-  // may not exist yet, e.g. on a 401-after-no-refresh code path).
-  token.setTokens("at-only");
-  expect(token.createConfig()).toStrictEqual({
-    headers: { Authorization: "bearer at-only" },
-  });
-  expect(token.getRefreshToken()).toBeUndefined();
-
-  // setTokens() with both undefined clears.
-  token.setTokens();
-  expect(token.createConfig()).toStrictEqual({});
+test("stripLegacyTokens is a no-op when there are no token fields", () => {
+  const blob = { id: "u1", isAdmin: false, editorGalleries: [] };
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(blob));
+  token.stripLegacyTokens();
+  expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY) ?? "{}")).toStrictEqual(
+    blob
+  );
 });

--- a/react-app/src/lib/token.ts
+++ b/react-app/src/lib/token.ts
@@ -1,31 +1,45 @@
-// In-memory bearer cache. The User store's localStorage row is the
-// durable copy; this module is read on every API request (via
-// `createConfig`) and updated on login / refresh / logout. Storing
-// both halves of the pair so the refresh-on-401 middleware can mint
-// new access tokens without a re-login.
-let accessToken: string | undefined = undefined;
-let refreshToken: string | undefined = undefined;
+// Legacy refresh-token carry-over: pre-#647 the SPA stored the access
+// + refresh tokens inside the `user` localStorage blob. New SPAs let
+// HttpOnly cookies handle auth and never read or write the tokens.
+//
+// During the transition window, this module is the bridge: read a
+// legacy refresh token from localStorage so it can be posted to
+// /api/v1/tokens/refresh once (server sets cookies + rotates), then
+// stripped from localStorage. Removable once cached SPA bundles and
+// legacy localStorage have aged out.
 
-const setTokens = (access?: string, refresh?: string): void => {
-  accessToken = access;
-  refreshToken = refresh;
-};
-const clearTokens = (): void => {
-  accessToken = undefined;
-  refreshToken = undefined;
-};
-const getAccessToken = (): string | undefined => accessToken;
-const getRefreshToken = (): string | undefined => refreshToken;
+const STORAGE_KEY = "user";
 
-const createConfig = (): { headers?: { Authorization: string } } => {
-  if (!accessToken) return {};
-  return { headers: { Authorization: `bearer ${accessToken}` } };
+const legacyRefreshToken = (): string | undefined => {
+  if (typeof window === "undefined" || !window.localStorage) return undefined;
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as { refreshToken?: unknown };
+    return typeof parsed.refreshToken === "string"
+      ? parsed.refreshToken
+      : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const stripLegacyTokens = (): void => {
+  if (typeof window === "undefined" || !window.localStorage) return;
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  if (!raw) return;
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (parsed.token === undefined && parsed.refreshToken === undefined) return;
+    delete parsed.token;
+    delete parsed.refreshToken;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed));
+  } catch {
+    // Corrupt localStorage — leave it; the next login flow rewrites it.
+  }
 };
 
 export default {
-  setTokens,
-  clearTokens,
-  getAccessToken,
-  getRefreshToken,
-  createConfig,
+  legacyRefreshToken,
+  stripLegacyTokens,
 };

--- a/react-app/src/models/UserModel.test.ts
+++ b/react-app/src/models/UserModel.test.ts
@@ -3,48 +3,17 @@ import UserModel from "./UserModel";
 describe("Construction", () => {
   test("undefined", () => expect(() => UserModel(undefined)).toThrow());
   test("empty", () => expect(() => UserModel({} as any)).toThrow());
-  test("no ID", () =>
-    expect(() => UserModel({ token: "123" } as any)).toThrow());
   test("ID only", () => {
     const user = UserModel({ id: 42 });
     expect(user.id()).toBe(42);
-    expect(user.token()).toBeUndefined();
     expect(user.isAdmin()).toBe(false);
   });
-  test("Admin, no token", () => {
+  test("Admin", () => {
     const user = UserModel({ id: 42, isAdmin: true });
     expect(user.id()).toBe(42);
-    expect(user.token()).toBeUndefined();
     expect(user.isAdmin()).toBe(true);
     expect(user.toJson()).toBe(
       '{"id":42,"isAdmin":true,"editorGalleries":[]}'
-    );
-  });
-  test("Separate token", () => {
-    const user = UserModel({ id: 42 }, "1234");
-    expect(user.id()).toBe(42);
-    expect(user.token()).toBe("1234");
-    expect(user.isAdmin()).toBe(false);
-    expect(user.toJson()).toBe(
-      '{"id":42,"token":"1234","editorGalleries":[]}'
-    );
-  });
-  test("Token in object", () => {
-    const user = UserModel({ id: 42, token: "1234" });
-    expect(user.id()).toBe(42);
-    expect(user.token()).toBe("1234");
-    expect(user.isAdmin()).toBe(false);
-    expect(user.toJson()).toBe(
-      '{"id":42,"token":"1234","editorGalleries":[]}'
-    );
-  });
-  test("Two tokens", () => {
-    const user = UserModel({ id: 42, token: "1234" }, "5678");
-    expect(user.id()).toBe(42);
-    expect(user.token()).toBe("5678");
-    expect(user.isAdmin()).toBe(false);
-    expect(user.toJson()).toBe(
-      '{"id":42,"token":"5678","editorGalleries":[]}'
     );
   });
   test("Editor galleries", () => {
@@ -59,5 +28,16 @@ describe("Construction", () => {
   test("Global admin satisfies isGalleryEditor for any gallery", () => {
     const user = UserModel({ id: 42, isAdmin: true });
     expect(user.isGalleryEditor("any-gallery")).toBe(true);
+  });
+  test("Legacy token/refreshToken fields in input are silently dropped", () => {
+    const user = UserModel({
+      id: 42,
+      token: "at",
+      refreshToken: "rt",
+    } as any);
+    expect(user.id()).toBe(42);
+    expect(user.toJson()).toBe(
+      '{"id":42,"editorGalleries":[]}'
+    );
   });
 });

--- a/react-app/src/models/UserModel.ts
+++ b/react-app/src/models/UserModel.ts
@@ -1,43 +1,31 @@
 interface UserData {
   id: string | number;
-  token?: string;
-  refreshToken?: string;
   isAdmin?: boolean;
-  // Gallery ids the user is gallery-editor on (has `is_admin=1`
+  // Gallery ids the user is gallery-editor on (has `is_editor=1`
   // on `user_gallery` directly or via a group). Populated by the
   // tokens endpoint at login + refresh; purely a client-side
   // rendering hint — the server enforces every request.
   editorGalleries?: string[];
 }
 
-const UserModel = (
-  userData: UserData | undefined,
-  token?: string,
-  refreshToken?: string
-) => {
+const UserModel = (userData: UserData | undefined) => {
   const importUserData = (
-    userData: UserData | undefined,
-    token?: string,
-    refreshToken?: string
+    userData: UserData | undefined
   ): UserData => {
     if (!userData || !("id" in userData) || !userData.id) {
       throw new Error("Invalid user");
     }
     return {
       id: userData.id,
-      token: token || userData.token,
-      refreshToken: refreshToken || userData.refreshToken,
       isAdmin: userData.isAdmin,
       editorGalleries: userData.editorGalleries ?? [],
     };
   };
 
-  const user = importUserData(userData, token, refreshToken);
+  const user = importUserData(userData);
   const editorSet = new Set(user.editorGalleries ?? []);
   const self = {
     id: () => user.id,
-    token: () => user.token,
-    refreshToken: () => user.refreshToken,
     isAdmin: () => !!user.isAdmin,
     // Global admin satisfies editor on every gallery (the server
     // does the same short-circuit in `authorizeGalleryEditor`).

--- a/react-app/src/services/tokens.ts
+++ b/react-app/src/services/tokens.ts
@@ -3,18 +3,9 @@ import api, { unwrap } from "../lib/api";
 const login = async (id: string, password: string) =>
   unwrap(api.POST("/api/v1/tokens", { body: { id, password } }));
 
-// Logout sends the current refresh token in the body so the server can
-// delete its session row. The bearer access token still authorizes the
-// call (`security: [{ bearer: [] }]`); the refresh token identifies
-// which device's session to revoke.
-const logout = async (refreshToken?: string) =>
-  unwrap(
-    api.DELETE("/api/v1/tokens", {
-      body: refreshToken ? { refreshToken } : {},
-    })
-  );
+// Logout sends an empty body — the server reads the refresh cookie to
+// identify which session row to revoke and clears the auth cookies.
+const logout = async () =>
+  unwrap(api.DELETE("/api/v1/tokens", { body: {} }));
 
-const refresh = async (refreshToken: string) =>
-  unwrap(api.POST("/api/v1/tokens/refresh", { body: { refreshToken } }));
-
-export default { login, logout, refresh };
+export default { login, logout };

--- a/react-app/src/stores/user.ts
+++ b/react-app/src/stores/user.ts
@@ -3,26 +3,29 @@ import { create } from "zustand";
 import UserModel, { type User } from "../models/UserModel";
 import token from "../lib/token";
 
-// Rehydrate from localStorage at module load — the previous pattern lived
-// in App.tsx and called `setUser` during render which conflicted with
-// React's render-purity rule. Doing it once at store creation moves the
-// side effect out of the render path entirely. The `localStorage` guard
-// covers test environments and any SSR / non-browser context where
+// Rehydrate from localStorage at module load. The legacy SPA stored
+// access + refresh tokens inside this blob; new SPAs only persist
+// display state (id, isAdmin, editorGalleries) and let HttpOnly
+// cookies handle the credential. The legacy fields are silently
+// stripped so the user keeps their stored identity across the cutover
+// — the next 401 + refresh dance promotes the legacy token to cookies
+// and clears the localStorage residue. The localStorage guard covers
+// test environments and any SSR / non-browser context where
 // `window.localStorage` may not be defined when the module first loads.
 const rehydrate = (): User | undefined => {
   if (typeof window === "undefined" || !window.localStorage) return undefined;
   const stored = window.localStorage.getItem("user");
   if (!stored) return undefined;
   try {
+    // UserModel ignores any legacy token / refreshToken fields, so this
+    // works without explicit stripping.
     const user = UserModel(JSON.parse(stored));
-    if (user) {
-      token.setTokens(user.token(), user.refreshToken());
-      return user;
-    }
+    return user;
   } catch {
     // Corrupt JSON — fall through to undefined; user can re-login.
+    token.stripLegacyTokens();
+    return undefined;
   }
-  return undefined;
 };
 
 interface UserState {

--- a/server/app.ts
+++ b/server/app.ts
@@ -7,6 +7,7 @@ import {
   TypeBoxValidatorCompiler,
   type TypeBoxTypeProvider,
 } from "@fastify/type-provider-typebox";
+import fastifyCookie from "@fastify/cookie";
 import fastifyHelmet from "@fastify/helmet";
 import fastifyCompress from "@fastify/compress";
 import fastifyStatic from "@fastify/static";
@@ -144,6 +145,7 @@ if (DOCS_EXPOSED) {
 // styles / dynamic imports (warrants its own audit). Referrer-
 // Policy overridden because OSM's tile servers block referrer-less
 // requests as bot traffic, breaking the Leaflet map widget.
+await app.register(fastifyCookie);
 await app.register(fastifyHelmet, {
   contentSecurityPolicy: false,
   referrerPolicy: { policy: "strict-origin-when-cross-origin" },

--- a/server/controllers/tokens-v1.ts
+++ b/server/controllers/tokens-v1.ts
@@ -2,6 +2,11 @@ import { Type } from "typebox";
 import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import { InvalidTokenError, LoginError, RateLimitError } from "../lib/errors.js";
+import {
+  REFRESH_COOKIE,
+  clearAuthCookies,
+  setAuthCookies,
+} from "../lib/auth-cookies.js";
 import logger from "../lib/logger.js";
 import authorizerFactory from "../lib/authorizer.js";
 import modelFactory from "../models/token.js";
@@ -30,8 +35,10 @@ const TokenPairResponse = Type.Object({
   refreshToken: Type.String(),
   editorGalleries: Type.Array(Type.String()),
 });
+// `refreshToken` is optional so cookie-only clients can hit /refresh
+// with no body. Legacy SPAs continue to POST the token explicitly.
 const RefreshBody = Type.Object({
-  refreshToken: Type.String(),
+  refreshToken: Type.Optional(Type.String()),
 });
 const LogoutBody = Type.Object({
   // Optional so an already-invalid refresh token (e.g. expired and
@@ -146,7 +153,12 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       const editorGalleries = await authorizer.loadEditorGalleries(
         credentials.id
       );
+      setAuthCookies(reply, pair.accessToken, pair.refreshToken);
       logger.debug(`User "${credentials.id}" logged in successfully.`);
+      // Tokens still travel in the response body for back-compat: the
+      // legacy SPA reads them from there and writes to localStorage.
+      // New SPAs ignore the body tokens and rely on the cookies set
+      // above. Removable once all clients are on the cookie path.
       reply.status(200).send({ ...pair, editorGalleries });
     }
   );
@@ -169,13 +181,15 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       },
     },
     async (request, reply) => {
-      if (!request.body?.refreshToken) throw new InvalidTokenError();
-      const { userId, refreshToken } = await model.verifyAndRotateRefresh(
-        request.body.refreshToken
-      );
+      const submitted =
+        request.body?.refreshToken ?? request.cookies?.[REFRESH_COOKIE];
+      if (!submitted) throw new InvalidTokenError();
+      const { userId, refreshToken } =
+        await model.verifyAndRotateRefresh(submitted);
       const isAdmin = await resolveIsAdmin(userId);
       const accessToken = await model.signAccessToken(userId, isAdmin);
       const editorGalleries = await authorizer.loadEditorGalleries(userId);
+      setAuthCookies(reply, accessToken, refreshToken);
       reply.status(200).send({ accessToken, refreshToken, editorGalleries });
     }
   );
@@ -196,9 +210,12 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
       },
     },
     async (request, reply) => {
-      if (request.body?.refreshToken) {
-        await model.revokeSession(request.body.refreshToken);
+      const submitted =
+        request.body?.refreshToken ?? request.cookies?.[REFRESH_COOKIE];
+      if (submitted) {
+        await model.revokeSession(submitted);
       }
+      clearAuthCookies(reply);
       reply.status(204).send();
     }
   );

--- a/server/controllers/users-v1.ts
+++ b/server/controllers/users-v1.ts
@@ -4,6 +4,7 @@ import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 import CONST from "../lib/constants.js";
 import { AccessError } from "../lib/errors.js";
 import authorizerFactory from "../lib/authorizer.js";
+import { setAuthCookies } from "../lib/auth-cookies.js";
 import { requireUnscoped } from "../lib/host-scope.js";
 import { ID_PATTERN_SOURCE } from "../lib/id-shape.js";
 import modelFactory from "../models/user.js";
@@ -180,7 +181,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         security: [{ bearer: [] }],
       },
     },
-    async (request) => {
+    async (request, reply) => {
       if (request.user.id === CONST.GUEST_USER) {
         // Guests have no password to change. AccessError matches the rest
         // of the "you can't do this" patterns in this codebase.
@@ -206,6 +207,7 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
         request.user.id,
         !!request.user.isAdmin
       );
+      setAuthCookies(reply, pair.accessToken, pair.refreshToken);
       return pair;
     }
   );

--- a/server/lib/auth-cookies.ts
+++ b/server/lib/auth-cookies.ts
@@ -1,0 +1,47 @@
+import type { FastifyReply } from "fastify";
+
+import CONST from "./constants.js";
+
+// HttpOnly auth cookies. Two cookies because the access and refresh
+// tokens have very different lifetimes — splitting them lets the
+// browser drop the short-lived access cookie on its own without
+// touching the long-lived refresh cookie. New SPAs read neither
+// directly; same-origin requests pick up both automatically.
+export const ACCESS_COOKIE = "pd_access";
+export const REFRESH_COOKIE = "pd_refresh";
+
+const ACCESS_COOKIE_MAX_AGE_S = Math.floor(
+  CONST.ACCESS_TOKEN_LIFETIME_MS / 1000
+);
+const REFRESH_COOKIE_MAX_AGE_S = Math.floor(CONST.SESSION_LENGTH_MS / 1000);
+
+const cookieOptions = (maxAgeS: number) => ({
+  httpOnly: true,
+  // Browsers allow Secure on http://localhost too, so this is safe in dev.
+  secure: true,
+  sameSite: "lax" as const,
+  path: "/",
+  maxAge: maxAgeS,
+});
+
+export const setAuthCookies = (
+  reply: FastifyReply,
+  accessToken: string,
+  refreshToken: string
+): void => {
+  reply.setCookie(
+    ACCESS_COOKIE,
+    accessToken,
+    cookieOptions(ACCESS_COOKIE_MAX_AGE_S)
+  );
+  reply.setCookie(
+    REFRESH_COOKIE,
+    refreshToken,
+    cookieOptions(REFRESH_COOKIE_MAX_AGE_S)
+  );
+};
+
+export const clearAuthCookies = (reply: FastifyReply): void => {
+  reply.clearCookie(ACCESS_COOKIE, { path: "/" });
+  reply.clearCookie(REFRESH_COOKIE, { path: "/" });
+};

--- a/server/lib/middleware/token-filter.ts
+++ b/server/lib/middleware/token-filter.ts
@@ -7,7 +7,12 @@ import logger from "../logger.js";
 
 const tokensModel = tokenFactory();
 
+// Cookie first (the new SPA's only auth carrier), bearer header second
+// (legacy SPAs + test fixtures). The bearer path is slated for removal
+// once cached bundles + carry-over migration shims have aged out.
 const getToken = (request: FastifyRequest): string | undefined => {
+  const cookie = request.cookies?.pd_access;
+  if (cookie) return cookie;
   const header = request.headers.authorization;
   if (header && header.toLowerCase().startsWith("bearer")) {
     return header.substring(7);

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -341,9 +341,6 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "refreshToken"
-                ],
                 "properties": {
                   "refreshToken": {
                     "type": "string"

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@fastify/compress": "^9.0.0",
+    "@fastify/cookie": "^11.0.2",
     "@fastify/helmet": "^13.0.2",
     "@fastify/static": "^9.1.3",
     "@fastify/swagger": "^9.7.0",

--- a/server/tests/api/tokens.test.ts
+++ b/server/tests/api/tokens.test.ts
@@ -51,6 +51,33 @@ describe("Login", () => {
     expect(result.body.refreshToken).toBeDefined();
     expect(typeof result.body.refreshToken).toBe("string");
   });
+  test("Login sets HttpOnly auth cookies", async () => {
+    const result = await api
+      .post("/api/v1/tokens")
+      .send({ id: "admin", password: "foobar" })
+      .expect(200);
+    const cookies = result.headers["set-cookie"] as unknown as string[];
+    expect(Array.isArray(cookies)).toBe(true);
+    const accessCookie = cookies.find((c) => c.startsWith("pd_access="));
+    const refreshCookie = cookies.find((c) => c.startsWith("pd_refresh="));
+    expect(accessCookie).toMatch(/HttpOnly/i);
+    expect(accessCookie).toMatch(/Secure/i);
+    expect(accessCookie).toMatch(/SameSite=Lax/i);
+    expect(refreshCookie).toMatch(/HttpOnly/i);
+    expect(refreshCookie).toMatch(/Secure/i);
+    expect(refreshCookie).toMatch(/SameSite=Lax/i);
+  });
+  test("Cookie auth — requests with pd_access cookie are authenticated", async () => {
+    const login = await api
+      .post("/api/v1/tokens")
+      .send({ id: "admin", password: "foobar" })
+      .expect(200);
+    // Identify by GET /api/v1/users which requires admin auth.
+    await api
+      .get("/api/v1/users")
+      .set("Cookie", `pd_access=${login.body.accessToken}`)
+      .expect(200);
+  });
 });
 describe("Login rate limit", () => {
   test("10 failed logins → 11th returns 429", async () => {
@@ -142,11 +169,23 @@ describe("Refresh", () => {
       .expect(401);
   });
 
-  test("returns 400 when the refresh-token body field is missing", async () => {
-    // Body shape is enforced by the typebox schema before the handler runs,
-    // so a missing field short-circuits as a 400 — never reaches the
-    // controller's defensive 401 fallback.
-    await api.post("/api/v1/tokens/refresh").send({}).expect(400);
+  test("returns 401 when neither cookie nor body field carries a refresh token", async () => {
+    // The body field is optional now (cookie-only clients hit /refresh
+    // with no body), so a missing field falls through to the handler's
+    // 401 path rather than short-circuiting on schema validation.
+    await api.post("/api/v1/tokens/refresh").send({}).expect(401);
+  });
+  test("Cookie-only refresh rotates and re-sets the cookies", async () => {
+    const pair = await loginUserPair(api, "admin");
+    const refreshed = await api
+      .post("/api/v1/tokens/refresh")
+      .set("Cookie", `pd_refresh=${pair.refreshToken}`)
+      .send({})
+      .expect(200);
+    const cookies = refreshed.headers["set-cookie"] as unknown as string[];
+    expect(cookies.find((c) => c.startsWith("pd_access="))).toBeDefined();
+    expect(cookies.find((c) => c.startsWith("pd_refresh="))).toBeDefined();
+    expect(refreshed.body.refreshToken).not.toBe(pair.refreshToken);
   });
 });
 
@@ -167,6 +206,26 @@ describe("Logout", () => {
       .post("/api/v1/tokens/refresh")
       .send({ refreshToken: sessionB.refreshToken })
       .expect(200);
+  });
+
+  test("Cookie-only logout revokes the session and clears the cookies", async () => {
+    const session = await loginUserPair(api, "plainuser");
+    const logout = await api
+      .delete("/api/v1/tokens")
+      .set("Cookie", `pd_access=${session.accessToken}; pd_refresh=${session.refreshToken}`)
+      .send({})
+      .expect(204);
+    const cookies = (logout.headers["set-cookie"] as unknown as string[]) ?? [];
+    // clearCookie emits a Set-Cookie with an expired Max-Age or Expires.
+    const accessClear = cookies.find((c) => c.startsWith("pd_access="));
+    const refreshClear = cookies.find((c) => c.startsWith("pd_refresh="));
+    expect(accessClear).toMatch(/Expires=|Max-Age=0/);
+    expect(refreshClear).toMatch(/Expires=|Max-Age=0/);
+    // The refresh token from the now-revoked session no longer works.
+    await api
+      .post("/api/v1/tokens/refresh")
+      .send({ refreshToken: session.refreshToken })
+      .expect(401);
   });
 
   test("is idempotent — second logout call still 204s", async () => {


### PR DESCRIPTION
## Summary

Auth tokens stop living in \`localStorage\` and start travelling as HttpOnly cookies (\`pd_access\`, \`pd_refresh\`; Secure, SameSite=Lax). The SPA never reads or writes the tokens — same-origin requests use \`credentials: \"include\"\`, the browser attaches the cookies, and a successful XSS can no longer exfiltrate the credential. Closes #647.

## What changed

Server:

- Registered \`@fastify/cookie\` in \`server/app.ts\`.
- New \`server/lib/auth-cookies.ts\` exposes \`setAuthCookies\` / \`clearAuthCookies\` with the canonical options (HttpOnly, Secure, SameSite=Lax, path=/, lifetimes from \`CONST\`).
- POST /api/v1/tokens, POST /api/v1/tokens/refresh, DELETE /api/v1/tokens, and PUT /api/v1/users/self/password all set or clear the cookies in their response.
- \`token-filter\` middleware reads \`pd_access\` cookie first, falls back to \`Authorization: bearer\` (transition).
- /refresh accepts either the refresh cookie or a body \`refreshToken\` (transition).

Client:

- \`lib/api.ts\` adds \`credentials: \"include\"\` on every fetch, simplifies the 401-refresh handler (no Authorization-header plumbing), and rebuilds the user model after refresh so \`editorGalleries\` stays in sync.
- \`UserModel\` drops \`token\` and \`refreshToken\` fields entirely.
- \`stores/user.ts\` rehydrates only display state (id, isAdmin, editorGalleries). Legacy \`token\` / \`refreshToken\` fields in the stored blob are silently ignored.
- \`lib/token.ts\` becomes a tiny carry-over shim — \`legacyRefreshToken()\` reads the old localStorage refresh token for one-shot promotion to cookies, \`stripLegacyTokens()\` cleans the residue.
- \`Login.tsx\` / \`UserMenu.tsx\` / \`ChangePassword.tsx\` no longer write tokens to localStorage; \`services/tokens.ts\` drops the body-token plumbing.

## Transition behaviour (removable pre-1.0 — filed as #650)

To avoid forcing every existing user to re-login:

1. \`Authorization: bearer\` still works server-side, so cached SPA bundles keep authenticating until the browser fetches the new bundle.
2. POST /tokens + POST /refresh + PUT /self/password keep echoing the tokens in the response body, so the legacy SPA's localStorage path keeps working.
3. New SPA's first /refresh attempt looks for a leftover \`refreshToken\` in localStorage and posts it as the body argument — server rotates + sets cookies, client strips the legacy fields from localStorage. After this one round-trip, the user is on the cookie path forever.

Once cached bundles + legacy localStorage have aged out (#650), drop all three.

## Test plan

- [ ] Fresh login: hit /m as anonymous, log in, confirm \`pd_access\` + \`pd_refresh\` show up in DevTools > Application > Cookies with HttpOnly + Secure + SameSite=Lax. Reload the page; still authenticated.
- [ ] Logout: click logout, confirm both cookies are cleared (Set-Cookie with Max-Age=0). Subsequent admin call → 401 → login modal.
- [ ] Change password: change own password from /m/users/&lt;self&gt; (or wherever), confirm cookies are re-set in the response (old sessions revoked). This device stays signed in.
- [ ] Mid-session expiry: wait 15 min (or shrink \`ACCESS_TOKEN_LIFETIME_MS\` locally), trigger an API call. Should see /refresh fire (cookie-only body) + the original call retry with no re-login.
- [ ] Legacy carry-over: with an old SPA bundle running, log in (gets tokens in localStorage). Then refresh to load the new bundle. First protected call → 401 → /refresh runs with localStorage refresh token → cookies get set → call retries. Verify the localStorage \`user\` blob has \`token\` and \`refreshToken\` fields removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)