### PR TITLE
Meta PUT: upsert instead of update-only (fixes knownHosts not persisting)

### DIFF
--- a/react-app/src/services/meta.ts
+++ b/react-app/src/services/meta.ts
@@ -18,30 +18,16 @@ export type KnownMetaKey = (typeof KNOWN_KEYS)[number];
 
 const getAll = async () => unwrap(api.GET("/api/v1/meta", {}));
 
-// Upsert a meta value. Tries PUT first (in-place update); on 404
-// (key doesn't yet exist) falls back to POST. The two routes
-// share an authorization gate, so callers don't have to know
-// which one fits — the result is the same persistent row.
+// Upsert a meta value. PUT is an upsert on the server (RFC 7231
+// §4.3.4) — a single request handles both first-time create and
+// in-place update.
 const set = async (key: KnownMetaKey, value: string): Promise<void> => {
-  try {
-    await unwrap(
-      api.PUT("/api/v1/meta/{key}", {
-        params: { path: { key } },
-        body: { value },
-      })
-    );
-  } catch (err) {
-    const status = (err as { status?: number } | undefined)?.status;
-    if (status === 404) {
-      await unwrap(
-        api.POST("/api/v1/meta", {
-          body: { key, value },
-        })
-      );
-      return;
-    }
-    throw err;
-  }
+  await unwrap(
+    api.PUT("/api/v1/meta/{key}", {
+      params: { path: { key } },
+      body: { value },
+    })
+  );
 };
 
 const remove = async (key: KnownMetaKey): Promise<void> => {

--- a/server/controllers/meta-v1.ts
+++ b/server/controllers/meta-v1.ts
@@ -146,10 +146,15 @@ const plugin: FastifyPluginAsyncTypebox = async (fastify) => {
     async (request, reply) => {
       requireUnscoped(request);
       await authorizer.authorizeAdmin(request.user.id);
-      await model.updateMeta(
-        `instance_${request.params.key}`,
-        request.body.value
-      );
+      // PUT is an upsert (RFC 7231 §4.3.4). A brand-new meta key
+      // needs to persist on first save without the client having to
+      // fall back to a POST — before this the SQL UPDATE silently
+      // no-op'd on a missing row and PUT returned 204 with nothing
+      // actually written.
+      await model.upsertMeta({
+        key: `instance_${request.params.key}`,
+        value: request.body.value,
+      });
       reply.status(204).send();
     }
   );

--- a/server/models/meta.ts
+++ b/server/models/meta.ts
@@ -8,6 +8,7 @@ export default () => {
     getMeta,
     createMeta,
     updateMeta,
+    upsertMeta,
     deleteMeta,
   };
 };
