### PR TITLE
Fix #283: docs overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Playwright e2e test suite under `e2e/` covers the regression-prone seams between SPA components, stores, and the API: login/logout cycle, session expiry → login modal, change-password (right + wrong current), non-existent gallery, and language persistence. Wired into CI as a separate workflow job. Closes #261.
 - `npm run coverage --workspace=e2e` produces a v8 coverage report of the server code exercised by the e2e suite (`e2e/coverage/`). Sits alongside the existing per-workspace vitest coverage; unifying the two reports tracks under a follow-up (the timing-sensitive vitest tests get flaky under raw v8 instrumentation). Closes #656.
 
+### Docs
+
+- Top-level `README.md` reorganized around the three audiences (visitor / operator / contributor) — Contents lists per-lane entry points, "What it looks like" surfaces the live-example links + a stub `docs/screenshots.md`, "Architecture" carries a mermaid diagram of the converter / server / SPA boundary. New `e2e/README.md` documents the e2e workspace. Closes #283.
+
 ## [0.18.0] - 2026-06-19
 
 ### Operator

--- a/README.md
+++ b/README.md
@@ -1,37 +1,40 @@
 # Photo Diary
 
-**Photo Diary** is a calendar-based photo gallery platform for self-hosting. The photos are arranged by the date they were shot, in calendar-based views, aimed at diaries and other, date-based photography projects.
+**Photo Diary** is a calendar-based photo gallery platform for self-hosting. Photos are arranged by the date they were shot, in calendar-based views, aimed at diaries and other date-based photography projects.
 
