### PR TITLE
Skip token verification on cross-host SSO consume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Server
+
+- Cross-host SSO consume (`GET /api/v1/tokens/sso`) skips `pd_access` verification. It's the target-host equivalent of login/refresh/logout — the endpoint exists to establish a fresh session from a signed ticket, so requiring a valid access cookie to get there is a chicken-and-egg block. A user switching hosts via the UserMenu with a stale/expired cookie left on the target from a prior session used to land on raw `{"error":"Token expired"}` JSON on the target's URL bar instead of the redirect.
+
 ### Frontend
 
 - Stats inline category card shows every row for month / weekday / hour instead of capping at 10. Those categories have a finite, well-defined value set (12 / 7 / 24 rows) — a "+ N more…" trailer read as an arbitrary cut of a distribution the reader already knows in full. Year and year-month keep the cap; their domains grow with the collection. Closes #701.

--- a/server/lib/middleware/token-filter.ts
+++ b/server/lib/middleware/token-filter.ts
@@ -26,6 +26,12 @@ const isNoAuthEndpoint = (url: string, method: string): boolean => {
   if (path === "/api/v1/tokens" && (method === "POST" || method === "DELETE")) {
     return true;
   }
+  // Cross-host SSO: the browser navigates to /api/v1/tokens/sso on the
+  // target host with a signed ticket in the query. The endpoint mints
+  // a fresh session from that ticket — running the token filter here
+  // would 401 out the recovery flow when the target host holds a
+  // stale pd_access from a prior session.
+  if (path === "/api/v1/tokens/sso" && method === "GET") return true;
   // /api/v1/meta is public — SPA reads it on every boot for the
   // instance's default theme / feature flags. A stale pd_access
   // cookie must not block SPA boot.

--- a/server/tests/api/sso.test.ts
+++ b/server/tests/api/sso.test.ts
@@ -161,6 +161,23 @@ describe("Cross-host SSO consume", () => {
     expect(res.headers["location"]).toBe("/");
   });
 
+  test("stale pd_access on the target host doesn't block the SSO consume", async () => {
+    // Regression: /api/v1/tokens/sso is the recovery path a cross-host
+    // hop uses to establish a fresh session on the target host. If the
+    // browser still holds a stale/expired pd_access cookie from an
+    // earlier session there, tokenFilter used to 401 before /sso ran
+    // — the user saw raw `{"error":"Token expired"}` JSON on the
+    // target host's URL bar after clicking the UserMenu host link.
+    const token = await mintTokenFor("admin", "127.0.0.1");
+    const res = await api
+      .get(
+        `/api/v1/tokens/sso?token=${encodeURIComponent(token)}&redirect=${encodeURIComponent("/g/dailybw")}`
+      )
+      .set("Cookie", "pd_access=eyJmYWtl.fake.token")
+      .expect(302);
+    expect(res.headers["location"]).toBe("/g/dailybw");
+  });
+
   test("session cookies issued by the consume verify on the next request", async () => {
     const token = await mintTokenFor("admin", "127.0.0.1");
     const ssoRes = await api


### PR DESCRIPTION
## Summary

Gap in #699's stale-cookie recovery pass: \`GET /api/v1/tokens/sso\` wasn't in \`isNoAuthEndpoint\`, so a UserMenu host switch (e.g. dailybw → photos) with a stale/expired \`pd_access\` on the target host from an earlier session landed on raw \`{\"error\":\"Token expired\"}\` JSON in the target's URL bar instead of the SSO redirect.

## Root cause

\`/api/v1/tokens/sso\` is the target-host equivalent of login / refresh / logout — the endpoint exists to establish a fresh session from a signed cross-host ticket. Requiring a valid access cookie on the target host to reach it is a chicken-and-egg block. The other three recovery paths were added to \`isNoAuthEndpoint\` in #699; this one was missed because it's a GET (the token travels in the query string, not a request body).

## Fix

Add \`GET /api/v1/tokens/sso\` to \`isNoAuthEndpoint\`. Regression test asserts the consume 302s cleanly even when the browser sends a stale/invalid \`pd_access\` alongside the SSO request.

## Test plan

- [x] Full server test suite green (957/957, +1 regression test).
- [x] typecheck + lint clean.
- [ ] Prod verification: UserMenu switch from a child host to the parent works even after the target host's \`pd_access\` has expired or been invalidated (e.g. after a password rotation on the target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)