### PR TITLE
Fix Gallery double scrollbar

### DIFF
--- a/react-app/src/components/Gallery/index.tsx
+++ b/react-app/src/components/Gallery/index.tsx
@@ -66,9 +66,12 @@ const globalStyles = (theme: ActiveTheme) => css`
     --photo-frame-mat: ${theme.get("photo-frame-mat")};
     --photo-frame-border: ${theme.get("photo-frame-border")};
     filter: ${theme.get("filter")};
-    overflow-x: hidden;
   }
   body {
+    /* Only body clips horizontal overflow — putting overflow-x on
+       html too triggers the CSS-spec rule that implicitly turns
+       overflow-y: visible into auto on both, creating a nested
+       scroll container and the classic "two scrollbars" bug. */
     overflow-x: hidden;
   }
 `;


### PR DESCRIPTION
## Symptom

Gallery views show two vertical scrollbars side-by-side. Worse when the viewport is short — the browser's normal scroll and a nested inner scroll both compete for the same content.

## Root cause

[Gallery/index.tsx:69-73](react-app/src/components/Gallery/index.tsx#L69) set \`overflow-x: hidden\` on **both** \`html\` and \`body\` via Emotion \`<Global>\`. Per CSS 2.1 §11.1.1 (and current CSS Overflow Module Level 3), when one axis has any value other than \`visible\`, the paired axis's \`visible\` is silently interpreted as \`auto\`. So the styles effectively read:

\`\`\`css
html { overflow-x: hidden; overflow-y: auto; }
body { overflow-x: hidden; overflow-y: auto; }
\`\`\`

Both elements become vertical scroll containers. On any page whose content overflows, both render a scrollbar.

## Fix

Only \`body\` clips horizontal overflow. \`html\` reverts to \`overflow: visible\` (the default), leaving the browser to scroll the viewport normally. One vertical scrollbar, as designed.

## Test plan

- [x] typecheck + lint + 999 tests pass
- [ ] Manual: gallery month view no longer shows two vertical scrollbars in a normal window
- [ ] Manual: same page on a short viewport (dev tools split) — one scrollbar, content scrolls normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)