### PR TITLE
Stats: show all inline rows for bounded time categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "0.18.0",
+  "version": "1.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "0.18.0",
+      "version": "1.0.0-rc.5",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -20,7 +20,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "0.18.0",
+      "version": "1.0.0-rc.5",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -3349,7 +3349,7 @@
       "version": "26.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
       "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -3365,7 +3365,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -10743,7 +10743,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -10810,7 +10810,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -11416,7 +11416,7 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "0.18.0",
+      "version": "1.0.0-rc.5",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -11691,7 +11691,7 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "0.18.0",
+      "version": "1.0.0-rc.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/react-app/src/components/Gallery/Stats/Table.tsx
+++ b/react-app/src/components/Gallery/Stats/Table.tsx
@@ -250,7 +250,11 @@ const Table = ({
 
   const fullTable = category.table;
   const isInline = limit !== undefined;
-  const shouldCap = isInline && fullTable.length > limit;
+  // Categories with a finite, well-defined value set (month, weekday,
+  // hour) opt out of the cap so the reader sees the full distribution
+  // inline instead of an arbitrary "+ N more…" cut.
+  const shouldCap =
+    isInline && !category.inlineShowAll && fullTable.length > limit;
   // Inline view defaults to top-by-count so the 10-row preview reads
   // as "the headlines" for categories with no inherent ordering (gear,
   // people, country, etc.). Time categories (year-month / year /

--- a/react-app/src/lib/stats.test.ts
+++ b/react-app/src/lib/stats.test.ts
@@ -459,6 +459,26 @@ describe("collectTopics", () => {
     expect((topics[0].categories[3] as any).photos).toBe(mapPhotos);
   });
 
+  test("inlineShowAll is set on bounded time categories (month/weekday/hour) only", () => {
+    const topics = stats.collectTopics(
+      baseData(),
+      "en",
+      mockT,
+      mockCountryData,
+      mockTheme
+    );
+    const time = topics.find((tt) => tt.key === "time")!;
+    const byKey = Object.fromEntries(
+      time.categories.map((c) => [c.key, c.inlineShowAll ?? false])
+    );
+    expect(byKey.month).toBe(true);
+    expect(byKey.weekday).toBe(true);
+    expect(byKey.hour).toBe(true);
+    // Unbounded time categories keep the cap.
+    expect(byKey.year).toBe(false);
+    expect(byKey["year-month"]).toBe(false);
+  });
+
   test("geotaggedCount=0 does not emit location category", () => {
     const data = baseData();
     data.count.geotaggedCount = 0;

--- a/react-app/src/lib/stats.tsx
+++ b/react-app/src/lib/stats.tsx
@@ -117,6 +117,11 @@ export interface StatsCategory {
   // hour read inline as a top-N-by-count list that doesn't line up
   // with the line / polar chart above it.
   naturalInlineOrder?: boolean;
+  // Skip the inline row cap for categories whose value set is finite
+  // and small (month = 12, weekday = 7, hour = 24). A "+ N more…"
+  // trailer on a bounded distribution reads as an arbitrary cut of a
+  // list the reader already knows in full.
+  inlineShowAll?: boolean;
 }
 // Expanded Summary view (SummaryModal). Four sub-trees:
 // period (when), peaks (how concentrated), variety (how varied),
@@ -1002,6 +1007,7 @@ const collectTopics = (
       title: t("stats-category-month"),
       valueSortable: true,
       naturalInlineOrder: true,
+      inlineShowAll: true,
       charts: [
         { type: "polar", data, options: chartOptions.polar },
         { type: "horizontal-bar", data, options: chartOptions.bar },
@@ -1044,6 +1050,7 @@ const collectTopics = (
       title: t("stats-category-weekday"),
       valueSortable: true,
       naturalInlineOrder: true,
+      inlineShowAll: true,
       charts: [
         { type: "polar", data, options: chartOptions.polar },
         { type: "horizontal-bar", data, options: chartOptions.bar },
@@ -1083,6 +1090,7 @@ const collectTopics = (
       title: t("stats-category-hour"),
       valueSortable: true,
       naturalInlineOrder: true,
+      inlineShowAll: true,
       charts: [
         { type: "polar", data, options: chartOptions.polar },
         { type: "horizontal-bar", data, options: chartOptions.bar },


### PR DESCRIPTION
## Summary

The inline stats category card capped at 10 rows across the board, which reads as an arbitrary cut for categories whose value set is finite and well-defined:

- **month** — 12 rows, cut to 10.
- **hour** — 24 rows, cut to 10.
- **weekday** — 7 rows, already fits (unaffected by the fix, but grouped in the same class).

The reader already knows the full domain of these axes; a "+ N more…" trailer implies there's more data behind the cut when there isn't any. Contrast with unbounded time categories (year, year-month) where the cap still makes sense.

## Change

Add \`inlineShowAll?: boolean\` to \`StatsCategory\`, set it on month / weekday / hour in \`collectTopics\`, and let \`<Table>\` skip the row cap when the flag is set. Modal behaviour unchanged (limit is only defined on the inline path).

## Not changed

- Year / year-month keep the cap — their value sets grow with the collection.
- All non-time categories (author, camera, country, exposure, etc.) keep the cap. The "top 10" preview is still the right framing when the tail is genuinely long.

## Test plan

- [x] Full test pass: react-app 1000/1000 (added targeted collectTopics assertion).
- [x] typecheck + lint clean.
- [x] Manual on prod: month shows all 12; hour shows all 24; year and year-month still cap at 10 with the "+ N more…" trailer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)