### PR TITLE
Fix SSO landing + switcher polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Frontend
+
+- Cross-host SSO landing now actually logs the visitor in on the target host. The `/api/v1/tokens/sso` response was setting cookies correctly, but the SPA's boot-time `verify()` was gated on `storedUser` being defined and skipped on a first-ever visit — the SPA never noticed the freshly-set cookies. Verify now fires unconditionally on mount; anonymous 401 stays quiet (login modal only opens when there was actually a session to lose). Closes #684.
+- Cross-host URL hop preserves the gallery id + year/month/day trail. Previously `translatePathForHost` stripped the gallery id from `/g/<id>/…`, and the target's off-scope redirect then dropped the date trail on top of that — a hop from `/g/somewhere/2026/07` landed on `/g/<scoped-default>` instead of `/g/<scoped-default>/2026/07`. Now the URL carries verbatim; the target's off-scope handler redirects with the trail preserved. Closes #684.
+- UserMenu's Other hosts list is filtered to what the user can actually reach: main host (`isMain: true`) always shown; non-main host shown only when the user has view access to at least one gallery whose `hostname` regex matches the host. The section is hidden entirely if there's nothing to switch to. Closes #684.
+
 ## [1.0.0-rc.2] - 2026-07-02
 
 ### Operator

--- a/react-app/src/App.tsx
+++ b/react-app/src/App.tsx
@@ -225,19 +225,20 @@ const App = (): React.ReactElement => {
 
   // Boot-time session reconcile. The user store rehydrates from
   // localStorage synchronously at module load, so the UI may render
-  // a stale identity on first paint — e.g. a sibling tab replaced
-  // the shared cookie+localStorage out from under this tab, or the
-  // admin / editor grants changed in the DB since the cookie was
-  // minted. One GET /tokens with credentials reconciles both:
-  // server's view wins; 401 lets api.ts's onResponse handler run
-  // the refresh-or-clear path. Guarded by a ref so React strict-
-  // mode's double-invocation in dev doesn't fire two requests.
+  // a stale identity on first paint (sibling-tab login, admin grant
+  // changed in the DB, etc.). Fires unconditionally: also catches
+  // the "cookies exist but localStorage doesn't" case — the cross-
+  // host SSO landing on a target host the browser has never visited,
+  // where cookies are set by /sso but localStorage is empty until
+  // this verify populates it. Guest → 401 → api.ts's onResponse
+  // handler silently drops it (anonymous visitors don't get a login
+  // modal). Guarded by a ref so React strict-mode's double-
+  // invocation in dev doesn't fire two requests.
   const storedUser = useUserStore((s) => s.user);
   const setUser = useUserStore((s) => s.setUser);
   const verifiedRef = React.useRef(false);
   React.useEffect(() => {
     if (verifiedRef.current) return;
-    if (!storedUser) return;
     verifiedRef.current = true;
     tokenService
       .verify()
@@ -247,13 +248,15 @@ const App = (): React.ReactElement => {
           isAdmin: session.isAdmin,
           editorGalleries: session.editorGalleries,
         });
-        if (next.toJson() === storedUser.toJson()) return;
+        if (storedUser && next.toJson() === storedUser.toJson()) return;
         window.localStorage.setItem("user", next.toJson());
         setUser(next);
       })
       .catch(() => {
-        // 401 / 403 — api.ts's onResponse handler already cleared
-        // local auth + opened the login modal. Nothing extra here.
+        // 401 for the anonymous / no-cookie case is normal — don't
+        // touch state. 401 with an expired cookie was already
+        // handled by api.ts's onResponse (refresh-or-clear); this
+        // catch is deliberately silent.
       });
   }, [storedUser, setUser]);
 

