### PR TITLE
Smooth EvolutionChart stacked bands to match year-month chart

### DIFF
--- a/react-app/src/components/Gallery/Stats/EvolutionChart.tsx
+++ b/react-app/src/components/Gallery/Stats/EvolutionChart.tsx
@@ -347,7 +347,7 @@ const EvolutionChart = ({
       borderColor: bandStroke,
       backgroundColor: colour,
       fill: true,
-      tension: 0,
+      tension: 0.4,
       pointRadius: 0,
       pointHoverRadius: 3,
       borderWidth: 0.5,


### PR DESCRIPTION
## Summary

The year-month stacked-line chart uses \`lineTension: 0.4\` for smooth curves through each year's band. The EvolutionChart (the trend modal that opens for trendable categories) was using \`tension: 0\` — hard polyline angles, visually inconsistent with its sibling.

One-line change in [EvolutionChart.tsx:350](react-app/src/components/Gallery/Stats/EvolutionChart.tsx#L350): \`0\` → \`0.4\` so the two stacked-area charts share an aesthetic.

## Test plan

- [x] typecheck + lint + tests clean
- [x] Local smoke: open the Stats page, click a trendable category (e.g. \"Country\" or \"Year-Month\" itself), confirm the EvolutionChart bands now have smooth curves matching the year-month inline chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)