### PR TITLE
Release 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,19 @@
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-06-19
+
 ### Operator
 
 - **Breaking:** the `.env` fallback path for the SPA's runtime defaults (`DEFAULT_GALLERY`, `DEFAULT_THEME`, `DEFAULT_LANGUAGE`, `INITIAL_GALLERY_VIEW`, `FIRST_WEEKDAY`, `BETA_FEATURE_<NAME>`) is gone — the `meta` table is the only source. **Upgrade step:** for each of these you currently set in `.env`, run `bin/meta.ts set instance_<key> <value>` (or edit at `/m/instance`) before upgrading past this version. The env entries are no longer read; leaving them in place silently does nothing. The new-gallery `default_language` seed now reads `instance_defaultLanguage` from the meta table (falling back to `en` when unset) instead of the env var. Closes #609.
 - New `/m/operations` admin page surfaces converter activity: recent events (intake + geocode), recent failures, and pending-queue counts (inbox files + photos awaiting geocode). Closes #495.
+- `bin/photo.ts` subcommand surface tidied for consistency with the rest of the operator scripts. Closes #376.
 - Frontend security audit pass (#217): no critical findings; OSM attribution links switched from http to https; two follow-ups filed (#647 JWT to HttpOnly cookies, #648 enable CSP).
-- Auth tokens now travel as HttpOnly cookies (`pd_access`, `pd_refresh`; `Secure`, `SameSite=Lax`) instead of being persisted by the SPA. Closes #647. The Authorization-bearer path and the body-token return values stay in place for one cycle so cached SPA bundles and pre-cutover localStorage carry-over cleanly migrate themselves; both are slated for removal before 1.0 (follow-ups filed).
+- Auth tokens now travel as HttpOnly cookies (`pd_access`, `pd_refresh`; `Secure`, `SameSite=Lax`) instead of being persisted by the SPA. Closes #647. The Authorization-bearer path and the body-token return values stay in place for one cycle so cached SPA bundles and pre-cutover localStorage carry-over cleanly migrate themselves; both are slated for removal before 1.0 (follow-up #650).
+
+### Developer
+
+- `vitest --coverage` wired up in the server and react-app workspaces (`npm run coverage`). Closes #194; no CI gating attached.
 
 ## [0.17.1] - 2026-06-17
 
@@ -643,6 +650,7 @@
 
 ## Initial commit - 2020-07-04
 
+[0.18.0]: https://github.com/vlumi/photo-diary/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/vlumi/photo-diary/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/vlumi/photo-diary/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/vlumi/photo-diary/compare/v0.15.2...v0.16.0

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Third structural take on a long-running personal photo-gallery side project — 
 - **0.15** (Jun 2026) — Composition + scale: hybrid galleries, saved filters as pseudo-galleries, per-language metadata, date-range filter, stats evolution chart; per-view `/query`/`/counts`/`/neighbors` endpoints.
 - **0.16** (Jun 2026) — Filter & viewing UX polish: redesigned filter widget (inline strip + per-category modal cards with faceted counts), continuous-variable range filters, stacked-area evolution chart, virtual-gallery edit page + hybrid-source admin UI, persistent map modal.
 - **0.17** (Jun 2026) — Admin UI shift to layered modals + Section card primitive; per-photo visibility + editor-tier admin actions on `/g/`; `/m/instance` page with runtime-overridable `meta` defaults; configurable rendition ladder + collapsed `photos/display/<maxDim>/` layout; `/m/photos` filters move into a modal; Stats Evolution adds `weekday` and `hour`; Finnish geocoding cleanup (state-code lvl fallthrough + script-rule address blob filter).
+- **0.18** (Jun 2026) — Cleanup + observability: `meta` table is the only source for SPA runtime defaults (no `.env` fallback); `/m/operations` admin page surfaces converter activity, pending queues, and failures; tidied `bin/photo.ts` surface; vitest coverage wired; frontend security audit pass; auth tokens move from localStorage to HttpOnly cookies.
 
-See the [Roadmap](#roadmap) for what's in flight after 0.17.
+See the [Roadmap](#roadmap) for what's in flight after 0.18.
   

--- a/SETUP.md
+++ b/SETUP.md
@@ -79,13 +79,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  0.17.1/                               #   so different instances can run different versions
+  0.18.0/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/0.17.1      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/0.18.0      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  thumbnail/        # display/<maxDim>/ subdirs auto-created on intake
@@ -112,7 +112,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.17.1
+V=0.18.0
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -127,7 +127,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.17.1/bin/instance.ts /var/photo-diary/dailybw
+/opt/photo-diary/0.18.0/bin/instance.ts /var/photo-diary/dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -159,7 +159,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.17.1/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
+/opt/photo-diary/0.18.0/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                                # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                                     # migration runner applies any schema bumps

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1"
   },
-  "version": "0.17.1"
+  "version": "0.18.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -71,5 +71,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.17.1"
+  "version": "0.18.0"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.17.1"
+    "version": "0.18.0"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -60,5 +60,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.17.1"
+  "version": "0.18.0"
 }


### PR DESCRIPTION
## Summary

Cleanup + observability release. Highlights:

- **Breaking:** `.env` fallbacks for SPA runtime defaults are gone; the `meta` table is the only source (#609). Operators need to migrate any in-use values to `meta` via `bin/meta.ts set instance_<key> <value>` or `/m/instance` before upgrading.
- **New /m/operations admin page** (#495) — recent converter activity, pending queues, recent failures.
- **Auth tokens move from localStorage to HttpOnly cookies** (#647). The bearer-header path + body-token responses stay one cycle so cached SPA bundles and pre-cutover localStorage carry-over cleanly migrate themselves; both removed in #650 before 1.0.
- **Frontend security audit** (#217) — no critical findings.
- **Vitest coverage tooling** wired up in server + react-app (#194) — measured baseline, no CI gating.
- **`bin/photo.ts` subcommand surface tidied** (#376).

Two follow-up tickets filed off the security work: #650 (drop bearer + body-token transition) and #648 (enable CSP). Two off the coverage audit: #645 (migration runner edge cases) and #646 (`bin/*` smoke tests).

The remaining 0.18-original tickets (#261 Playwright, #283 docs, #366 subdivision dataset) moved to a new 0.19 milestone so the cookie transition window can start sooner.

## Test plan

- [x] `npm test`, `npm run typecheck`, `npm run lint` clean across server + react-app + converter
- [x] `npm run build` clean in react-app (bundle sizes unchanged)
- [x] `npm run docs:dump` + `npm run api:codegen` regenerated, schemas in lockstep
- [x] Cookie migration verified locally on a session that had pre-cutover localStorage tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)