### PR TITLE
Release 1.0.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+## [1.0.0-rc.4] - 2026-07-08
+
+Session-hardening rc surfaced by longer prod verification. Focus is on the "session goes stale mid-session while the UI still shows logged in" pattern and its adjacent cases (logout race, cross-tab refresh, arrow-key nav during in-flight neighbor fetch). Plus operator-tooling polish.
+
+### Operator
+
+- `bin/instance.ts --cycle`'s post-restart `/api/v1/meta` probe polls with a 500 ms interval up to a 15 s overall budget instead of one-shot with a 5 s timeout. The rc.3 boot-time CSP prime added enough synchronous DB work that first-boot-after-upgrade could push the first responding moment past 5 s on slower disks — false-alarming an otherwise-healthy cycle. Closes #691.
+
+### Frontend
+
+- `pd_access` cookie Max-Age now matches `pd_refresh` (session length). Under the old 15-minute Max-Age, if the SPA didn't fire an authed request within any 15-minute window (TanStack's 5-minute staleTime + reading-in-one-gallery flow could produce this), the browser removed the cookie from the jar. Subsequent requests carried no `pd_access`; `tokenFilter` treats a missing cookie as anonymous `:guest` (no 401 raised — anonymous access is a supported code path), so the SPA got 200s with guest-view data and no signal to refresh. Session appeared to drift silently: private galleries dropped from the list, gated endpoints 403'd. The JWT's own `exp` claim (still 15 min) is what enforces access lifetime server-side — an expired-but-present JWT returns 401, which the client's refresh flow handles cleanly. Closes #695.
+- Refresh-token rotation is now an atomic check-and-swap. New `db.rotateSessionHash(id, expectedHash, newHash, at)` driver op does `UPDATE session SET hash = ?, last_used_at = ? WHERE id = ? AND refresh_token_hash = ?` — the loser in a cross-tab race gets a deterministic 0-rows-changed instead of a fuzzy bcrypt-mismatch fallout. The client-side `onResponse` handler retries the original request once on refresh failure so a cross-tab race resolves by picking up the winner's tokens from the shared cookie jar instead of spuriously firing a "session expired" modal in the losing tab. Closes #696.
+- Photo-modal arrow-key navigation waits for fresh neighbors. The neighbors query's `keepPreviousData` (kept for the slide animation) meant rapid arrow presses within the ~50-100 ms refetch window read stale prev/next values — Right-then-Right could re-animate the same photo, Right-then-Left could skip. `animateToPrev` / `animateToNext` / Home / End now gate on `!isPlaceholderData`. Closes #697.
+- Refresh path invalidates access-derived caches (`galleries`, `gallery-photos`) so grant / admin-flag changes surfaced by a refresh response don't leave stale cached lists behind. Retry loop broken with an `x-pd-retried-after-refresh` header so a retried 401 expires cleanly instead of recursing. Closes #694.
+- Logout awaits the server-side revoke before invalidating the gallery cache. Previously fire-and-forget: the invalidate's follow-up refetch raced the DELETE and sometimes went out with the previous user's cookies, leaving the SPA showing admin's gallery list to a guest until the next reload. Closes #693.
+- Finnish translations for the virtual-host switcher and `/m/instance` known-hosts editor: `isäntä` → `sivusto` (site), `isäntänimi` → `verkkotunnus`, `selite` → `kuvaus`. The literal Finnish "host" reads as party-host in a tech UI. Closes #692.
+
 ## [1.0.0-rc.3] - 2026-07-02
 
 Second bugfix rc on rc.1's virtual-host / SSO work. Ships the SSO story end-to-end (federated login from non-main hosts) plus polish surfaced by operator prod verification.
@@ -712,6 +729,7 @@ Release candidate for 1.0. Cumulative 0.18 → 1.0 changes: end of the JWT-cooki
 
 ## Initial commit - 2020-07-04
 
+[1.0.0-rc.4]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.3...v1.0.0-rc.4
 [1.0.0-rc.3]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.2...v1.0.0-rc.3
 [1.0.0-rc.2]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.1...v1.0.0-rc.2
 [1.0.0-rc.1]: https://github.com/vlumi/photo-diary/compare/v0.18.0...v1.0.0-rc.1

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Per-instance state — the SQLite DB, the `photos/` tree, `.env` — lives in a 
 
 Active milestones on the way to 1.0, plus the far-out 2.0 direction. Each bullet links the GitHub milestone for live status.
 