-Live examples: [dailybw.misaki.fi](https://dailybw.misaki.fi) and [papusama.misaki.fi](https://papusama.misaki.fi).
+**Live examples:** [dailybw.misaki.fi](https://dailybw.misaki.fi) · [papusama.misaki.fi](https://papusama.misaki.fi)
 
-Key features include:
+Key features:
 
-- Calendar-based views (year, month, photo)
-  - Including map from embedded GPS information
-- Comprehensive photo statistics (time, gear, exposure settings, etc.)
+- Calendar-based views (year, month, photo), with map from embedded GPS information
+- Comprehensive photo statistics (time, gear, exposure settings, etc.) with stacked-area evolution charts
 - Fast browsing — per-view fetch narrowed by the active filter, cached client-side so filter toggles update in place
-- User management and basic access control
+- Admin UI for galleries, users, groups, photo bulk-edit, and per-instance settings
+- Multi-instance deploy pattern: shared code + per-instance state + atomic upgrades
 
 ## Contents
 
-- [Structure](#structure)
+For visitors / evaluators:
+
+- [What it looks like](#what-it-looks-like)
 - [Features](#features)
-  - [Beta features](#beta-features)
-- [Setup](SETUP.md) — basic setup, dev mode, multi-instance deployment, day-to-day ops
-- [Photo pipeline](#photo-pipeline)
 - [Roadmap](#roadmap)
-- [Backlog](#backlog)
 - [Version history](#version-history)
 
-## Structure
+For operators:
 
-Photo Diary is split into independent modules, each handling its own sub-system:
+- [Setup](SETUP.md) — install, dev mode, multi-instance deployment, day-to-day ops
+- [Photo pipeline](#photo-pipeline)
+- [Architecture](#architecture)
 
-- [react-app](react-app) — front-end React SPA. Served as static files by the backend; no separate hosting required.
-- [server](server) — Fastify + SQLite backend. Exposes `/api/v1` (with an OpenAPI doc at `/api/v1/docs`) and serves the bundled frontend.
-- [converter](converter) — back-end worker that pre-processes new photos (EXIF extraction, configurable downscale ladder + thumbnail via sharp).
+For contributors:
 
-The three pieces communicate via the shared filesystem and SQLite DB rather than over a network — the converter writes one thumbnail and one or more display renditions per intake under `photos/display/<maxDim>/<id>.jpg` (the ladder is operator-configurable via the `renditions` meta key; the default is a single 1500-px rendition) and inserts the photo row into the DB on intake, processing operator JSON sidecars through the same pipeline; the server reads the DB to serve the API; `bin/photo.ts update <id>` is the operator hook for after-the-fact enrichment. Per-instance state (database, photo files, `.env`) lives in a single instance directory outside the repo; see [Setup](#setup) below.
+- [Working in the repo](AGENTS.md) — layout, commands, footguns, release flow
+- [react-app](react-app/README.md) · [server](server/README.md) · [converter](converter/README.md) · [e2e](e2e/README.md)
+
+## What it looks like
+
+The live examples up top are the canonical "see it in action" — the calendar grid, photo modal, stats, and admin UI are best understood by clicking around. A small set of screenshots will land in [docs/screenshots.md](docs/screenshots.md) as the operator captures them.
 
 ## Features
 
@@ -120,11 +123,48 @@ End-to-end flow from a new JPG arriving on the host to it being browsable in the
 4. **(Optional) operator enrichment via JSON sidecar.** Drop a `<name>.json` alongside (or anywhere under) `inbox/` with the fields you want to overlay onto an existing row — title, description, operator-set country / place, etc. The converter matches it back to the row by id / originalFilename + timestamp and applies the overlay. The sidecar is archived under `photos/original/<id>.intake.json` after processing.
 5. **(Optional) operator enrichment via CLI.** For one-off corrections, `./bin/photo.ts update <id> --title "…" --place "…"` applies the same overrides directly. `./bin/photo.ts show <id>` prints the current row; `./bin/photo.ts delete <id>` removes one. See `./bin/photo.ts --help`.
 
+## Architecture
+
+Three TypeScript workspaces, no network between them — the converter and server share the same SQLite DB and `photos/` tree on the host filesystem; the SPA talks to the server over HTTP.
+
+```mermaid
+flowchart LR
+    operator["Operator: drop JPGs / JSON sidecars"]
+    visitor["Visitor browser"]
+
+    subgraph instance["Instance dir"]
+        inbox["photos/inbox/"]
+        photos["photos/{original,thumbnail,display}/"]
+        db[("db.sqlite3")]
+    end
+
+    operator -->|"copy"| inbox
+    inbox -->|"chokidar watch"| converter
+    converter -->|"sharp + exifr"| photos
+    converter -->|"insert photo row"| db
+    converter -.->|"reverse-geocode"| nominatim["Nominatim"]
+
+    visitor -->|"HTTPS"| nginx["nginx (TLS)"]
+    nginx -->|"/api/*"| server
+    nginx -.->|"photos/* directly"| photos
+    server -->|"read"| db
+    server -->|"static SPA bundle"| visitor
+```
+
+For more on the boundaries:
+
+- **[react-app](react-app/README.md)** — Vite + React 19 SPA. Built into static files, served by the server. No backend of its own.
+- **[server](server/README.md)** — Fastify + TypeBox + better-sqlite3. Owns `/api/v1` and serves the SPA bundle. OpenAPI doc at `/api/v1/docs`.
+- **[converter](converter/README.md)** — chokidar-watched intake daemon. EXIF extraction, configurable rendition ladder via sharp, optional Nominatim reverse-geocoding.
+
+Per-instance state — the SQLite DB, the `photos/` tree, `.env` — lives in a single directory outside the repo. Same code can run multiple instances; see [Setup](SETUP.md) for the multi-instance layout.
+
 ## Roadmap
 
 Active milestones on the way to 1.0, plus the far-out 2.0 direction. Each bullet links the GitHub milestone for live status.
 
-- [**1.0 — Pre-release audits**](https://github.com/vlumi/photo-diary/milestone/4) — test-coverage gap analysis, frontend security audit, end-to-end UI test suite, documentation overhaul, operator-script surface tidy.
+- [**0.19**](https://github.com/vlumi/photo-diary/milestone/22) — Pre-release polish: e2e UI test suite, this docs overhaul, subdivision-dataset story.
+- [**1.0**](https://github.com/vlumi/photo-diary/milestone/4) — Stamp once the audit + hardening work has aged out. Drop the JWT bearer-header transition (#650), CSP enable pass (#648), per-photo licence metadata (#263), other follow-ups from the security + coverage audits.
 - [**2.0 — Thin server, cloud-native direction**](https://github.com/vlumi/photo-diary/milestone/18) *(direction-setting, far out)* — originals leave the server for client-side / cold storage, the converter's sharp pipeline becomes a bundled local uploader, all DB ops route through the API, storage backends behind a vendor-agnostic interface. Likely diverges from today's self-hosted-monolith shape enough that it may end up being a different product line.
 
 ## Backlog

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,0 +1,13 @@
+# Screenshots
+
+Stub — to be filled in with screenshots from a live instance. Cover surfaces:
+
+- **Calendar view (year + month)** — heat-mapped grid, thumbnail clusters, the filter strip in action.
+- **Photo modal** — full-screen image, MetadataPanel open with EXIF / location / map.
+- **Stats** — General + Time + Gear cards, the stacked-area Evolution chart at month + year granularity.
+- **Admin dashboard (`/m/`)** — tile grid + audit count cards.
+- **Filter widget** — inline strip with chips, modal with per-category cards + faceted counts.
+
+Capture at 1440×900 (typical desktop) and a 414×896 mobile crop. Light + at least one of the dark themes per surface so the theming variety is visible.
+
+Until this page is populated, the [live examples](../README.md) at the top of the main README are the canonical "see it in action".

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,50 @@
+# Photo Diary E2E Suite
+
+End-to-end UI tests driven by [Playwright](https://playwright.dev) against a real server + built SPA + seeded SQLite DB. Sibling to the per-workspace unit tests; targets the regression-prone seams between SPA components, stores, and the API.
+
+## Requirements
+
+- [Node.js](https://nodejs.org) 22 or newer; npm 10+ recommended
+- Playwright browser binaries — installed via `npx playwright install chromium` after `npm install` from the repo root
+
+## Running
+
+```sh
+npm test                          # from e2e/ — runs the full suite once
+E2E_SKIP_BUILD=1 npm test         # skip the react-app build (faster on tight iteration)
+npm run seed                      # re-seed the .runtime/db.sqlite3 fixture manually
+npm run coverage                  # server-side v8 coverage report (e2e-only); writes to coverage/
+```
+
+`npm test` runs `playwright test`, which:
+
+1. Builds the SPA into `react-app/build/` (skip with `E2E_SKIP_BUILD=1`).
+2. Seeds a tight fixture (`e2e/.runtime/db.sqlite3`) — one admin user, one regular user, one gallery, one photo. Tables are wiped in place rather than the DB file replaced, so a reused server connection survives.
+3. Starts the server under `NODE_ENV=test` (the only config branch that honours `DB_OPTS`) against the seeded DB.
+4. Runs the six flow tests in `tests/` against the running stack.
+
+## Layout
+
+- `fixtures/data.ts` — the seed data (users, galleries, photos, access grants)
+- `seed.ts` — standalone seed script (wipes + reinserts via the server's public DB surface)
+- `playwright.config.ts` — runner config, webServer, coverage capture
+- `global-setup.ts` — runs once before any test: builds the SPA + invokes the seed
+- `tests/` — one `*.spec.ts` per regression seam:
+  - `auth.spec.ts` — login/logout cycle + session expiry → re-login modal
+  - `change-password.spec.ts` — correct current → new tokens; wrong current → inline error, session intact
+  - `spa-routing.spec.ts` — non-existent gallery → Empty view; language switch persists across reload
+- `tests/helpers.ts` — shared `login()` + `userMenuClick()` for the spec files
+
+## Conventions
+
+- Selectors prefer accessible roles + names (`getByRole("button", { name: "Login" })`) over `data-testid`. The translations file's `en` strings are stable enough; add `data-testid` only when role + name can't disambiguate.
+- Tests are sequential (Playwright `workers: 1`) — the server is stateful, and running in parallel would race on the shared SQLite file.
+- Each test that mutates persistent state (password change, gallery edit) restores the fixture at the end. Don't rely on `beforeEach` to re-seed mid-run — the suite is short, and adding a per-test seed would bloat wall clock significantly.
+
+## Coverage
+
+`npm run coverage` runs the suite under `NODE_V8_COVERAGE` and produces a c8 report against `server/**/*.ts`. Currently reports server-side coverage from e2e in isolation; unifying with the vitest baseline is tracked under [#658](https://github.com/vlumi/photo-diary/issues/658). Browser-side coverage (mapping minified bundle execution back to `src/*.tsx`) is filed under [#657](https://github.com/vlumi/photo-diary/issues/657).
+
+## Why a separate workspace
+
+The suite straddles `server` and `react-app`, so it doesn't naturally fit inside either. Putting it at the repo root as its own workspace also keeps Playwright + tsx out of the production dependency surface — the e2e suite is a developer tool, not part of any shipped artefact.


### PR DESCRIPTION
## Summary

Audit + restructure pass on the repo docs per #283. Modest moves — no big rewrites; existing content was already solid, just unevenly addressed across audiences.

## What changed

- **README**: \"Contents\" reorganised around three audiences (visitor / operator / contributor), each with its own link list. The body order matches: \"What it looks like\" → Features → Setup link → Photo pipeline → Architecture → Roadmap → Backlog → Version History.
- **Architecture diagram** (new): mermaid flowchart of the operator → inbox → converter → photos/db → server → nginx → visitor path. Replaces the older text-only \"Structure\" section. GitHub renders mermaid natively so it appears inline.
- **e2e/README.md** (new): documents the e2e workspace — requirements, running, layout, selector conventions, coverage. Sibling READMEs in `server/` / `react-app/` / `converter/` were already in place.
- **docs/screenshots.md** (stub): a brief on what to capture (calendar, photo modal, stats, admin dashboard, filter widget) so the operator can fill it in later. Linked from \"What it looks like\".
- **Roadmap bullet** for \"1.0 — Pre-release audits\" was stale (the audits are mostly closed) — replaced with the active 0.19 + 1.0 milestones.

## What I deliberately didn't do

- **Screenshots.** No way for me to take meaningful ones (you have the live galleries with real photos and the theme variety). \`docs/screenshots.md\` carries the brief; you fill the images when convenient.
- **Top-level rewrite.** The README's content was already accurate; the audit didn't surface anything stale enough to warrant a from-scratch rewrite.
- **\`CLAUDE.md\` cleanup.** It's already a symlink to \`AGENTS.md\` — no duplication to fix.

## Test plan

- [x] All three subtree \`typecheck\` + \`lint\` clean (touched no code).
- [ ] Eyeball the GitHub-rendered README on this PR's branch — mermaid block renders, the audience-banded TOC reads cleanly, intra-doc anchors resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)