### PR TITLE
Release 1.0.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,27 +2,43 @@
 
 ## [Unreleased]
 
+## [1.0.0-rc.1] - 2026-07-01
+
+Release candidate for 1.0. Cumulative 0.18 → 1.0 changes: end of the JWT-cookie transition, CSP enable pass, cross-host SSO for the UserMenu virtual-host switcher, Playwright e2e suite, docs overhaul, session-state reconcile on boot + across tabs, and a review-driven cleanup pass. Feature freeze holds through 1.0; rc.2+ ships only if prod verification surfaces regressions.
+
 ### Operator
 
 - **Breaking:** end of the JWT-cookie transition window opened in 0.18. The server no longer accepts `Authorization: bearer` headers, no longer echoes `accessToken` / `refreshToken` in any response body, and `POST /api/v1/tokens/refresh` requires the `pd_refresh` cookie (the body field is gone). Pre-0.18 SPA bundles cached in any browser will need a one-time hard reload to pick up the cookie path. New SPAs handle the cookie flow entirely. Closes #650.
 - Content-Security-Policy headers are now sent on every response. Directive set tuned to what the SPA actually needs: `default-src 'self'`, `style-src 'self' 'unsafe-inline'` (Emotion's runtime style injection), `img-src 'self' data: https:` (covers operator-set `instance_cdn` URLs + OSM tile servers without per-request header computation), `frame-ancestors 'none'`, `object-src 'none'`. Closes #648.
 - New `bin/instance.ts gc` subcommand reports `/opt/photo-diary/` code dirs that no scanned instance under `/var/photo-diary/` references, with sizes and the `rm -rf` commands the operator would run. Read-only — never deletes. Closes #653.
-- Cross-host SSO endpoints for the upcoming virtual-host switcher (#664, server side): `POST /api/v1/tokens/cross-host` mints a short-lived HMAC-signed token; `GET /api/v1/tokens/sso` consumes it on the target host, sets normal auth cookies, and 302s to the in-app redirect path. Signed with the existing `SECRET` (without the per-user mix-in, so it doesn't share signing keys with access JWTs); multi-instance deploys share `SECRET` across siblings to enable the feature. The mint endpoint validates the target against `instance_knownHosts` — a new JSON-shaped meta key carrying the list of `{hostname, label, isMain}` entries the SPA's switcher will render — so tokens can't be minted for arbitrary hosts. Client side lands in #664 follow-up.
+- Cross-host SSO endpoints for the virtual-host switcher (#664, server side): `POST /api/v1/tokens/cross-host` mints a short-lived HMAC-signed token; `GET /api/v1/tokens/sso` consumes it on the target host, sets normal auth cookies, and 302s to the in-app redirect path. Signed with the existing `SECRET` (without the per-user mix-in, so it doesn't share signing keys with access JWTs); multi-instance deploys share `SECRET` across siblings to enable the feature. The mint endpoint validates the target against `instance_knownHosts` — a new JSON-shaped meta key carrying the list of `{hostname, label, isMain}` entries the SPA's switcher will render — so tokens can't be minted for arbitrary hosts.
+- Creating a gallery / user / group with an id that already exists now returns 409 with an "already exists" message instead of a 500 surfacing the raw SQLite UNIQUE constraint text. Closes #672.
+- `POST /api/v1/galleries/_order` now respects the virtual-host scope like its sibling admin-mutation routes (was the only cross-gallery admin mutation missing the guard). Closes #671.
 
 ### Frontend
 
 - `/m` no longer auto-opens the gallery edit modal on host-scoped or single-gallery-editor instances. Earlier the dashboard short-circuited straight to `/m/g/<id>` (which mounts the edit modal), so every visit to Manage landed inside a modal-over-dashboard overlay. Now the dashboard renders normally; the gallery tile opens the modal on click. Closes #663.
 - UserMenu now offers a virtual-host switcher (#664). Authed users see an "Other hosts" section listing the operator-curated `instance_knownHosts`; clicking a host hits the cross-host SSO mint, redirects via the target host's `/sso` endpoint, and lands on the equivalent path (best-effort: `/g/<id>/<y>/<m>` swaps the gallery for the target's default; admin routes collapse to `/m`). A new section in `/m/instance` lets admins edit the host list (hostname / label / isMain). Closes #664.
+- SPA session state now reconciles against the server on boot and across tabs. Previously a stale localStorage-vs-cookie divergence (sibling-tab login, admin flag flipped in the DB, or all cookies expired while the tab was rehydrating) left the UI showing a phantom identity where admin pages 403'd with a generic notice and only manual logout+login recovered. `GET /api/v1/tokens` now returns `{id, isAdmin, editorGalleries}` and App calls it once on mount; the user store also listens for cross-tab `storage` events so Tab A follows Tab B's login. Closes #677.
+- Gallery names / descriptions containing an ampersand no longer render double-escaped in the gallery-list heading — dropped a redundant hand-rolled `escapeHTML` that layered on top of JSX's own text-node escaping. Closes #671.
+- Title-bar map query now includes `numericRanges` so focal-length / aperture / ISO filters actually affect the map pins (and its queryKey matches Month's for TanStack dedup). Closes #671.
+- Inline category tables for year-month / year / month / weekday / hour now follow the chart's natural chronological or cyclical order instead of being force-sorted by count; the expanded modal still defaults to "By count" with the toggle. Closes #676.
+- EvolutionChart stacked bands render with smooth curves matching the year-month inline chart. Closes #675.
 
 ### Developer
 
 - Playwright e2e test suite under `e2e/` covers the regression-prone seams between SPA components, stores, and the API: login/logout cycle, session expiry → login modal, change-password (right + wrong current), non-existent gallery, and language persistence. Wired into CI as a separate workflow job. Closes #261.
 - `npm run coverage --workspace=e2e` produces a v8 coverage report of the server code exercised by the e2e suite (`e2e/coverage/`). Sits alongside the existing per-workspace vitest coverage; unifying the two reports tracks under a follow-up (the timing-sensitive vitest tests get flaky under raw v8 instrumentation). Closes #656.
+- Server test-suite flakiness reduced: cross-file module-state bleed (`failedLogins` rate-limiter Map, `secrets` cache + reload timer) is now cleared per fixture reset, and `retry: 1` added as tolerance. Closes the small-N transient failures; the residual "catastrophic cascade" mode where a hook hangs for 10 s and 30+ dependent tests inherit the failure tracks as #674.
+- Full outdated-dep sweep: fastify 5.9, sharp 0.35.2, typebox 1.3, vite 8.1, framer-motion 12.42, i18next 26.3.4, playwright 1.61.1, react-router-dom 7.18.1, @tanstack/react-query 5.101.2, plus eslint 10.6 on server / converter and typescript-eslint 8.62; @types/node bumped 25 → 26 to match the Node 26 CI + runtime.
+- Review-driven cleanup pass across 7 lenses (layout, dead-code, comments, docs, types-errors, react patterns, server surface). Bugfixes above; also stripped ~130 `#NNN` ticket refs from source comments (two of which shipped in the public OpenAPI dump); doc drift caught up (server/README.md route inventory, DB-driver docs, theme list, per-instance script list); dead-code deletions across react-app + server. Closes #671.
 
 ### Docs
 
 - Top-level `README.md` reorganized around the three audiences (visitor / operator / contributor) — Contents lists per-lane entry points, "What it looks like" surfaces the live-example links + a stub `docs/screenshots.md`, "Architecture" carries a mermaid diagram of the converter / server / SPA boundary. New `e2e/README.md` documents the e2e workspace. Closes #283.
 - `docs/screenshots/` now ships year-calendar / month-calendar / photo-modal / stats captures from a fixture under `docs/fixtures/screenshots/`. Seed + capture scripts are reproducible (`npx tsx seed.mjs && npx tsx capture.mjs`); the 7 placeholder photos can be swapped for AI-generated replacements per `docs/fixtures/screenshots/PROMPTS.md`. Closes #661.
+- Cross-host SSO endpoints and the multi-instance shared-`SECRET` deployment pattern documented in server/README.md and SETUP.md.
+- `react-app` eslint's pinned-to-major-9 constraint (until `eslint-plugin-react` ships an eslint-10 peer range) documented in `react-app/eslint.config.js` and AGENTS.md's Footguns.
 
 ## [0.18.0] - 2026-06-19
 
@@ -672,6 +688,7 @@
 
 ## Initial commit - 2020-07-04
 
+[1.0.0-rc.1]: https://github.com/vlumi/photo-diary/compare/v0.18.0...v1.0.0-rc.1
 [0.18.0]: https://github.com/vlumi/photo-diary/compare/v0.17.1...v0.18.0
 [0.17.1]: https://github.com/vlumi/photo-diary/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/vlumi/photo-diary/compare/v0.16.0...v0.17.0

--- a/README.md
+++ b/README.md
@@ -171,8 +171,7 @@ Per-instance state — the SQLite DB, the `photos/` tree, `.env` — lives in a 
 
 Active milestones on the way to 1.0, plus the far-out 2.0 direction. Each bullet links the GitHub milestone for live status.
 
-- [**0.19**](https://github.com/vlumi/photo-diary/milestone/22) — Pre-release polish: e2e UI test suite, this docs overhaul, subdivision-dataset story.
-- [**1.0**](https://github.com/vlumi/photo-diary/milestone/4) — Stamp once the audit + hardening work has aged out. Drop the JWT bearer-header transition (#650), CSP enable pass (#648), per-photo licence metadata (#263), other follow-ups from the security + coverage audits.
+- [**1.0**](https://github.com/vlumi/photo-diary/milestone/4) — Soak the accumulated security + polish work in prod, then stamp. `1.0.0-rc.1` cut 2026-07-01; feature freeze holds until 1.0 (bugfix-only, rc.2+ ships only if verification surfaces regressions).
 - [**2.0 — Thin server, cloud-native direction**](https://github.com/vlumi/photo-diary/milestone/18) *(direction-setting, far out)* — originals leave the server for client-side / cold storage, the converter's sharp pipeline becomes a bundled local uploader, all DB ops route through the API, storage backends behind a vendor-agnostic interface. Likely diverges from today's self-hosted-monolith shape enough that it may end up being a different product line.
 
 ## Backlog
@@ -201,5 +200,6 @@ Third structural take on a long-running personal photo-gallery side project — 
 - **0.16** (Jun 2026) — Filter & viewing UX polish: redesigned filter widget (inline strip + per-category modal cards with faceted counts), continuous-variable range filters, stacked-area evolution chart, virtual-gallery edit page + hybrid-source admin UI, persistent map modal.
 - **0.17** (Jun 2026) — Admin UI shift to layered modals + Section card primitive; per-photo visibility + editor-tier admin actions on `/g/`; `/m/instance` page with runtime-overridable `meta` defaults; configurable rendition ladder + collapsed `photos/display/<maxDim>/` layout; `/m/photos` filters move into a modal; Stats Evolution adds `weekday` and `hour`; Finnish geocoding cleanup (state-code lvl fallthrough + script-rule address blob filter).
 - **0.18** (Jun 2026) — Cleanup + observability: `meta` table is the only source for SPA runtime defaults (no `.env` fallback); `/m/operations` admin page surfaces converter activity, pending queues, and failures; tidied `bin/photo.ts` surface; vitest coverage wired; frontend security audit pass; auth tokens move from localStorage to HttpOnly cookies.
+- **1.0-rc.1** (Jul 2026) — Release candidate for 1.0. End of the JWT-cookie transition, CSP enable pass, cross-host SSO for the UserMenu virtual-host switcher, Playwright e2e suite, docs overhaul, session-state reconcile on boot + across tabs, review-driven cleanup pass. Feature freeze until 1.0.
 
-See the [Roadmap](#roadmap) for what's in flight after 0.18.
+See the [Roadmap](#roadmap) for what's in flight after 1.0-rc.1.

--- a/SETUP.md
+++ b/SETUP.md
@@ -79,13 +79,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  0.18.0/                               #   so different instances can run different versions
+  1.0.0-rc.1/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/0.18.0      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/1.0.0-rc.1      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  thumbnail/        # display/<maxDim>/ subdirs auto-created on intake
@@ -112,7 +112,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=0.18.0
+V=1.0.0-rc.1
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -127,7 +127,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/0.18.0/bin/instance.ts /var/photo-diary/dailybw
+/opt/photo-diary/1.0.0-rc.1/bin/instance.ts /var/photo-diary/dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -159,7 +159,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/0.18.0/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
+/opt/photo-diary/1.0.0-rc.1/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                                # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                                     # migration runner applies any schema bumps
@@ -176,7 +176,7 @@ The DB backup is named `db.sqlite3.pre-<new-version>` — a plain file copy that
 The multi-instance layout never garbage-collects old `/opt/photo-diary/<version>/` directories — each one is 400+ MB (`sharp`, `better-sqlite3`, etc. in `node_modules`), so after a dozen releases they add up. `bin/instance.ts gc` scans the conventional layout and reports versions that no scanned instance references:
 
 ```sh
-/opt/photo-diary/0.18.0/bin/instance.ts gc
+/opt/photo-diary/1.0.0-rc.1/bin/instance.ts gc
 ```
 
 It walks `/var/photo-diary/*/code` symlinks to collect what's in use, then prints anything under `/opt/photo-diary/` that isn't in that set, along with sizes and the `rm -rf` commands you would run. It never deletes — an operator with non-conventional instance layouts may have instances outside `/var/photo-diary/` that reference these dirs, so the actual `rm` is left to you after reviewing. Override the scan roots with `--code-root` / `--instances-root` if your layout differs.

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1"
   },
-  "version": "0.18.0"
+  "version": "1.0.0-rc.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "0.18.0",
+  "version": "1.0.0-rc.1",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -71,5 +71,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.18.0"
+  "version": "1.0.0-rc.1"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "0.18.0"
+    "version": "1.0.0-rc.1"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -60,5 +60,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "0.18.0"
+  "version": "1.0.0-rc.1"
 }


### PR DESCRIPTION
## Summary

Release candidate for 1.0. Cuts the accumulated 0.18 → 1.0 work into a soakable checkpoint; feature freeze holds until 1.0 (rc.2+ ships only if prod verification surfaces regressions). Skipping the 0.19 label — the work batched under it ships here directly.

## Release step touchpoints (per AGENTS.md)

- Version bumped 0.18.0 → 1.0.0-rc.1 in root, server, react-app, converter \`package.json\`.
- \`server/openapi.json\` regenerated (\`info.version\` picks up the bump). \`react-app/src/lib/api-schema.ts\` re-codegen'd and is unchanged — no route or schema deltas, only the info string.
- \`CHANGELOG.md\`: \`[Unreleased]\` renamed to \`[1.0.0-rc.1] - 2026-07-01\`, fresh empty \`[Unreleased]\` above, diff-link at the footer. Added bullets for the PRs that landed after the prior \`[Unreleased]\` freeze (session sync #677, EvolutionChart smoothing #675, inline-order stats #676, duplicate-id 409 #672, test flakiness reduction #673, review cleanup #671, dep bump wave #679, doc #680). Section prefaced with a one-paragraph release summary.
- \`README.md\`: Roadmap trimmed to just 1.0 + 2.0 (0.19 was skipped); Version History gains the 1.0-rc.1 entry in the same one-line-per-release shape as its neighbours.
- \`SETUP.md\`: install / upgrade / gc examples bumped \`0.18.0\` → \`1.0.0-rc.1\` (six sites).

## Not in this PR (post-merge steps)

Per the AGENTS.md checklist, after merge:

- Tag: \`git tag -a v1.0.0-rc.1 -m "Release 1.0.0-rc.1" && git push origin v1.0.0-rc.1\`
- Publish the GitHub Release with the \`[1.0.0-rc.1]\` CHANGELOG section as the body.
- Close the 0.19 milestone (empty of open items, all its closed tickets ship under this tag).

## Test plan

- [x] typecheck + lint + tests + build all clean on the new tree: react-app 999/999, server 950/950, converter 28/28.
- [x] openapi.json + api-schema.ts regenerated and committed.
- [x] CI green (all four jobs).
- [ ] Post-merge: tag, GitHub Release, milestone close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)