### PR TITLE
CSP: allow cdn.jsdelivr.net for react-country-flag SVGs

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -175,10 +175,13 @@ try {
 //   external script tags.
 // - `img-src` pins the exact set of image origins: same-origin (for
 //   the SPA's bundled assets + the photos when no CDN is set),
-//   OSM's tile subdomains (Leaflet map), and the operator's
-//   `instance_cdn` origin if configured. `data:` covers Leaflet's
-//   inline marker icons + similar embedded sprites. `blob:` covers
-//   the gallery-icon cropper's canvas preview.
+//   OSM's tile subdomains (Leaflet map), the operator's
+//   `instance_cdn` origin if configured, and jsdelivr for the flag
+//   SVGs `react-country-flag` fetches from `lipis/flag-icons`
+//   (used in Stats + MetadataPanel country renderings). `data:`
+//   covers Leaflet's inline marker icons + similar embedded
+//   sprites. `blob:` covers the gallery-icon cropper's canvas
+//   preview.
 // - `connect-src 'self'` covers the API + same-origin /thumbnail,
 //   /display, /gallery-icons static paths.
 // - `frame-ancestors 'none'` — no embedding; clickjacking-clean.
@@ -198,6 +201,7 @@ await app.register(fastifyHelmet, {
         "data:",
         "blob:",
         "https://*.tile.openstreetmap.org",
+        "https://cdn.jsdelivr.net",
         ...(cdnOrigin ? [cdnOrigin] : []),
       ],
       "connect-src": ["'self'"],


### PR DESCRIPTION
## Symptom

Flag icons in Stats (country card) blocked with a CSP violation. Same block hits any \`<FlagIcon>\` render — MetadataPanel country row, Manage gallery source display, filter chips.

Console: \`Refused to load the image 'https://cdn.jsdelivr.net/gh/lipis/flag-icons/flags/4x3/jp.svg' because it violates the following Content Security Policy directive: "img-src 'self' data: blob: https://*.tile.openstreetmap.org …"\`

## Fix

Add \`https://cdn.jsdelivr.net\` to \`img-src\`. That's where \`react-country-flag\` loads its SVGs from (via the \`lipis/flag-icons\` repo on jsdelivr).

## Notes

- This is the vendored default of \`react-country-flag\`. If we ever wanted to self-host, we could ship the flag SVGs from \`node_modules/flag-icons\` (~3 kB per country × ~250 countries = ~750 kB, or ~50–100 kB gzipped) and swap the component's \`svg\` prop / drop the CDN allowlist entry. Not doing that now; the jsdelivr entry is scoped tightly enough.
- \`react-country-flag\` uses jsdelivr's origin verbatim; no path prefix to narrow further.

## Test plan

- [x] server typecheck + lint + tokens/meta tests pass
- [ ] Manual: open Stats on a gallery with country data — flags render, no CSP violations in console
- [ ] Manual: open a photo's MetadataPanel where the country is set — flag renders

## Release track

rc.2 → rc.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)