### PR TITLE
Photo modal: gate arrow navigation on fresh neighbors

### DIFF
--- a/react-app/src/components/Gallery/Photo/index.tsx
+++ b/react-app/src/components/Gallery/Photo/index.tsx
@@ -324,7 +324,7 @@ const Photo = ({
     () => filter.toServerFilters(filters),
     [filters]
   );
-  const { data: neighbors } = useQuery({
+  const { data: neighbors, isPlaceholderData } = useQuery({
     queryKey: [
       "gallery-photo-neighbors",
       gallery.id(),
@@ -405,24 +405,38 @@ const Photo = ({
   const SPRING = { type: "spring", stiffness: 400, damping: 40 } as const;
   const SLIDE = { duration: 0.18, ease: "easeOut" } as const;
 
+  // Gate arrow-key / swipe navigation on having FRESH neighbors for
+  // the current photo. `keepPreviousData` keeps the previous photo's
+  // neighbors visible while the new photo's fetch is in flight so
+  // the slide-out lands on a real neighbor thumbnail — but the
+  // navigation callbacks were reading those stale neighbors too. A
+  // second arrow press within that ~50–100 ms fetch window would
+  // navigate against the OLD photo's prev/next: same-photo "double
+  // transition" on repeated Right, or a skipped photo on
+  // Right-then-Left. Once fresh neighbors arrive, isPlaceholderData
+  // flips false and navigation re-enables.
+  const canNavigate = !isPlaceholderData;
+
   const animateToPrev = React.useCallback(async () => {
-    if (!prevPhoto) return;
+    if (!prevPhoto || !canNavigate) return;
     await trackControls.start({ x: TRACK_PREV, transition: SLIDE });
     navigate(prevPhoto.path(gallery));
-  }, [prevPhoto, gallery, navigate, trackControls]);
+  }, [prevPhoto, canNavigate, gallery, navigate, trackControls]);
 
   const animateToNext = React.useCallback(async () => {
-    if (!nextPhoto) return;
+    if (!nextPhoto || !canNavigate) return;
     await trackControls.start({ x: TRACK_NEXT, transition: SLIDE });
     navigate(nextPhoto.path(gallery));
-  }, [nextPhoto, gallery, navigate, trackControls]);
+  }, [nextPhoto, canNavigate, gallery, navigate, trackControls]);
 
   const handlMoveToFirst = () => {
+    if (!canNavigate) return;
     if (firstPhoto && firstPhoto.id() !== photo.id()) {
       navigate(firstPhoto.path(gallery));
     }
   };
   const handlMoveToLast = () => {
+    if (!canNavigate) return;
     if (lastPhoto && lastPhoto.id() !== photo.id()) {
       navigate(lastPhoto.path(gallery));
     }


### PR DESCRIPTION
## Symptom

Reported: pressing arrow keys quickly in the Photo modal sometimes shows the same photo transitioning twice, or Right-then-Left skips a photo instead of returning to the previous one.

## Root cause

The neighbors query uses \`placeholderData: keepPreviousData\` so the slide-out animation lands on a real thumbnail (~180 ms transition) instead of flashing empty during the refetch. But the navigation callbacks were reading those same stale-during-refetch values. Within the ~50–100 ms window while the new photo's fresh neighbors are fetching:

- **Right, Right**: second press captures OLD photo's \`nextPhoto\` = the photo we just moved to → \`navigate(currentUrl)\` → the slide animation replays against the same URL. Reads as "same photo transitioned twice."
- **Right, Left**: second press captures OLD photo's \`prevPhoto\` = the photo BEFORE the source → skips the intended target.

## Fix

Gate \`animateToPrev\` / \`animateToNext\` / \`handleMoveToFirst\` / \`handleMoveToLast\` on \`!isPlaceholderData\`. Once fresh neighbors arrive (isPlaceholderData flips to false), arrows re-enable. The animation still uses \`keepPreviousData\` so the visual slide still lands on the previous photo's neighbors — no regression to the "empty slide" flash the placeholder was fixing.

## Test plan

- [x] react-app 999/999, typecheck + lint clean
- [ ] Manual: rapid-fire Right, Right in the Photo modal — arrows queue-and-discard cleanly, no double-transition
- [ ] Manual: rapid-fire Right, Left — returns to the source photo (no skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)