### PR TITLE
Fix #663: /m no longer auto-opens the gallery edit modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Frontend
+
+- `/m` no longer auto-opens the gallery edit modal on host-scoped or single-gallery-editor instances. Earlier the dashboard short-circuited straight to `/m/g/<id>` (which mounts the edit modal), so every visit to Manage landed inside a modal-over-dashboard overlay. Now the dashboard renders normally; the gallery tile opens the modal on click. Closes #663.
+
 ### Operator
 
 - New `bin/instance.ts gc` subcommand reports `/opt/photo-diary/` code dirs that no scanned instance under `/var/photo-diary/` references, with sizes and the `rm -rf` commands the operator would run. Read-only — never deletes. Closes #653.

--- a/react-app/src/components/Manage/Dashboard.tsx
+++ b/react-app/src/components/Manage/Dashboard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Navigate, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import styled from "@emotion/styled";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
@@ -223,7 +223,7 @@ const galleryScopedTiles = (
 const Dashboard = (): React.ReactElement => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { isReady, isHostScoped, scopedGalleryIds } = useHostScope();
+  const { isHostScoped, scopedGalleryIds } = useHostScope();
   const user = useUserStore((s) => s.user);
   const isAdmin = !!user?.isAdmin();
   const auditQuery = useQuery({
@@ -234,20 +234,9 @@ const Dashboard = (): React.ReactElement => {
   });
   // Gallery-editor (non-admin) sees only the galleries they
   // can act on — same tile shape as host-scope, with editor
-  // grants driving the per-gallery set. A single editable
-  // gallery short-circuits to its edit page like the
-  // single-host-scope case does.
+  // grants driving the per-gallery set.
   const editorGalleries = user?.editorGalleries() ?? [];
   const editorScoped = !isAdmin && editorGalleries.length > 0;
-  // Single-gallery host scope is the common shape (one hostname →
-  // one gallery). Drop the operator straight into that gallery's
-  // edit page — the manage dashboard has nothing to add on top.
-  if (isReady && isHostScoped && scopedGalleryIds.length === 1) {
-    return <Navigate to={`/m/g/${scopedGalleryIds[0]}`} replace />;
-  }
-  if (editorScoped && !isHostScoped && editorGalleries.length === 1) {
-    return <Navigate to={`/m/g/${editorGalleries[0]}`} replace />;
-  }
   // Global admins (incl. host-scoped global admins) keep the
   // Access tile per-gallery; editors (no global admin) don't —
   // gallery ACL management stays out of their reach.


### PR DESCRIPTION
## Summary

Dashboard used to short-circuit to \`/m/g/<id>\` when the operator landed on a host-scoped instance with one gallery (or a gallery-editor with one editable gallery). \`/m/g/<id>\` is the routed-modal path — the edit modal mounts as soon as the URL matches. Net effect: every visit to \`/m\` landed inside a modal overlaying the dashboard. Reads as a permanent overlay, not an explicit edit action.

Drop both redirects ([Dashboard.tsx:245-250](react-app/src/components/Manage/Dashboard.tsx#L245-L250)). The dashboard's tile generator already narrows the tile set to scoped galleries, so a host-scoped operator still gets the right gallery's tile on \`/m\` — clicking the tile opens the edit modal as expected.

Closes #663.

## Test plan

- [ ] Visit \`/m\` on a single-gallery host-scoped instance — dashboard renders, no modal open.
- [ ] Click the gallery tile — gallery edit modal opens as before.
- [ ] Esc closes the modal, lands back on \`/m\` (not \`/m/g/<id>\`).
- [x] \`npm run typecheck\` + \`npm run lint\` + \`npm test\` clean in react-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)