### PR TITLE
Refresh: invalidate access-derived caches + break retry loop

### DIFF
--- a/react-app/src/lib/api.ts
+++ b/react-app/src/lib/api.ts
@@ -3,6 +3,7 @@ import createClient from "openapi-fetch";
 import type { paths } from "./api-schema";
 import { beginLogin } from "./auth-redirect";
 import i18n from "./i18n";
+import { queryClient } from "./query-client";
 import UserModel from "../models/UserModel";
 import { useUserStore, useChangePasswordModalStore } from "../stores";
 
@@ -64,6 +65,15 @@ const refreshOnce = async (): Promise<boolean> => {
       } catch {
         // Body wasn't JSON-shaped — cookies still rotated, ignore.
       }
+      // Any grant / admin-flag change server-side is reflected in
+      // the refresh response (see above), but the queryKeys for
+      // access-derived caches (galleries, gallery-photos) don't
+      // include the grant set — they'd stay pinned to the stale
+      // pre-change data until the user id itself changed. Invalidate
+      // them so the next render fetches fresh. Cheap; refresh only
+      // fires every ~15 min under normal load.
+      queryClient.invalidateQueries({ queryKey: ["galleries"] });
+      queryClient.invalidateQueries({ queryKey: ["gallery-photos"] });
       return true;
     } catch {
       return false;
@@ -96,6 +106,13 @@ const expireLocalAuth = () => {
   beginLogin(i18n.t("session-expired"));
 };
 
+// Marker on the retry to prevent double-refresh loops. If the
+// refresh-and-retry response ALSO comes back 401, we've hit a case
+// the refresh didn't cure (server-side session gone, weird cookie
+// desync, etc.) — expire local auth once and give up rather than
+// looping the refresh forever.
+const RETRIED_HEADER = "x-pd-retried-after-refresh";
+
 client.use({
   // Mid-session 401 handler with refresh fallback. If a request comes
   // back 401 and a refresh succeeds (cookie or legacy localStorage),
@@ -113,13 +130,22 @@ client.use({
     if (request.method === "POST" && request.url.endsWith("/api/v1/tokens")) {
       return;
     }
+    // Already retried once and still 401 — refresh didn't fix it.
+    // Stop looping.
+    if (request.headers.get(RETRIED_HEADER)) {
+      expireLocalAuth();
+      return;
+    }
     const ok = await refreshOnce();
     if (!ok) {
       expireLocalAuth();
       return;
     }
-    // Retry the original request — cookies are now refreshed.
-    return await globalThis.fetch(request);
+    // Retry the original request — cookies are now refreshed. Mark
+    // it so a repeat 401 doesn't re-enter this handler.
+    const retryHeaders = new Headers(request.headers);
+    retryHeaders.set(RETRIED_HEADER, "1");
+    return await globalThis.fetch(request, { headers: retryHeaders });
   },
 });
 


### PR DESCRIPTION
## Symptom

Reported after a long photo-browsing session on rc.3: pressing arrow keys rapidly for a while → suddenly next/prev photos fail, month view still renders (from cache), and the gallery list is missing the private gallery the operator was browsing. UserMenu still shows the operator as logged in.

## Analysis

Two adjacent gaps in the current 401 handling:

**1. Cache staleness after refresh.**

`refreshOnce` mirrors the fresh `{id, isAdmin, editorGalleries}` into the user store + localStorage on success. But the TanStack Query cache for \`["galleries", user.id]\` and \`["gallery-photos", …]\` doesn't include the grant set in its key — the cached list stays pinned to the pre-change view. If server-side grants change between refreshes (rare in practice, but possible via admin action, password rotation on a shared session, etc.), the SPA keeps showing the old wider list until a natural refetch or reload.

Fix: invalidate both queryKeys on every successful refresh. Cheap; refresh only fires ~every 15 min under normal load.

**2. Retry loop on repeated 401.**

If the refresh-and-retry itself 401s, `onResponse` fires refresh again → new retry → possibly 401 again. The refresh keeps succeeding (rotation OK) but retries keep failing (cookie desync, session-row race, or similar). Could loop through many refresh calls until something breaks.

Fix: tag the retry with an internal header; a tagged retry that 401s expires local auth once and stops looping.

## What this doesn't fully explain

The user's specific symptom ("UI still shows logged in, gallery gone from list") — refresh-cache-staleness (1) explains the gallery-list part. The "next/prev fails" part is consistent with the same grant change (photo access lost). But the exact trigger of the grant change during a single-user session is still speculative — no other clients, no admin action. The user's own theory ("many parallel refresh calls, the last one failed") is plausible if the single-flight guard has a subtle window; #2 above blocks the resulting infinite loop.

## Test plan

- [x] react-app 999/999, typecheck + lint clean
- [ ] Manual: log in, wait for access to expire (or manipulate cookies to force 401), press arrow keys rapidly through a gallery. Refresh path should fire once, retries succeed, no cascading refreshes in devtools Network.
- [ ] Manual (contrived): manipulate DB to strip user's access mid-session; press arrow keys; SPA's gallery list refetches and reflects the new access on next refresh cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)