### PR TITLE
instance.ts: --cycle probe polls with backoff

### DIFF
--- a/bin/instance.ts
+++ b/bin/instance.ts
@@ -449,16 +449,29 @@ const runGc = (opts: GcOpts): void => {
 // Best-effort post-cycle probe — server's /api/v1/meta is unauthenticated
 // and cheap. PORT is required in .env so we always have it. Non-fatal:
 // returns false on any error, caller decides what to do with that.
+//
+// Polls with a short interval up to a longer overall budget instead of
+// firing a single-shot 5 s fetch. The server's boot has a few
+// synchronous DB reads (migrations, secrets cache, CSP CDN prime) so
+// the first fetchable moment can drift past a single deadline on
+// slower disks or first-boot-after-upgrade. 15 s overall covers those
+// legitimate delays; anything past that is a real problem the
+// operator should see via pm2 logs.
 const probeMeta = async (port: number): Promise<boolean> => {
   const url = `http://127.0.0.1:${port}/api/v1/meta`;
-  try {
-    const res = await fetch(url, {
-      signal: AbortSignal.timeout(5000),
-    });
-    return res.ok;
-  } catch {
-    return false;
+  const deadline = performance.now() + 15_000;
+  while (performance.now() < deadline) {
+    try {
+      const res = await fetch(url, {
+        signal: AbortSignal.timeout(2000),
+      });
+      if (res.ok) return true;
+    } catch {
+      // ECONNREFUSED / timeout / etc. — retry after a short wait.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
   }
+  return false;
 };
 
 const argv = yargs(hideBin(process.argv))
@@ -1072,7 +1085,7 @@ async function runPm2Cycle(kind: "upgrade" | "restart"): Promise<void> {
   if (Number.isFinite(port)) {
     const served = await probeMeta(port);
     log(
-      `  ${served ? "✓" : "✗"} GET http://127.0.0.1:${port}/api/v1/meta ${served ? "responded" : "didn't respond within 5s"}`
+      `  ${served ? "✓" : "✗"} GET http://127.0.0.1:${port}/api/v1/meta ${served ? "responded" : "didn't respond within 15s"}`
     );
     if (!served) {
       console.error();


### PR DESCRIPTION
## Symptom

Operator ran \`instance.ts <name> --cycle\` after upgrading to rc.3:

\`\`\`
pm2 state after cycle:
  ✓ photos: online
  ✓ photos-converter: online
  ✗ GET http://127.0.0.1:4201/api/v1/meta didn't respond within 5s

✗ Server is up in pm2 but not answering on its port — review pm2 logs.
\`\`\`

But the server was actually fine — hitting it a moment later worked. False alarm.

## Root cause

\`probeMeta\` fires a single \`fetch\` with a 5 s timeout. The server's boot does a few synchronous DB reads (migrations, secrets cache, and — new in rc.3 — the CSP CDN prime) that can push the first fetchable moment past 5 s on slower disks or first-boot-after-upgrade.

## Fix

Poll with a 500 ms interval up to a 15 s overall budget. Each probe still has its own 2 s per-request timeout so a hung server doesn't stall the loop. False negatives now only happen on genuinely broken startups.

## Test plan

- [x] typecheck + lint clean
- [ ] Manual: run \`--cycle\` on the operator's prod, watch for a green probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)