@@ -27,6 +28,24 @@ const createMeta = async (meta: { key: string; value: string }) => {
 const updateMeta = async (key: string, value: string) => {
   logger.debug("Updating meta", { key, value });
   await db.updateMeta(key, { value });
+};
+// Create-or-update. The HTTP PUT endpoint uses this so a brand-new
+// key (e.g. instance_knownHosts on a fresh install, before the
+// operator has ever set it) persists through the admin UI on the
+// first save. Try INSERT first; on the driver's UNIQUE-constraint
+// error, fall through to UPDATE. Any other error rethrows.
+const upsertMeta = async (meta: { key: string; value: string }) => {
+  logger.debug("Upserting meta", meta);
+  try {
+    await db.createMeta(meta);
+  } catch (err) {
+    const code = (err as { code?: string } | undefined)?.code;
+    if (code === "SQLITE_CONSTRAINT_PRIMARYKEY") {
+      await db.updateMeta(meta.key, { value: meta.value });
+      return;
+    }
+    throw err;
+  }
 };
 const deleteMeta = async (key: string) => {
   logger.debug("Deleting meta", key);

--- a/server/tests/api/meta.test.ts
+++ b/server/tests/api/meta.test.ts
@@ -100,6 +100,40 @@ describe("As admin", () => {
     const result = await getMeta("name");
     expectMeta(result, "name", "renamed instance");
   });
+  test("PUT on a missing key creates it (upsert)", async () => {
+    // knownHosts isn't seeded by the fixture. The PUT endpoint is
+    // an upsert (RFC 7231 §4.3.4), so a first-time write persists
+    // in one request without the client needing a POST fallback.
+    const value = '[{"hostname":"a.example.com","isMain":true}]';
+    await api
+      .put("/api/v1/meta/knownHosts")
+      .set("Cookie", `pd_access=${token}`)
+      .send({ value })
+      .expect(204);
+    const result = await getMeta("knownHosts");
+    // knownHosts is JSON_META_KEYS — cleanMeta parses it back to
+    // an array on the way out.
+    expect(result.body.knownHosts).toEqual([
+      { hostname: "a.example.com", isMain: true },
+    ]);
+  });
+  test("PUT on an existing key updates in place", async () => {
+    // Second write hits the UPSERT's UPDATE branch. Verify the
+    // value overwrites the first write completely (no residual
+    // list items from the previous value).
+    await api
+      .put("/api/v1/meta/knownHosts")
+      .set("Cookie", `pd_access=${token}`)
+      .send({ value: '[{"hostname":"a.example.com","isMain":true}]' })
+      .expect(204);
+    await api
+      .put("/api/v1/meta/knownHosts")
+      .set("Cookie", `pd_access=${token}`)
+      .send({ value: '[{"hostname":"b.example.com"}]' })
+      .expect(204);
+    const result = await getMeta("knownHosts");
+    expect(result.body.knownHosts).toEqual([{ hostname: "b.example.com" }]);
+  });
   test("Delete existing meta", async () => {
     await api
       .delete("/api/v1/meta/name")


### PR DESCRIPTION
## Symptom

Reported: adding hosts in \`/m/instance\`'s \"Known hosts\" editor and saving appears successful in the UI, but the values are gone after a page refresh — nothing was actually written.

## Root cause

\`PUT /api/v1/meta/:key\` called \`db.updateMeta\`, which ran a bare SQL \`UPDATE\` against the row. Against a **missing** row the \`UPDATE\` is a silent no-op — 0 rows changed, no error — and the endpoint returned 204 with nothing actually persisted.

The SPA's \`metaService.set()\` had a PUT-then-POST fallback intended to catch this exact case, but it only triggered on 404 (never fires) not on \"succeeded but wrote nothing.\" So the fallback path was dead code for the very shape it was written for.

The bug affects any brand-new meta key — \`instance_knownHosts\` was just the first case to hit it (fresh key introduced in 1.0-rc.1). Other keys survive because the operator's typical \`bin/meta.ts set …\` bootstraps them at install time, creating the rows.

## Fix

**PUT is now an upsert** (RFC 7231 §4.3.4 explicitly covers this as valid PUT semantics — \"the state of the target resource be created or replaced\"). A new \`models/meta.ts:upsertMeta\` tries \`INSERT\` first and falls through to \`UPDATE\` on \`SQLITE_CONSTRAINT_PRIMARYKEY\`. The controller's PUT handler routes through it.

The SPA-side \`metaService.set()\` simplifies to a single PUT — the (broken) POST fallback is gone. The POST endpoint stays for now; \`bin/meta.ts\` still uses it directly for the create-only CLI case.

## Test plan

- [x] Two new server tests: \`PUT on a missing key creates it (upsert)\` + \`PUT on an existing key updates in place\`. Meta suite 23/23 passes.
- [x] react-app 999/999, typecheck + lint clean on both subtrees.
- [ ] Manual: on the prod / local instance without any prior knownHosts row, add a host in \`/m/instance\`, save, refresh — the value now persists.

## Release track

This is the first rc.1 → rc.2 candidate bug. Merging alone doesn't cut rc.2; a follow-up release commit will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)