### PR TITLE
Sync SPA session state on boot + across tabs

### DIFF
--- a/e2e/tests/change-password.spec.ts
+++ b/e2e/tests/change-password.spec.ts
@@ -40,9 +40,16 @@ test.describe("change password", () => {
 
     // Subsequent authed call still works under the new session. The
     // /api/v1/tokens GET keep-alive returns 200 when authed, 401
-    // otherwise.
-    const keepalive = await page.request.get("/api/v1/tokens");
-    expect(keepalive.ok()).toBe(true);
+    // otherwise. Routed through the browser via page.evaluate rather
+    // than page.request — the cookies carry the Secure flag, and
+    // Playwright's Node-side APIRequestContext (page.request) refuses
+    // to attach Secure cookies on plain HTTP, while chromium treats
+    // 127.0.0.1 as a secure context and sends them.
+    const keepaliveOk = await page.evaluate(async () => {
+      const r = await fetch("/api/v1/tokens", { credentials: "include" });
+      return r.ok;
+    });
+    expect(keepaliveOk).toBe(true);
 
     // Restore the fixture password so the next test / run starts
     // from a known baseline. The current session (rotated above) is

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -79,12 +79,15 @@ const GlobalStats = React.lazy(() => import("./components/GlobalStats"));
 
 import config from "./lib/config";
 import metaService from "./services/meta";
+import tokenService from "./services/tokens";
+import UserModel from "./models/UserModel";
 import theme from "./lib/theme";
 import {
   hadStoredLangAtBoot,
   useBetaStore,
   useLangStore,
   useThemePreferenceStore,
+  useUserStore,
 } from "./stores";
 import { BETA_FEATURES, type BetaFeature, type BetaMode } from "./stores/beta";
 
@@ -219,6 +222,40 @@ const App = (): React.ReactElement => {
     langAppliedRef.current = true;
     setLang(meta.defaultLanguage);
   }, [meta?.defaultLanguage, setLang]);
+
+  // Boot-time session reconcile. The user store rehydrates from
+  // localStorage synchronously at module load, so the UI may render
+  // a stale identity on first paint — e.g. a sibling tab replaced
+  // the shared cookie+localStorage out from under this tab, or the
+  // admin / editor grants changed in the DB since the cookie was
+  // minted. One GET /tokens with credentials reconciles both:
+  // server's view wins; 401 lets api.ts's onResponse handler run
+  // the refresh-or-clear path. Guarded by a ref so React strict-
+  // mode's double-invocation in dev doesn't fire two requests.
+  const storedUser = useUserStore((s) => s.user);
+  const setUser = useUserStore((s) => s.setUser);
+  const verifiedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (verifiedRef.current) return;
+    if (!storedUser) return;
+    verifiedRef.current = true;
+    tokenService
+      .verify()
+      .then((session) => {
+        const next = UserModel({
+          id: session.id,
+          isAdmin: session.isAdmin,
+          editorGalleries: session.editorGalleries,
+        });
+        if (next.toJson() === storedUser.toJson()) return;
+        window.localStorage.setItem("user", next.toJson());
+        setUser(next);
+      })
+      .catch(() => {
+        // 401 / 403 — api.ts's onResponse handler already cleared
+        // local auth + opened the login modal. Nothing extra here.
+      });
+  }, [storedUser, setUser]);
 
   const themePreference = useThemePreferenceStore((s) => s.preference);
   // Until `/meta` resolves, fall back to App.css's neutral defaults

--- a/react-app/src/lib/api-schema.ts
+++ b/react-app/src/lib/api-schema.ts
@@ -161,7 +161,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Verify token (keep-alive) */
+        /** Verify token + return current session identity */
         get: {
             parameters: {
                 query?: never;
@@ -176,7 +176,13 @@ export interface paths {
                     headers: {
                         [name: string]: unknown;
                     };
-                    content?: never;
+                    content: {
+                        "application/json": {
+                            id: string;
+                            isAdmin: boolean;
+                            editorGalleries: string[];
+                        };
+                    };
                 };
             };
         };

--- a/react-app/src/services/tokens.ts
+++ b/react-app/src/services/tokens.ts
@@ -3,6 +3,13 @@ import api, { unwrap } from "../lib/api";
 const login = async (id: string, password: string) =>
   unwrap(api.POST("/api/v1/tokens", { body: { id, password } }));
 
