### PR TITLE
Release 1.0.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,23 @@
 
 ## [Unreleased]
 
+## [1.0.0-rc.3] - 2026-07-02
+
+Second bugfix rc on rc.1's virtual-host / SSO work. Ships the SSO story end-to-end (federated login from non-main hosts) plus polish surfaced by operator prod verification.
+
+### Operator
+
+- CSP `img-src` now reflects `instance_cdn` changes without a pm2 restart. The CDN origin was resolved once at server boot and pinned into fastify-helmet's config; changing it via `/m/instance` didn't update the running server's CSP until pm2 was recycled, leaving photos blocked in the meantime. In-memory cache primed at boot, refreshed on every meta write; an `onRequest` hook writes the header per response. `bin/meta.ts` writes still need a pm2 restart (out-of-process from the server) — noted in the CSP module comment. Closes #688, #689.
+- CSP `img-src` allows `https://cdn.jsdelivr.net` so `react-country-flag`'s flag SVGs render in Stats + MetadataPanel + filter chips. Closes #687.
+
 ### Frontend
 
 - Cross-host SSO landing now actually logs the visitor in on the target host. The `/api/v1/tokens/sso` response was setting cookies correctly, but the SPA's boot-time `verify()` was gated on `storedUser` being defined and skipped on a first-ever visit — the SPA never noticed the freshly-set cookies. Verify now fires unconditionally on mount; anonymous 401 stays quiet (login modal only opens when there was actually a session to lose). Closes #684.
 - Cross-host URL hop preserves the gallery id + year/month/day trail. Previously `translatePathForHost` stripped the gallery id from `/g/<id>/…`, and the target's off-scope redirect then dropped the date trail on top of that — a hop from `/g/somewhere/2026/07` landed on `/g/<scoped-default>` instead of `/g/<scoped-default>/2026/07`. Now the URL carries verbatim; the target's off-scope handler redirects with the trail preserved. Closes #684.
 - UserMenu's Other hosts list is filtered to what the user can actually reach: main host (`isMain: true`) always shown; non-main host shown only when the user has view access to at least one gallery whose `hostname` regex matches the host. The section is hidden entirely if there's nothing to switch to. Closes #684.
-- Federated login: on non-main hosts (any deploy with an `isMain: true` entry in `instance_knownHosts`), the Login button and the mid-session 401 handler both delegate to the main host instead of showing a local password form. The visitor sees a brief "Signing in via `<mainHost>`…" modal, gets redirected to the main host with `?login=1&sso_to=<currentHost>&sso_path=<path>` context, signs in there, and is bounced back with SSO cookies for the origin host. Credentials live on the main host only — non-main hosts don't accept passwords. On main / standalone deploys, the local password modal still applies. Closes #684.
+- Federated login: on non-main hosts (any deploy with an `isMain: true` entry in `instance_knownHosts`), the Login button and the mid-session 401 handler both delegate to the main host instead of showing a local password form. The visitor sees a brief "Signing in via `<mainHost>`…" modal, gets redirected to the main host with `?login=1&sso_to=<currentHost>&sso_path=<path>` context, signs in there, and is bounced back with SSO cookies for the origin host. Credentials live on the main host only — non-main hosts don't accept passwords. On main / standalone deploys, the local password modal still applies. Closes #685.
+- Gallery views no longer show two vertical scrollbars. Setting `overflow-x: hidden` on both `html` and `body` triggered a CSS-spec rule that turns `overflow-y: visible` into `auto` on both, giving each a scrollbar. `body` alone clips horizontal now. Closes #686.
+- UserMenu dropdown gains `max-height` + `overflow-y: auto` so short viewports (dev tools open, small windows) still reach Logout. Closes #685.
 
 ## [1.0.0-rc.2] - 2026-07-02
 
@@ -701,6 +712,7 @@ Release candidate for 1.0. Cumulative 0.18 → 1.0 changes: end of the JWT-cooki
 
 ## Initial commit - 2020-07-04
 
