### PR TITLE
Stats: inline time-category lists follow the chart's natural order

### DIFF
--- a/react-app/src/components/Gallery/Stats/Table.tsx
+++ b/react-app/src/components/Gallery/Stats/Table.tsx
@@ -251,18 +251,21 @@ const Table = ({
   const fullTable = category.table;
   const isInline = limit !== undefined;
   const shouldCap = isInline && fullTable.length > limit;
-  // Inline view always reads as top-by-count — even short categories
-  // (weekday's 7 rows, month's 12) sort more usefully by frequency
-  // than by their chronological default. The modal then offers "By
-  // value" as the alternate reading. The exposure modal's natural
-  // numeric sort and the gear modal's alphabetical sort are both
-  // handled here under `sortMode === "value"`:
-  //   - `valueSortByLabel` (gear, people-or-place) → alpha sort on
-  //     the display column (which lives at `row[category.key]`).
-  //   - Otherwise → the order from collectTopics (exposure numeric,
-  //     time chronological).
+  // Inline view defaults to top-by-count so the 10-row preview reads
+  // as "the headlines" for categories with no inherent ordering (gear,
+  // people, country, etc.). Time categories (year-month / year /
+  // month / weekday / hour) opt out via `naturalInlineOrder` — their
+  // chart axis is the value, and a by-count list would visually
+  // contradict the chart sitting above it. The modal still defaults
+  // to "By count" but offers "By value" as the alternate reading.
+  // `valueSortByLabel` (gear, people-or-place) → alpha sort on the
+  // display column (which lives at `row[category.key]`). Otherwise →
+  // the order from collectTopics (exposure numeric, time
+  // chronological).
+  const forceCount =
+    sortMode === "count" || (isInline && !category.naturalInlineOrder);
   const sortedTable = (() => {
-    if (sortMode === "count" || isInline) {
+    if (forceCount) {
       return [...fullTable].sort(
         (a, b) => Number(b._count ?? 0) - Number(a._count ?? 0)
       );

--- a/react-app/src/lib/stats.tsx
+++ b/react-app/src/lib/stats.tsx
@@ -107,9 +107,16 @@ export interface StatsCategory {
   // alphabetical (the alpha case needs `valueSortByLabel` below
   // because collectTopics pre-sorts gear/people by count-desc).
   valueSortable?: boolean;
-  // "By value" re-sorts by display label (alphabetical) rather than
-  // trusting the natural order.
+  // "By value" re-sorts by display column label (alphabetical)
+  // rather than trusting the natural order.
   valueSortByLabel?: boolean;
+  // Inline card preserves the comparator's natural order instead of
+  // re-sorting to count-desc. Set on the time categories so the
+  // 10-row preview matches the chart's x-axis (chronological /
+  // cyclical) — without it, year-month / year / month / weekday /
+  // hour read inline as a top-N-by-count list that doesn't line up
+  // with the line / polar chart above it.
+  naturalInlineOrder?: boolean;
 }
 // Expanded Summary view (SummaryModal). Four sub-trees:
 // period (when), peaks (how concentrated), variety (how varied),
@@ -917,6 +924,7 @@ const collectTopics = (
       key: "year-month",
       title: t("stats-category-year-month"),
       valueSortable: true,
+      naturalInlineOrder: true,
       charts: [{ type: "line", data, options: chartOptions.line }],
       tableColumns: [
         { title: "rank", align: "right", header: true },
@@ -954,6 +962,7 @@ const collectTopics = (
       key: "year",
       title: t("stats-category-year"),
       valueSortable: true,
+      naturalInlineOrder: true,
       charts: [
         { type: "doughnut", data, options: chartOptions.doughnut },
         { type: "horizontal-bar", data, options: chartOptions.bar },
@@ -992,6 +1001,7 @@ const collectTopics = (
       key: "month",
       title: t("stats-category-month"),
       valueSortable: true,
+      naturalInlineOrder: true,
       charts: [
         { type: "polar", data, options: chartOptions.polar },
         { type: "horizontal-bar", data, options: chartOptions.bar },
@@ -1033,6 +1043,7 @@ const collectTopics = (
       key: "weekday",
       title: t("stats-category-weekday"),
       valueSortable: true,
+      naturalInlineOrder: true,
       charts: [
         { type: "polar", data, options: chartOptions.polar },
         { type: "horizontal-bar", data, options: chartOptions.bar },
@@ -1071,6 +1082,7 @@ const collectTopics = (
       key: "hour",
       title: t("stats-category-hour"),
       valueSortable: true,
+      naturalInlineOrder: true,
       charts: [
         { type: "polar", data, options: chartOptions.polar },
         { type: "horizontal-bar", data, options: chartOptions.bar },


### PR DESCRIPTION
## Summary

The inline 10-row table on a category card was force-sorting to count-desc regardless of how the topic data was prepared. For the five time categories (year-month, year, month, weekday, hour), the chart sitting directly above the table is ordered by *value* (chronological / cyclical), so a count-sorted list underneath read as an inconsistency — the chart's leftmost bar / band wasn't the table's first row.

Adds a \`naturalInlineOrder\` flag on \`StatsCategory\`, set on the five time collectors. When set, \`Table.tsx\` skips the inline count-override and lets the comparator's natural order through. Direction follows the existing comparators:

| Category | Direction |
|---|---|
| year-month | desc (newest first) |
| year | desc (newest first) |
| month | asc (Jan → Dec) |
| weekday | asc (Mon → Sun, locale-offset) |
| hour | asc (00 → 23) |

Other categories (gear, people, country) keep the inline count-by-default behaviour — their charts re-sort by count too, so there's no inconsistency to fix.

The modal expanded view is unchanged: it still defaults to \"By count\" with \"By value\" as the toggle, which matches the modal chart's re-sort.

## Test plan

- [x] typecheck + lint + 999 tests pass
- [x] Local smoke: open Gallery Stats, verify the five time categories' inline tables now match the chart axis order. Verify gear / people / country inline tables are unchanged (still by count). Open a time category's modal: \"By count\" is the default, \"By value\" toggle still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)