+// Returns the cookie's current identity ({id, isAdmin,
+// editorGalleries}). The SPA calls this on boot to reconcile the
+// localStorage-rehydrated user against the actual session — without
+// it, a sibling tab's login (or an admin grant change in the DB)
+// leaves this tab showing a stale identity until the next 401.
+const verify = async () => unwrap(api.GET("/api/v1/tokens", {}));
+
 // Logout takes no body — the server reads the refresh cookie to
 // identify which session row to revoke and clears the auth cookies.
 const logout = async () => unwrap(api.DELETE("/api/v1/tokens", {}));
@@ -17,4 +24,4 @@ const crossHost = async (target: string, path?: string) =>
     })
   );
 
-export default { login, logout, crossHost };
+export default { login, verify, logout, crossHost };

--- a/react-app/src/stores/user.ts
+++ b/react-app/src/stores/user.ts
@@ -29,3 +29,24 @@ export const useUserStore = create<UserState>((set) => ({
   user: rehydrate(),
   setUser: (user) => set({ user }),
 }));
+
+// Cross-tab sync: when another tab logs in / out / refreshes, the
+// shared localStorage["user"] entry changes but Zustand stays
+// frozen at its initial rehydrate. Without this, Tab A keeps
+// showing user A's identity even though the cookie has been
+// replaced with B's — and admin pages then fail with the generic
+// 403 the user has no path to recover from short of re-login.
+if (typeof window !== "undefined" && window.addEventListener) {
+  window.addEventListener("storage", (e) => {
+    if (e.key !== "user" || e.storageArea !== window.localStorage) return;
+    if (e.newValue === null) {
+      useUserStore.getState().setUser(undefined);
+      return;
+    }
+    try {
+      useUserStore.getState().setUser(UserModel(JSON.parse(e.newValue)));
+    } catch {
+      // Other tab wrote garbage — leave this tab's user as-is.
+    }
+  });
+}

--- a/server/controllers/tokens-v1.ts
+++ b/server/controllers/tokens-v1.ts
@@ -2,6 +2,7 @@ import { Type } from "typebox";
 import { type FastifyPluginAsyncTypebox } from "@fastify/type-provider-typebox";
 
 import config from "../lib/config/index.js";