+[1.0.0-rc.3]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.2...v1.0.0-rc.3
 [1.0.0-rc.2]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.1...v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/vlumi/photo-diary/compare/v0.18.0...v1.0.0-rc.1
 [0.18.0]: https://github.com/vlumi/photo-diary/compare/v0.17.1...v0.18.0

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Per-instance state — the SQLite DB, the `photos/` tree, `.env` — lives in a 
 
 Active milestones on the way to 1.0, plus the far-out 2.0 direction. Each bullet links the GitHub milestone for live status.
 
-- [**1.0**](https://github.com/vlumi/photo-diary/milestone/4) — Soak the accumulated security + polish work in prod, then stamp. `1.0.0-rc.2` cut 2026-07-02 (bugfix on top of rc.1: meta PUT upsert). Feature freeze until 1.0; rc.3+ ships only if further prod verification surfaces regressions.
+- [**1.0**](https://github.com/vlumi/photo-diary/milestone/4) — Soak the accumulated security + polish work in prod, then stamp. `1.0.0-rc.3` cut 2026-07-02 (SSO landing + federated login end-to-end, plus CSP + double-scrollbar fixes surfaced by prod verification). Feature freeze until 1.0; rc.4+ ships only if further verification surfaces regressions.
 - [**2.0 — Thin server, cloud-native direction**](https://github.com/vlumi/photo-diary/milestone/18) *(direction-setting, far out)* — originals leave the server for client-side / cold storage, the converter's sharp pipeline becomes a bundled local uploader, all DB ops route through the API, storage backends behind a vendor-agnostic interface. Likely diverges from today's self-hosted-monolith shape enough that it may end up being a different product line.
 
 ## Backlog
@@ -200,6 +200,6 @@ Third structural take on a long-running personal photo-gallery side project — 
 - **0.16** (Jun 2026) — Filter & viewing UX polish: redesigned filter widget (inline strip + per-category modal cards with faceted counts), continuous-variable range filters, stacked-area evolution chart, virtual-gallery edit page + hybrid-source admin UI, persistent map modal.
 - **0.17** (Jun 2026) — Admin UI shift to layered modals + Section card primitive; per-photo visibility + editor-tier admin actions on `/g/`; `/m/instance` page with runtime-overridable `meta` defaults; configurable rendition ladder + collapsed `photos/display/<maxDim>/` layout; `/m/photos` filters move into a modal; Stats Evolution adds `weekday` and `hour`; Finnish geocoding cleanup (state-code lvl fallthrough + script-rule address blob filter).
 - **0.18** (Jun 2026) — Cleanup + observability: `meta` table is the only source for SPA runtime defaults (no `.env` fallback); `/m/operations` admin page surfaces converter activity, pending queues, and failures; tidied `bin/photo.ts` surface; vitest coverage wired; frontend security audit pass; auth tokens move from localStorage to HttpOnly cookies.
-- **1.0-rc.2** (Jul 2026) — Release candidate for 1.0. End of the JWT-cookie transition, CSP enable pass, cross-host SSO for the UserMenu virtual-host switcher, Playwright e2e suite, docs overhaul, session-state reconcile on boot + across tabs, review-driven cleanup pass. Feature freeze until 1.0.
+- **1.0-rc.3** (Jul 2026) — Release candidate for 1.0. End of the JWT-cookie transition, CSP enable pass, cross-host SSO for the UserMenu virtual-host switcher (with federated login from non-main hosts), Playwright e2e suite, docs overhaul, session-state reconcile on boot + across tabs, review-driven cleanup pass. Feature freeze until 1.0.
 
 See the [Roadmap](#roadmap) for what's in flight after 1.0.

--- a/SETUP.md
+++ b/SETUP.md
@@ -79,13 +79,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  1.0.0-rc.2/                               #   so different instances can run different versions
+  1.0.0-rc.3/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/1.0.0-rc.2      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/1.0.0-rc.3      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  thumbnail/        # display/<maxDim>/ subdirs auto-created on intake
@@ -112,7 +112,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=1.0.0-rc.2
+V=1.0.0-rc.3
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -127,7 +127,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/1.0.0-rc.2/bin/instance.ts /var/photo-diary/dailybw
+/opt/photo-diary/1.0.0-rc.3/bin/instance.ts /var/photo-diary/dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -159,7 +159,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/1.0.0-rc.2/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
+/opt/photo-diary/1.0.0-rc.3/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                                # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                                     # migration runner applies any schema bumps
@@ -176,7 +176,7 @@ The DB backup is named `db.sqlite3.pre-<new-version>` — a plain file copy that
 The multi-instance layout never garbage-collects old `/opt/photo-diary/<version>/` directories — each one is 400+ MB (`sharp`, `better-sqlite3`, etc. in `node_modules`), so after a dozen releases they add up. `bin/instance.ts gc` scans the conventional layout and reports versions that no scanned instance references:
 
 ```sh
-/opt/photo-diary/1.0.0-rc.2/bin/instance.ts gc
+/opt/photo-diary/1.0.0-rc.3/bin/instance.ts gc
 ```
 
 It walks `/var/photo-diary/*/code` symlinks to collect what's in use, then prints anything under `/opt/photo-diary/` that isn't in that set, along with sizes and the `rm -rf` commands you would run. It never deletes — an operator with non-conventional instance layouts may have instances outside `/var/photo-diary/` that reference these dirs, so the actual `rm` is left to you after reviewing. Override the scan roots with `--code-root` / `--instances-root` if your layout differs.

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1"
   },
-  "version": "1.0.0-rc.2"
+  "version": "1.0.0-rc.3"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.3",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -71,5 +71,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "1.0.0-rc.2"
+  "version": "1.0.0-rc.3"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "1.0.0-rc.2"
+    "version": "1.0.0-rc.3"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -60,5 +60,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "1.0.0-rc.2"
+  "version": "1.0.0-rc.3"
 }


### PR DESCRIPTION
## Summary

Second bugfix rc on rc.1's virtual-host / SSO work. Six PRs bundled since rc.2 (2026-07-02):

- **#684** — SSO landing: boot-verify unconditional (SPA now notices freshly-set cookies on target host); URL trail preserved (gallery id + year/month/day carry across hops via the off-scope handler); switcher access-filtered (main always shown, non-main only if user has view access to a scoped gallery).
- **#685** — Federated login from non-main hosts. Anonymous visitor on `dailybw.misaki.fi` clicks Login → redirected to `photos.misaki.fi/?login=1&sso_to=…&sso_path=…` → signs in there → bounced back with SSO cookies. Non-main hosts don't accept passwords locally. Includes the UserMenu dropdown short-viewport polish that surfaced during testing.
- **#686** — Gallery double-scrollbar fix. `overflow-x: hidden` on both `html` and `body` triggered a CSS-spec quirk (paired axis's `visible` → `auto`), producing two vertical scrollbars.
- **#687** — CSP allow `cdn.jsdelivr.net` for `react-country-flag`'s flag SVGs.
- **#688** — CSP dynamic CDN origin. Live in-memory cache primed at boot and refreshed on every meta write; `instance_cdn` changes take effect on next request without pm2 restart. CLI writes still need restart (documented).
- **#689** — CSP set on `onRequest` instead of `onSend` to avoid `ERR_HTTP_HEADERS_SENT` on compress-wrapped static-asset paths.

## Release step touchpoints (per AGENTS.md)

- Version bumped `1.0.0-rc.2` → `1.0.0-rc.3` in root, server, react-app, converter `package.json`.
- `server/openapi.json` regenerated; `react-app/src/lib/api-schema.ts` re-codegen'd (unchanged content — same routes and schemas).
- `CHANGELOG.md`: new `[1.0.0-rc.3] - 2026-07-02` section with a one-paragraph summary + Operator / Frontend bullets; diff-link at footer.
- `README.md`: Roadmap 1.0 pointer + Version History rc.2 entry replaced with rc.3.
- `SETUP.md`: install / upgrade / gc examples bumped in six sites.

## Not in this PR (post-merge)

- Tag `v1.0.0-rc.3` + push.
- Publish GitHub Release (prerelease) with the `[1.0.0-rc.3]` CHANGELOG section as notes.

## Test plan

- [x] Full test pass: react-app 999/999, server 952/952, converter 28/28.
- [x] typecheck + lint clean; react-app build green.
- [ ] Manual on prod: full federated login flow works (photos ↔ dailybw); CSP responds to `/m/instance` CDN changes without pm2 restart; no `ERR_HTTP_HEADERS_SENT` in pm2 log.
- [ ] CI (4 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)