--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -291,13 +291,22 @@ const Gallery = ({
   const scopedGalleries = galleriesForHost(galleries, window.location.hostname);
   const isHostScoped = scopedGalleries.length > 0;
   // Off-scope URL on a scoped host: redirect to the first in-scope
-  // gallery rather than render the unreachable view.
+  // gallery, preserving the year / month / day / photoId trail so
+  // a cross-host hop from /g/somewhere/2026/07 lands on
+  // /g/<scoped-default>/2026/07 instead of stripping the visitor
+  // back to the gallery root.
   if (
     galleryId &&
     isHostScoped &&
     !scopedGalleries.some((gallery) => gallery.id() === galleryId)
   ) {
-    return <Navigate to={scopedGalleries[0].path()} replace />;
+    const base = scopedGalleries[0].path(
+      year || undefined,
+      month || undefined,
+      day || undefined
+    );
+    const target = photoId ? `${base}/${photoId}` : base;
+    return <Navigate to={target} replace />;
   }
   // On a scoped host, narrow `galleries` to the scope set so the
   // breadcrumb dropdown and landing picker can't navigate outside.

--- a/react-app/src/components/UserMenu.tsx
+++ b/react-app/src/components/UserMenu.tsx
@@ -8,6 +8,8 @@ import { BsPersonFill, BsPerson } from "react-icons/bs";
 import theme from "../lib/theme";
 import { translatePathForHost } from "../lib/cross-host-path";
 import { useHostScope } from "../lib/use-host-scope";
+import GalleryModel, { type Gallery } from "../models/GalleryModel";
+import galleryService from "../services/galleries";
 import metaService from "../services/meta";
 import tokenService from "../services/tokens";
 import {
@@ -181,7 +183,22 @@ const UserMenu = (): React.ReactElement => {
     queryFn: () => metaService.getAll(),
     enabled: !!user,
   });
-  const knownHosts = (() => {
+  // Galleries the current user can see. Shared queryKey with
+  // Gallery/index.tsx so we don't double-fetch. Used to filter the
+  // knownHosts list — a scoped host (one whose regex matches a
+  // gallery) is only reachable if the user has some access to that
+  // gallery.
+  const galleriesQuery = useQuery({
+    queryKey: ["galleries", user?.id ?? null],
+    queryFn: async () => {
+      const data = await galleryService.getAll();
+      return data
+        .map((gallery) => GalleryModel(gallery))
+        .filter((g): g is Gallery => !!g);
+    },
+    enabled: !!user,
+  });
+  const rawKnownHosts = (() => {
     const raw = (metaQuery.data as { knownHosts?: unknown } | undefined)
       ?.knownHosts;
     if (!Array.isArray(raw)) return [] as KnownHost[];
@@ -193,6 +210,24 @@ const UserMenu = (): React.ReactElement => {
   const currentHostname = typeof window !== "undefined"
     ? window.location.hostname.toLowerCase()
     : "";
+  // Access-aware filter:
+  // - Main host (isMain === true) is always shown — by the operator
+  //   model, main exposes every gallery, so everyone can reach it.
+  // - Non-main host is scope-narrowed by a gallery.hostname regex.
+  //   Only show if the user has view access to at least one gallery
+  //   whose regex matches this host.
+  const visibleGalleries = galleriesQuery.data ?? [];
+  const knownHosts = rawKnownHosts.filter((h) => {
+    if (h.isMain) return true;
+    const hostname = h.hostname.toLowerCase();
+    return visibleGalleries.some((g) => g.matchesHostname(hostname));
+  });
+  // Only render the switcher when there's actually somewhere to
+  // switch to. A knownHosts list with a single entry (usually the
+  // current host itself) has no target and reads as noise.
+  const hasOtherHost = knownHosts.some(
+    (h) => h.hostname.toLowerCase() !== currentHostname
+  );
 
   const switchToHost = async (target: string) => {
     setIsOpen(false);
@@ -349,7 +384,7 @@ const UserMenu = (): React.ReactElement => {
               {t(`beta-feature-${f}`)}
             </BetaToggle>
           ))}
-          {knownHosts.length > 0 && (
+          {hasOtherHost && (
             <>
               <SectionDivider />
               <SectionHeading>{t("user-menu-other-hosts")}</SectionHeading>

--- a/react-app/src/lib/api.ts
+++ b/react-app/src/lib/api.ts
@@ -78,8 +78,17 @@ const refreshOnce = async (): Promise<boolean> => {
 };
 
 const expireLocalAuth = () => {
+  // Only escalate to the login modal if there was actually a
+  // session to expire. Without this, the boot-time verify against
+  // /tokens fires the modal for every anonymous visitor (401 →
+  // refresh → 401 → here) — the SPA thinks a session was lost when
+  // in fact none ever existed. localStorage["user"] is the ground
+  // truth for "there was a session"; the Zustand store mirrors it.
+  const hadLocalUser =
+    !!window.localStorage.getItem("user") || !!useUserStore.getState().user;
   window.localStorage.removeItem("user");
   useUserStore.getState().setUser(undefined);
+  if (!hadLocalUser) return;
   // Close any other modal that might be open (e.g. change-password mid-
   // submit) so the login modal doesn't stack on top of it — two
   // backdrops at once reads as broken.

--- a/react-app/src/lib/cross-host-path.test.ts
+++ b/react-app/src/lib/cross-host-path.test.ts
@@ -1,19 +1,22 @@
 import { translatePathForHost } from "./cross-host-path";
 
 describe("translatePathForHost", () => {
-  test("strips the gallery id from /g/<id> shapes, keeps the date trail", () => {
-    expect(translatePathForHost("/g/dailybw")).toBe("/g");
-    expect(translatePathForHost("/g/dailybw/2024")).toBe("/g/2024");
-    expect(translatePathForHost("/g/dailybw/2024/3")).toBe("/g/2024/3");
-    expect(translatePathForHost("/g/dailybw/2024/3/15")).toBe("/g/2024/3/15");
+  test("gallery URLs carry the id + trail verbatim", () => {
+    // Main host has every gallery; non-main hosts scope-narrow.
+    // Passing the id verbatim gives non-main → main a direct hit,
+    // and main → non-main degrades into Gallery/index.tsx's
+    // off-scope handler which redirects to the scoped default
+    // while preserving the year / month / day / photoId trail.
+    expect(translatePathForHost("/g/dailybw")).toBe("/g/dailybw");
+    expect(translatePathForHost("/g/dailybw/2024/3")).toBe("/g/dailybw/2024/3");
     expect(translatePathForHost("/g/dailybw/2024/3/15/photo.jpg")).toBe(
-      "/g/2024/3/15/photo.jpg"
+      "/g/dailybw/2024/3/15/photo.jpg"
     );
   });
 
-  test("strips the gallery id from /s/<id>", () => {
-    expect(translatePathForHost("/s/dailybw")).toBe("/s");
-    expect(translatePathForHost("/s/dailybw/extra")).toBe("/s/extra");
+  test("stats URLs carry the id verbatim", () => {
+    expect(translatePathForHost("/s/dailybw")).toBe("/s/dailybw");
+    expect(translatePathForHost("/s/dailybw/extra")).toBe("/s/dailybw/extra");
   });
 
   test("admin paths land on the manage dashboard regardless of subpath", () => {

--- a/react-app/src/lib/cross-host-path.ts
+++ b/react-app/src/lib/cross-host-path.ts
@@ -1,20 +1,13 @@
 // Best-effort path translation when the operator hops between
-// virtual hosts. Each host serves a different gallery set,
-// so a deep URL like /g/dailybw/2024/3 only makes sense on its own
-// host; we keep the *shape* (year / month / day / stats) where
-// reasonable and let the target host pick a default gallery on
-// arrival.
-
-// Visitor calendar shape: /g/<id>/<y>?/<m>?/<d>?/<photoId>?.
-// Strip the gallery id from the path so the target host falls back
-// to its own default gallery (the `instance_defaultGallery` meta
-// + hostname-scope landing logic). Keep the rest of the trail so
-// the visitor stays on the same date / view.
-const STRIP_GALLERY = /^\/g\/[^/]+(\/.*)?$/;
-
-// Per-gallery stats: /s/<id>. Drop the id; target lands on its
-// own /s with whatever heuristic picks the default.
-const STRIP_STATS = /^\/s\/[^/]+(\/.*)?$/;
+// virtual hosts.
+//
+// Operator model: the main host exposes every gallery; non-main
+// hosts are scope-narrowed subsets. Carrying the gallery id
+// verbatim across hops works for both directions — non-main → main
+// lands on the exact same gallery (main has it), main → non-main
+// lands on an off-scope URL that the target's Gallery view catches
+// and redirects to the scoped default (see Gallery/index.tsx),
+// preserving the year / month / day trail.
 
 export const translatePathForHost = (currentPath: string): string => {
   if (!currentPath.startsWith("/")) return "/";
@@ -23,14 +16,7 @@ export const translatePathForHost = (currentPath: string): string => {
   // per-host. Land on the manage dashboard.
   if (currentPath === "/m" || currentPath.startsWith("/m/")) return "/m";
 
-  // Per-gallery surfaces — keep the date / photo trail, drop the
-  // gallery id so the target picks its own default.
-  const galleryMatch = STRIP_GALLERY.exec(currentPath);
-  if (galleryMatch) return "/g" + (galleryMatch[1] ?? "");
-
-  const statsMatch = STRIP_STATS.exec(currentPath);
-  if (statsMatch) return "/s" + (statsMatch[1] ?? "");
-
-  // Top-level routes (/, /g, /s) carry over verbatim.
+  // Everything else carries over verbatim. Off-scope /g/<id> URLs
+  // on the target host go through the existing off-scope handler.
   return currentPath;
 };


### PR DESCRIPTION
## Symptoms from prod SSO testing

**1. Session shows as guest after landing on the target host** (commit 1)

Cookies were set correctly by \`/api/v1/tokens/sso\` (302 + \`Set-Cookie: pd_access…\` + \`pd_refresh…\`), but the SPA on the target host still rendered guest state. First-ever visit = empty localStorage; the boot-time \`verify()\` from #677 was guarded on \`storedUser\` being defined and skipped, so the SPA never learned about the newly-set cookies.

**2. URL landed with the gallery id missing** (commit 2)

Hop from \`photos/g/gallery/2026/07\` landed on the target as \`/g/2026/07\` (gallery id stripped by \`translatePathForHost\`). React-router parsed \`2026\` as \`:galleryId\`, the target's off-scope handler redirected to \`/g/<scoped-default>\` — losing the year/month/day trail entirely.

**3. Switcher shows hosts the user can't access** (commit 3)

The Other hosts section listed every entry in \`instance_knownHosts\` for any authenticated visitor, regardless of whether they could actually see anything on the target host.

## Fixes

**Commit 1** — Boot verify fires unconditionally:

- \`App.tsx\`: drops the \`if (!storedUser) return\` guard. Verify runs on every mount. SSO landing case → 200 → identity syncs. Anonymous → 401 → nothing to do. Stale cookies → existing refresh path.
- \`api.ts\` \`expireLocalAuth\`: gate the login modal on \`hadLocalUser\` so anonymous visitors' verify-401 → refresh-401 doesn't spuriously open the \"session expired\" modal on every page load.

**Commit 2** — URL carries verbatim, off-scope redirect preserves the trail:

Operator model (confirmed with the operator): the main host has every gallery; non-main hosts are scope-narrowed subsets, typically with a default gallery in the scope set. Under that model, stripping the gallery id degrades both directions:

- **non-main → main**: main has the original gallery, so passing the id verbatim is a direct hit. Stripping loses information the target could use.
- **main → non-main**: gallery id doesn't exist on the target, but the target's off-scope handler already knows to fall back to the scoped default. It just wasn't preserving the year/month/day trail.

Change:

- \`translatePathForHost\` — pass \`/g/<id>/…\` and \`/s/<id>/…\` verbatim. Admin paths still collapse to \`/m\`; malformed input still falls to \`/\`.
- \`Gallery/index.tsx\` off-scope redirect — preserve year / month / day / photoId when redirecting to the scoped default.

Test flipped from \"asserts strip\" to \"asserts verbatim carry.\"

**Commit 3** — Access-aware switcher visibility:

Two rules on the UserMenu's Other hosts list:

- Host with \`isMain: true\` → always shown. Main exposes every gallery by the operator model, so everyone can reach it.
- Otherwise → the host is scope-narrowed by a \`gallery.hostname\` regex. Only show if the user has view access to at least one gallery whose regex matches this host.

Section is hidden entirely when nothing remains to switch to (single-entry list, or the filter reduced things to only the current host). Uses the same galleries queryKey as \`<Gallery>\` so it doesn't double-fetch. Guests still see nothing regardless — the whole UserMenu dropdown is authed-user-only.

## Test plan

- [x] react-app 999/999, typecheck + lint clean.
- [ ] Manual on prod: SSO hop photos → dailybw. Target now shows logged-in state + URL preserves the year/month.
- [ ] Manual: SSO hop dailybw → photos. Same-gallery-id URL renders directly on main.
- [ ] Manual: anonymous visit — no login modal on first page load.
- [ ] Manual: a non-admin user with access to only some galleries — Other hosts section lists only the hosts they can reach (main + non-main hosts whose scoped gallery they can see).

## Release track

rc.2 → rc.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)