-- [**1.0**](https://github.com/vlumi/photo-diary/milestone/4) — Soak the accumulated security + polish work in prod, then stamp. `1.0.0-rc.3` cut 2026-07-02 (SSO landing + federated login end-to-end, plus CSP + double-scrollbar fixes surfaced by prod verification). Feature freeze until 1.0; rc.4+ ships only if further verification surfaces regressions.
+- [**1.0**](https://github.com/vlumi/photo-diary/milestone/4) — Soak the accumulated security + polish work in prod, then stamp. `1.0.0-rc.4` cut 2026-07-08 (session-hardening pass: `pd_access` cookie lifetime, atomic refresh rotation, photo-modal nav race, and adjacent fixes surfaced by extended prod verification). Feature freeze until 1.0; rc.5+ ships only if further verification surfaces regressions.
 - [**2.0 — Thin server, cloud-native direction**](https://github.com/vlumi/photo-diary/milestone/18) *(direction-setting, far out)* — originals leave the server for client-side / cold storage, the converter's sharp pipeline becomes a bundled local uploader, all DB ops route through the API, storage backends behind a vendor-agnostic interface. Likely diverges from today's self-hosted-monolith shape enough that it may end up being a different product line.
 
 ## Backlog
@@ -200,6 +200,6 @@ Third structural take on a long-running personal photo-gallery side project — 
 - **0.16** (Jun 2026) — Filter & viewing UX polish: redesigned filter widget (inline strip + per-category modal cards with faceted counts), continuous-variable range filters, stacked-area evolution chart, virtual-gallery edit page + hybrid-source admin UI, persistent map modal.
 - **0.17** (Jun 2026) — Admin UI shift to layered modals + Section card primitive; per-photo visibility + editor-tier admin actions on `/g/`; `/m/instance` page with runtime-overridable `meta` defaults; configurable rendition ladder + collapsed `photos/display/<maxDim>/` layout; `/m/photos` filters move into a modal; Stats Evolution adds `weekday` and `hour`; Finnish geocoding cleanup (state-code lvl fallthrough + script-rule address blob filter).
 - **0.18** (Jun 2026) — Cleanup + observability: `meta` table is the only source for SPA runtime defaults (no `.env` fallback); `/m/operations` admin page surfaces converter activity, pending queues, and failures; tidied `bin/photo.ts` surface; vitest coverage wired; frontend security audit pass; auth tokens move from localStorage to HttpOnly cookies.
-- **1.0-rc.3** (Jul 2026) — Release candidate for 1.0. End of the JWT-cookie transition, CSP enable pass, cross-host SSO for the UserMenu virtual-host switcher (with federated login from non-main hosts), Playwright e2e suite, docs overhaul, session-state reconcile on boot + across tabs, review-driven cleanup pass. Feature freeze until 1.0.
+- **1.0-rc.4** (Jul 2026) — Release candidate for 1.0. End of the JWT-cookie transition, CSP enable pass, cross-host SSO for the UserMenu virtual-host switcher (with federated login from non-main hosts), Playwright e2e suite, docs overhaul, session-state reconcile on boot + across tabs, session-hardening pass. Feature freeze until 1.0.
 
 See the [Roadmap](#roadmap) for what's in flight after 1.0.

--- a/SETUP.md
+++ b/SETUP.md
@@ -79,13 +79,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  1.0.0-rc.3/                               #   so different instances can run different versions
+  1.0.0-rc.4/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/1.0.0-rc.3      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/1.0.0-rc.4      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  thumbnail/        # display/<maxDim>/ subdirs auto-created on intake
@@ -112,7 +112,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=1.0.0-rc.3
+V=1.0.0-rc.4
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -127,7 +127,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/1.0.0-rc.3/bin/instance.ts /var/photo-diary/dailybw
+/opt/photo-diary/1.0.0-rc.4/bin/instance.ts /var/photo-diary/dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -159,7 +159,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/1.0.0-rc.3/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
+/opt/photo-diary/1.0.0-rc.4/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                                # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                                     # migration runner applies any schema bumps
@@ -176,7 +176,7 @@ The DB backup is named `db.sqlite3.pre-<new-version>` — a plain file copy that
 The multi-instance layout never garbage-collects old `/opt/photo-diary/<version>/` directories — each one is 400+ MB (`sharp`, `better-sqlite3`, etc. in `node_modules`), so after a dozen releases they add up. `bin/instance.ts gc` scans the conventional layout and reports versions that no scanned instance references:
 
 ```sh
-/opt/photo-diary/1.0.0-rc.3/bin/instance.ts gc
+/opt/photo-diary/1.0.0-rc.4/bin/instance.ts gc
 ```
 
 It walks `/var/photo-diary/*/code` symlinks to collect what's in use, then prints anything under `/opt/photo-diary/` that isn't in that set, along with sizes and the `rm -rf` commands you would run. It never deletes — an operator with non-conventional instance layouts may have instances outside `/var/photo-diary/` that reference these dirs, so the actual `rm` is left to you after reviewing. Override the scan roots with `--code-root` / `--instances-root` if your layout differs.

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1"
   },
-  "version": "1.0.0-rc.3"
+  "version": "1.0.0-rc.4"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0-rc.4",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -71,5 +71,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "1.0.0-rc.3"
+  "version": "1.0.0-rc.4"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "1.0.0-rc.3"
+    "version": "1.0.0-rc.4"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -60,5 +60,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "1.0.0-rc.3"
+  "version": "1.0.0-rc.4"
 }


### PR DESCRIPTION
## Summary

Session-hardening rc surfaced by extended prod verification. Seven PRs bundled since rc.3 (2026-07-02).

The theme: the "session goes stale mid-session while UI still shows logged in" pattern (traced to \`pd_access\` Max-Age dropping the cookie silently, plus a couple of adjacent races and cache-staleness gaps).

## Bundled PRs

**Session / auth:**
- **#695** — \`pd_access\` cookie Max-Age matches \`pd_refresh\`. Fixes the silent-guest drift when the browser removes the access cookie after 15 min. JWT \`exp\` claim still enforces the 15-min access lifetime server-side.
- **#696** — Atomic check-and-swap on refresh-token rotation (server) + client retries original once on refresh failure. Cross-tab race resolves via the shared cookie jar instead of expiring the loser.
- **#694** — Refresh path invalidates access-derived caches (\`galleries\`, \`gallery-photos\`) so grant / admin-flag changes get picked up. Retry loop bounded with an \`x-pd-retried-after-refresh\` marker.
- **#693** — Logout awaits the DELETE /tokens before invalidating gallery cache, so refetches don't race the cookie clearing.

**UI:**
- **#697** — Photo modal arrow navigation gated on \`!isPlaceholderData\` so rapid keys during the neighbors-refetch window don't act on stale prev/next values.
- **#692** — Finnish i18n polish (host → sivusto, hostname → verkkotunnus).

**Operator:**
- **#691** — \`bin/instance.ts --cycle\` probe polls with backoff to avoid false-alarming on slower first-boot-after-upgrade cycles.

## Release step touchpoints (per AGENTS.md)

- Version bumped `1.0.0-rc.3` → `1.0.0-rc.4` in root + server + react-app + converter `package.json`.
- `server/openapi.json` regenerated; `react-app/src/lib/api-schema.ts` re-codegen'd (unchanged content — no route or schema deltas since rc.3).
- `CHANGELOG.md`: new `[1.0.0-rc.4] - 2026-07-08` section with a one-paragraph summary + Operator / Frontend bullets; diff-link at footer.
- `README.md`: Roadmap 1.0 pointer + Version History rc.3 entry replaced with rc.4.
- `SETUP.md`: install / upgrade / gc examples bumped in six sites.

## Not in this PR (post-merge)

- Tag `v1.0.0-rc.4` + push.
- Publish GitHub Release (prerelease) with the `[1.0.0-rc.4]` CHANGELOG section as notes.

## Test plan

- [x] Full test pass: react-app 999/999, server 952/952, converter 28/28.
- [x] typecheck + lint clean; react-app build green.
- [ ] Manual on prod: long-running photo browsing session (arrow keys, single-tab) no longer surfaces the "silent guest" drift after ~15 min idle. Cross-tab concurrent refresh doesn't spuriously log out the loser. Photo arrow-key spam doesn't skip photos.
- [ ] CI (4 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)