### PR TITLE
Logout: await revoke before invalidating cached galleries

### DIFF
--- a/react-app/src/components/UserMenu.tsx
+++ b/react-app/src/components/UserMenu.tsx
@@ -287,15 +287,20 @@ const UserMenu = (): React.ReactElement => {
     };
   }, [isOpen]);
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
     setIsOpen(false);
-    // Server-side revoke first so the session row is gone before we
-    // throw away local state. The server identifies the session via
-    // the refresh cookie and clears both auth cookies in the response.
-    // Fire-and-forget — local state is cleared regardless of whether
-    // the network call succeeds, so a user offline can still log out
-    // locally.
-    tokenService.logout().catch(() => {});
+    // Await server-side revoke so the cookies are actually cleared
+    // in the browser before the useQuery re-fetch (triggered by the
+    // user-state change below) fires. Otherwise the new fetch races
+    // the DELETE response and goes out with the previous user's
+    // cookies still attached — the SPA ends up showing the admin's
+    // gallery list until the next natural refetch. Fall through on
+    // network failure so an offline user can still log out locally.
+    try {
+      await tokenService.logout();
+    } catch {
+      // no-op — offline logout still clears local state below.
+    }
     // localStorage is narrowed to the `user` key so the `lang`
     // preference survives.
     window.localStorage.removeItem("user");


### PR DESCRIPTION
## Symptom

After clicking Logout: the gallery list on the dashboard still shows galleries the guest doesn't have access to. Opening one renders the empty view (since the actual auth is guest server-side); a page refresh removes them from the list.

## Root cause

\`handleLogout\` was fire-and-forget on \`tokenService.logout()\`. The follow-up \`queryClient.invalidateQueries({ queryKey: ["galleries"] })\` kicked \`<Gallery>\`'s \`useQuery\` to refetch. That refetch raced the DELETE /tokens response: if the DELETE hadn't cleared the cookies yet, the new /galleries call went out with the previous user's cookies still attached. Server returned admin's list; SPA cached it under the new (guest) query key and rendered.

## Fix

Await the DELETE /tokens before invalidating. By the time the invalidate fires, the browser has processed the response's cookie-clearing headers, so the next fetch goes out cookieless → server sees guest → returns the guest-visible gallery set. The offline case still logs out locally (network error is caught).

## Test plan

- [x] react-app 999/999, typecheck + lint clean
- [ ] Manual on prod: log in as admin, land on /m dashboard, click Logout → gallery list immediately reflects guest's visible set without needing a refresh

## Release track

rc.3 → rc.4 candidate (whenever we cut it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)