### PR TITLE
Document cross-host SSO (#664)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -295,6 +295,12 @@ Gotchas:
 - The `/display/` and `/thumbnail/` aliases point at the **same** photo directory (the instance's `photos/`), so the bytes are shared across the per-gallery vhosts. That's intentional — galleries in the same instance are just different curations of the same photo pool.
 - `cdn` is a single meta value per instance, not per gallery. All the vhosts on one instance share it; usually that means setting `cdn` to one of the hostnames (say the primary one) and letting the others load images cross-origin from it.
 
+### UserMenu host switcher
+
+Authed visitors can hop between sibling hostnames without re-logging-in via the UserMenu's "Other hosts" section. Populate `instance_knownHosts` via `/m/instance` (or `./bin/meta.ts set instance_knownHosts '[{"hostname":"dailybw.example.com","label":"Daily B&W","isMain":true},{"hostname":"travel.example.com","label":"Travel"}]'`) — each click mints a 30 s SSO token bound to the target, redirects through its `/sso` endpoint, and lands on the equivalent path. The `isMain` flag tells the SPA which host to mint tokens from when the visitor lands on a non-primary host.
+
+The flow uses bare `SECRET` (not the per-user composite) so it works across separate instances too: if a deployment splits siblings into independent processes / DBs, set the **same** `SECRET` in every `.env` and the switcher works between them. For the operator's typical setup (one instance, multiple vhosts, one DB) no extra config is needed beyond the meta row.
+
 ### Operating an instance
 
 Common day-to-day operations after an instance is running:

--- a/server/README.md
+++ b/server/README.md
@@ -250,6 +250,8 @@ The authorization primitives live in [`server/lib/authorizer.ts`](lib/authorizer
 
 The **virtual-host scope** ([`server/lib/host-scope.ts`](lib/host-scope.ts)) layers on top: requests whose `Host` header matches a gallery's `hostname` regex are narrowed to that gallery's photos for both reads and writes. `requireUnscoped(request)` rejects cross-gallery admin operations on a bound hostname — `gh issue` examples in the top-level README.
 
+**Cross-host SSO** ([`server/lib/sso.ts`](lib/sso.ts)) lets an authed visitor jump between sibling hostnames without re-logging-in. The flow: SPA `POST /tokens/cross-host` with `{target, path}` → server validates `target` against `instance_knownHosts`, mints a 30 s HS256 JWT with the user id + path in the payload and the target hostname as the audience, returns `redirectUrl` → SPA navigates the browser there → target host's `GET /tokens/sso` verifies the token (audience, expiry), atomically claims the `jti` via the `sso_consumed_token` table (PRIMARY KEY collision = replay), sets the normal `pd_access` + `pd_refresh` cookies for the destination user, 302s to the supplied `path`. The path is leading-slash-only validated to prevent open-redirect. Tokens are signed with the bare `SECRET` (no per-user mix-in) so sibling instances sharing `SECRET` can validate each other's tokens; access JWTs use the per-user `${user.secret}${SECRET}` composite so a leaked SSO token can't be turned into a long-lived access token.
+
 ### RESTful resources
 
 The required tier is listed in brackets at the end of each route. From least to most privileged:
@@ -273,6 +275,8 @@ A bracketed `[unscoped]` suffix means the route is also rejected on hostname-bou
   - `GET` — Verify the current token **[any]**
   - `DELETE` — Logout the current session **[any]**
   - `DELETE ../:userId` — Force-logout every session for a user **[admin]**
+  - `POST ../cross-host` — Mint a one-shot SSO token bound to a target hostname, for the UserMenu host switcher **[user]**
+  - `GET ../sso` — Consume an SSO token on the target host, set normal auth cookies, 302 to the in-app path **[any]**
 - `/users` **[unscoped]**
   - `GET` — List users **[admin]**
   - `POST` — Create a user **[admin]**


### PR DESCRIPTION
## Summary

Reference-docs follow-up to #664. The SSO endpoints + the multi-instance shared-SECRET pattern weren't documented anywhere operator-facing.

- \`server/README.md\`: add \`POST /tokens/cross-host\` + \`GET /tokens/sso\` to the route list; add one paragraph describing the flow (mint → audience-bound JWT → \`/sso\` consumes + atomic \`jti\` claim → cookies + 302), and why sharing \`SECRET\` across siblings is safe (access JWTs use the per-user composite).
- \`SETUP.md\`: new \"UserMenu host switcher\" subsection in the per-gallery vhost section. Covers populating \`instance_knownHosts\` via \`/m/instance\` or \`./bin/meta.ts\`, what \`isMain\` controls, and the shared-\`SECRET\` requirement for the separate-instances case.

No source changes.

## Test plan

- [x] No code touched; CI is docs-only.
- [ ] Skim rendered markdown on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)