+import CONST from "../lib/constants.js";
 import db from "../db/index.js";
 import {
   AccessError,
@@ -149,9 +150,29 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
    */
   fastify.get(
     "/",
-    { schema: { tags: TAGS, summary: "Verify token (keep-alive)" } },
-    async (_request, reply) => {
-      reply.status(200).send();
+    {
+      schema: {
+        tags: TAGS,
+        summary: "Verify token + return current session identity",
+        response: { 200: SessionResponse },
+      },
+    },
+    async (request, reply) => {
+      // tokenFilter has already verified the cookie; an anonymous
+      // request lands on the guest user. The SPA uses this on boot
+      // to reconcile its localStorage-rehydrated view against the
+      // cookie's actual identity — needed when a sibling tab's
+      // login has replaced the shared cookie+localStorage out from
+      // under this tab, or when admin / editor grants changed in
+      // the DB since the cookie was minted.
+      if (request.user.id === CONST.GUEST_USER) {
+        throw new InvalidTokenError();
+      }
+      const isAdmin = await resolveIsAdmin(request.user.id);
+      const editorGalleries = await authorizer.loadEditorGalleries(
+        request.user.id
+      );
+      reply.status(200).send({ id: request.user.id, isAdmin, editorGalleries });
     }
   );
 

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -236,13 +236,39 @@
     },
     "/api/v1/tokens": {
       "get": {
-        "summary": "Verify token (keep-alive)",
+        "summary": "Verify token + return current session identity",
         "tags": [
           "tokens"
         ],
         "responses": {
           "200": {
-            "description": "Default Response"
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "isAdmin",
+                    "editorGalleries"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "isAdmin": {
+                      "type": "boolean"
+                    },
+                    "editorGalleries": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       },

--- a/server/tests/api/tokens.test.ts
+++ b/server/tests/api/tokens.test.ts
@@ -135,16 +135,29 @@ describe("Login rate limit", () => {
 });
 
 describe("Keep-alive", () => {
-  let token: string | undefined = undefined;
-  beforeEach(async () => {
-    token = await loginUser(api, "admin");
-  });
-
-  test("Success", async () => {
-    await api
+  test("Admin: returns identity + isAdmin: true + editorGalleries", async () => {
+    const token = await loginUser(api, "admin");
+    const res = await api
       .get("/api/v1/tokens")
       .set("Cookie", `pd_access=${token}`)
       .expect(200);
+    expect(res.body).toEqual({
+      id: "admin",
+      isAdmin: true,
+      editorGalleries: expect.any(Array),
+    });
+  });
+  test("Non-admin: returns identity + isAdmin: false", async () => {
+    const token = await loginUser(api, "gallery1user");
+    const res = await api
+      .get("/api/v1/tokens")
+      .set("Cookie", `pd_access=${token}`)
+      .expect(200);
+    expect(res.body.id).toBe("gallery1user");
+    expect(res.body.isAdmin).toBe(false);
+  });
+  test("Guest: 401 so the SPA can clear stale localStorage", async () => {
+    await api.get("/api/v1/tokens").expect(401);
   });
 });
 


### PR DESCRIPTION
## Symptom

Reported: "I appear to be logged in to the site, but trying to access certain parts (like operations on manage page) fail with an unspecific error. Logging out and in again makes it work." Follow-up clarification: the underlying state is the SPA showing logged-in while the server treats the request as `:guest` — so partial pages render under guest-visible data (the galleries `:guest` has access to) alongside a logged-in UserMenu, and any user-tier endpoint returns guest-shaped data or an error.

## Root cause

The user store rehydrates id / isAdmin / editorGalleries from \`localStorage\` synchronously at module load, and the UI renders the logged-in state from that view. Re-sync only fires on a 401 → refresh path. Anything that puts localStorage out of step with the actual cookie's identity leaves the UI showing a phantom identity:

- A sibling tab logged out + logged in as a different user. The shared cookie is now the new user's; localStorage was rewritten to the new identity; this tab's running Zustand store still holds the old identity.
- An admin grant flipped in the DB since the cookie was minted (or the local view was stale from an earlier session as someone who used to be admin).
- A long-running tab where the SPA never had a reason to re-verify the session.

Admin-only endpoints then return 403 (or, in the all-cookies-gone case, the server treats every request as `:guest` and the SPA renders a strange hybrid: guest-visible galleries under a logged-in UserMenu), and the only path to recovery is manual logout + login. Both shapes share the same root cause — the SPA never reconciles its rehydrated view against what the cookie actually represents.

## Fix

Two complementary changes:

1. **\`GET /api/v1/tokens\`** now returns the cookie's current identity (\`{ id, isAdmin, editorGalleries }\`) instead of a bare 200. Same \`SessionResponse\` shape as login and refresh. On boot, \`App.tsx\` calls \`tokenService.verify()\` once after rehydrate; if the response disagrees with the local view, the local view is replaced. Guest hits the endpoint → 401, which routes through the existing \`api.ts\` \`onResponse\` handler (refresh-or-clear + login modal).
2. **The user store** now registers a window \`storage\` event listener that mirrors external \`localStorage\` writes into this tab's Zustand state. When Tab B logs in / out, Tab A's store reflects the change instead of staying frozen.

## What's not changed

- The 403 response path on admin endpoints stays as-is (still surfaces as the typed error). With (1) reconciling on boot and (2) reconciling cross-tab, the divergence window should be small enough that the residual 403 case is the genuinely-not-admin case where the user shouldn't be there anyway.
- Refresh / login / logout flows are untouched — they already write to localStorage correctly. The new listener picks those writes up across tabs.

## Test plan

- [x] Server: 19/19 in tokens.test.ts (3 new for the GET /tokens body shape — admin, non-admin, guest).
- [x] React: 999/999, typecheck + lint clean on both subtrees.
- [x] OpenAPI dump + \`api-schema.ts\` regenerated.
- [ ] Manual repro of the symptom: open two windows, log out + log in as a different user in window B, click around in window A. Window A should sync to the new identity instead of staying on the old one.
- [ ] Boot path: stash a non-admin user in localStorage but no auth cookies (clear cookies via devtools), reload — login modal should open instead of admin tiles rendering on a stale view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
