### PR TITLE
Cookie: pd_access Max-Age matches pd_refresh (fixes silent guest drift)

### DIFF
--- a/server/lib/auth-cookies.ts
+++ b/server/lib/auth-cookies.ts
@@ -2,18 +2,23 @@ import type { FastifyReply } from "fastify";
 
 import CONST from "./constants.js";
 
-// HttpOnly auth cookies. Two cookies because the access and refresh
-// tokens have very different lifetimes — splitting them lets the
-// browser drop the short-lived access cookie on its own without
-// touching the long-lived refresh cookie. New SPAs read neither
-// directly; same-origin requests pick up both automatically.
+// HttpOnly auth cookies. Two cookies with different roles: pd_access
+// carries a short-lived JWT (15 min), pd_refresh points at the
+// long-lived DB-tracked session row (90 days).
+//
+// Both cookies get the same Max-Age (session length). Making
+// pd_access's cookie shorter than its JWT's exp is what would cause
+// the "silent guest" bug: browsers strictly enforce Max-Age, so
+// once it elapses the cookie is gone from the jar, subsequent
+// requests carry no pd_access, and `tokenFilter` treats a missing
+// cookie as anonymous guest (no 401 to trigger the refresh path).
+// The JWT's own `exp` claim is what actually gates access — an
+// expired JWT still in the jar returns 401 and the client's
+// refresh flow kicks in normally.
 const ACCESS_COOKIE = "pd_access";
 export const REFRESH_COOKIE = "pd_refresh";
 
-const ACCESS_COOKIE_MAX_AGE_S = Math.floor(
-  CONST.ACCESS_TOKEN_LIFETIME_MS / 1000
-);
-const REFRESH_COOKIE_MAX_AGE_S = Math.floor(CONST.SESSION_LENGTH_MS / 1000);
+const COOKIE_MAX_AGE_S = Math.floor(CONST.SESSION_LENGTH_MS / 1000);
 
 const cookieOptions = (maxAgeS: number) => ({
   httpOnly: true,
@@ -29,15 +34,11 @@ export const setAuthCookies = (
   accessToken: string,
   refreshToken: string
 ): void => {
-  reply.setCookie(
-    ACCESS_COOKIE,
-    accessToken,
-    cookieOptions(ACCESS_COOKIE_MAX_AGE_S)
-  );
+  reply.setCookie(ACCESS_COOKIE, accessToken, cookieOptions(COOKIE_MAX_AGE_S));
   reply.setCookie(
     REFRESH_COOKIE,
     refreshToken,
-    cookieOptions(REFRESH_COOKIE_MAX_AGE_S)
+    cookieOptions(COOKIE_MAX_AGE_S)
   );
 };
 


### PR DESCRIPTION
## Symptom

Operator reported (rc.3): after a long photo-browsing session (arrow keys, single-tab, no admin action), the SPA suddenly shows guest-view data — private galleries drop from the list, next/prev photos 403 — while the UserMenu still shows the operator as logged in. Only manual logout+login recovers.

## Root cause

Interaction between the `pd_access` cookie's Max-Age and the server's guest-fallback:

1. \`pd_access\` had \`Max-Age = 15 min\`, matched to the JWT's \`exp\`. Intent was "cookie disappears when JWT would have expired anyway."
2. TanStack Query with 5-min staleTime + a reading-in-one-gallery flow can go 15+ min without firing any authed request that would trigger a 401 → refresh. During that window the JWT would still verify if present; the cookie just isn't consulted.
3. When 15 min elapses, the browser strictly enforces Max-Age and removes \`pd_access\` from the jar. Next request goes out with no \`pd_access\` (only \`pd_refresh\` remains).
4. \`server/lib/middleware/token-filter.ts\` falls through: \`if (!token) { request.user = guest; return; }\` — no 401 raised. Silent anonymous access.
5. SPA gets 200 OK with guest-view data. Local user state is untouched. UserMenu still shows the operator. Private galleries drop out because \`:guest\` doesn't have access.
6. No 401 anywhere → no refresh → session drifts until noticed.

## Fix

Give \`pd_access\` the same Max-Age as \`pd_refresh\` (session length, 90 days sliding). The cookie now stays in the jar longer than the JWT's own exp claim; expired-but-present JWT returns 401, refresh path fires, new tokens issued. That's the design's actual expiry mechanism — it just needs the cookie present in the jar to surface the 401.

The JWT payload's \`exp\` is unchanged (still 15 min). No change to actual access lifetime, just to which layer signals expiry to the client.

## Why not fix elsewhere?

- **Server tokenFilter falling back to guest**: this is a design choice — anonymous endpoints (\`GET /meta\`, public gallery reads) legitimately need to work without a token. Returning 401 for missing cookie would break that.
- **Proactive client-side refresh timer**: complementary but adds moving parts. The cookie-lifetime fix is one line of config; the refresh path we already have does the rest.

## Test plan

- [x] tokens.test.ts 19/19 passes (Max-Age changes don't touch the tested behavior; JWT expiry tests still hit the 15-min boundary via the JWT payload).
- [x] typecheck + lint clean.
- [ ] Manual on prod: log in, leave the tab idle for 20+ min, come back and browse. Session should still be intact (or trigger a clean 401 → refresh cycle instead of silent guest drift).

## Release track

rc.3 → rc.4 candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)