### PR TITLE
CSP: set header on onRequest to avoid ERR_HTTP_HEADERS_SENT

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -166,13 +166,19 @@ try {
 // Content-Security-Policy. Tuned to what the SPA actually needs
 // — full directive rationale is in `lib/csp.ts`. Fastify-helmet
 // still handles all the other security headers (HSTS, X-Frame-
-// Options, etc.); CSP alone gets set by the onSend hook below so
-// the CDN origin can change without a restart.
+// Options, etc.); CSP alone is set from an onRequest hook so the
+// CDN origin can change without a pm2 restart.
+//
+// onRequest, not onSend: `@fastify/compress` streams the response
+// body early on some paths (static assets), and any onSend that
+// runs after it tries to write headers → ERR_HTTP_HEADERS_SENT.
+// Setting the header on the reply at onRequest time queues it
+// with the rest of the headers before the response starts.
 await app.register(fastifyHelmet, {
   contentSecurityPolicy: false,
   referrerPolicy: { policy: "strict-origin-when-cross-origin" },
 });
-app.addHook("onSend", async (_request, reply) => {
+app.addHook("onRequest", async (_request, reply) => {
   reply.header("Content-Security-Policy", getCspHeader());
 });
 await app.register(fastifyCompress);


### PR DESCRIPTION
## Symptom

After #688 merged, pm2 logs fill with:

\`\`\`
ERROR: Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client
    at ServerResponse.writeHead …
    at safeWriteHead (fastify/lib/reply.js:568:9)
    at onSendEnd (fastify/lib/reply.js:633:5)
    at Object.onSend (@fastify/compress/index.js:248:14)
\`\`\`

## Root cause

The CSP header was set from an \`onSend\` hook. On static-asset paths, \`@fastify/compress\` starts streaming the compressed response body before \`onSendEnd\` runs. By the time \`onSendEnd\` tries to \`writeHead\` to flush collected headers, the response's headers have already been sent → \`ERR_HTTP_HEADERS_SENT\` per request. The requests themselves still succeed (the CSP header does land, from compress's own header handling), but each one logs an error.

## Fix

Move the CSP header to an \`onRequest\` hook. Headers set at that phase go into the reply's header map before any handler starts writing, so streaming and buffered responses both flush them cleanly. The dynamic-cache design from #688 is unchanged — \`getCspHeader()\` reads the current cached CDN origin, still refreshed by meta writes.

## Test plan

- [x] typecheck + lint + meta.test.ts (23/23) pass
- [ ] Manual on prod: pm2 log no longer shows ERR_HTTP_HEADERS_SENT after upgrade
- [ ] Manual: CSP header still lists the operator-configured CDN in img-src after a live update via /m/instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)