### PR TITLE
Refresh: atomic check-and-swap + client retries across cross-tab race

### DIFF
--- a/react-app/src/lib/api.ts
+++ b/react-app/src/lib/api.ts
@@ -136,15 +136,25 @@ client.use({
       expireLocalAuth();
       return;
     }
+    const retryHeaders = new Headers(request.headers);
+    retryHeaders.set(RETRIED_HEADER, "1");
     const ok = await refreshOnce();
     if (!ok) {
+      // Refresh failed — could be a cross-tab race where a sibling
+      // tab won the rotation and invalidated our submitted refresh
+      // cookie. The browser's shared jar has the sibling's fresh
+      // tokens by now, so retry the original once before giving up.
+      // If cookies weren't updated (genuine session loss), the
+      // retry 401s and we fall through to expire.
+      const retry = await globalThis.fetch(request, {
+        headers: retryHeaders,
+      });
+      if (retry.ok) return retry;
       expireLocalAuth();
-      return;
+      return retry;
     }
     // Retry the original request — cookies are now refreshed. Mark
     // it so a repeat 401 doesn't re-enter this handler.
-    const retryHeaders = new Headers(request.headers);
-    retryHeaders.set(RETRIED_HEADER, "1");
     return await globalThis.fetch(request, { headers: retryHeaders });
   },
 });

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -122,6 +122,19 @@ export default {
   ): Promise<void> => {
     await db.updateSession(sessionId, patch);
   },
+  rotateSessionHash: async (
+    sessionId: string,
+    expectedHash: string,
+    newHash: string,
+    lastUsedAt: number
+  ): Promise<boolean> => {
+    return await db.rotateSessionHash(
+      sessionId,
+      expectedHash,
+      newHash,
+      lastUsedAt
+    );
+  },
   deleteSession: async (sessionId: string): Promise<void> => {
     await db.deleteSession(sessionId);
   },

--- a/server/db/sqlite3/index.ts
+++ b/server/db/sqlite3/index.ts
@@ -63,6 +63,7 @@ export default () => {
     createSession,
     loadSession,
     updateSession,
+    rotateSessionHash,
     deleteSession,
     deleteUserSessions,
 
@@ -226,6 +227,28 @@ const updateSession = async (
   const { query, values } = SCHEMA.session.buildUpdateByIdQuery(patch);
   if (!query || !values) return;
   db.prepare(query).run([...values, sessionId]);
+};
+// Atomic check-and-swap for the refresh-token rotation. Returns true
+// if exactly one row was updated — meaning we are the winning caller
+// in a concurrent-refresh race. Returns false if 0 rows matched —
+// some other request already rotated the same session (the WHERE
+// clause's `refresh_token_hash = ?` no longer matches). The caller
+// throws InvalidTokenError in that case; the client's cross-tab
+// retry path picks up the winner's fresh cookies from the shared
+// jar and re-issues the original request.
+const rotateSessionHash = async (
+  sessionId: string,
+  expectedHash: string,
+  newHash: string,
+  lastUsedAt: number
+): Promise<boolean> => {
+  const info = db
+    .prepare(
+      "UPDATE session SET refresh_token_hash = ?, last_used_at = ? " +
+        "WHERE id = ? AND refresh_token_hash = ?"
+    )
+    .run(newHash, lastUsedAt, sessionId, expectedHash);
+  return info.changes === 1;
 };
 const deleteSession = async (sessionId: string): Promise<void> =>
   deleteById(SCHEMA.session, sessionId);

--- a/server/models/token.ts
+++ b/server/models/token.ts
@@ -140,13 +140,22 @@ const verifyAndRotateRefresh = async (
   }
   const ok = await bcrypt.compare(parsed.secret, row.refresh_token_hash);
   if (!ok) throw new InvalidTokenError();
-  // Rotate: generate a new secret, replace the hash, and update last_used_at.
+  // Rotate: generate a new secret, replace the hash, and update
+  // last_used_at. Atomic check-and-swap: the DB UPDATE only lands
+  // if the row's hash is still what we compared against — if a
+  // concurrent refresh call (typically a sibling tab) already
+  // rotated, we lose the race and throw. The client retries the
+  // original request; the browser's cookie jar has the winner's
+  // fresh tokens by then, so the retry succeeds.
   const newSecret = randomBytes(REFRESH_SECRET_BYTES).toString("base64url");
   const newHash = await bcrypt.hash(newSecret, SALT_ROUNDS);
-  await db.updateSession(parsed.sessionId, {
-    refresh_token_hash: newHash,
-    last_used_at: Date.now(),
-  });
+  const won = await db.rotateSessionHash(
+    parsed.sessionId,
+    row.refresh_token_hash,
+    newHash,
+    Date.now()
+  );
+  if (!won) throw new InvalidTokenError();
   return {
     userId: row.user_id,
     refreshToken: `${parsed.sessionId}.${newSecret}`,


### PR DESCRIPTION
## Motivation

Per the multi-tab Q&A: two tabs firing \`/api/v1/tokens/refresh\` at almost the same moment can put the "loser" tab in a spurious \`expireLocalAuth\` → login modal state, even though the session is otherwise fine (the "winner" tab already rotated and the browser jar has valid tokens).

The user hasn't hit this in practice; this is the pre-emptive fix.

## Change

**Server (\`verifyAndRotateRefresh\`)**: new \`db.rotateSessionHash(sessionId, expectedHash, newHash, lastUsedAt)\` op that does an atomic check-and-swap:

```sql
UPDATE session
SET refresh_token_hash = ?, last_used_at = ?
WHERE id = ? AND refresh_token_hash = ?
```

Returns \`true\` iff 1 row changed (this call won the race). \`false\` iff 0 rows — the row's hash was already rotated by a concurrent call. Model throws \`InvalidTokenError\` on \`false\`, same status code as before but a deterministic trigger.

**Client (\`api.ts\` \`onResponse\`)**: on refresh failure, retry the original request once before firing \`expireLocalAuth\`. If the sibling tab's rotation already put fresh tokens in the shared cookie jar, the retry uses them and succeeds. If not (genuine session loss), the retry 401s and expire fires as before. The existing \`RETRIED_HEADER\` marker keeps this from looping.

## Not covered

- Same-tab back-to-back refresh calls are already single-flight via \`refreshInFlight\`. This change targets cross-tab races only.
- If both tabs 401 at effectively the same instant AND the losing tab's retry runs before the winner's Set-Cookie has hit the jar, the retry can still 401. That's a very narrow window; the client's \`refreshOnce\` will fire another refresh (single-flight again), which the retry-on-fail path handles. Bounded by the \`RETRIED_HEADER\` marker so it can't loop.

## Test plan

- [x] tokens tests + models tests: 30/30 pass. No test relied on the pre-atomic behavior.
- [x] Server typecheck + lint clean.
- [x] react-app 999/999, typecheck + lint clean.
- [ ] Manual reproduction (contrived): open two tabs, force both to 401 at ~same time (devtools "Application → Storage → Delete cookie" for \`pd_access\` in both, then trigger an authed API call in both quickly). Loser tab should stay authed instead of showing the "session expired" modal.

## Release track

rc.3 → rc.4 candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)