### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-07-19
+
+Released unchanged from `1.0.0-rc.6` after prod verification. See the [Version History](README.md#version-history) in the README for the milestone-level summary of what this release covers.
+
 ## [1.0.0-rc.6] - 2026-07-13
 
 Small follow-up. One recovery-path gap in the token filter (cross-host SSO consume was missed by the rc.5 refactor), plus a stats-card polish surfaced by prod use.
@@ -753,6 +757,7 @@ Release candidate for 1.0. Cumulative 0.18 → 1.0 changes: end of the JWT-cooki
 
 ## Initial commit - 2020-07-04
 
+[1.0.0]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.6...v1.0.0
 [1.0.0-rc.6]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.5...v1.0.0-rc.6
 [1.0.0-rc.5]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.4...v1.0.0-rc.5
 [1.0.0-rc.4]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.3...v1.0.0-rc.4

--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ Per-instance state — the SQLite DB, the `photos/` tree, `.env` — lives in a 
 
 ## Roadmap
 
-Active milestones on the way to 1.0, plus the far-out 2.0 direction. Each bullet links the GitHub milestone for live status.
+Where the project is headed. Each bullet links the GitHub milestone for live status.
 
-- [**1.0**](https://github.com/vlumi/photo-diary/milestone/4) — Soak the accumulated security + polish work in prod, then stamp. `1.0.0-rc.6` cut 2026-07-13 (rc.5 follow-up: cross-host SSO consume was still verifying `pd_access` and stranding UserMenu host switches with a stale cookie on the target; also a small stats polish). Feature freeze until 1.0; rc.7+ ships only if further verification surfaces regressions.
+- **1.0** — shipped 2026-07-19 (see the [Version History](#version-history) entry below).
 - [**2.0 — Thin server, cloud-native direction**](https://github.com/vlumi/photo-diary/milestone/18) *(direction-setting, far out)* — originals leave the server for client-side / cold storage, the converter's sharp pipeline becomes a bundled local uploader, all DB ops route through the API, storage backends behind a vendor-agnostic interface. Likely diverges from today's self-hosted-monolith shape enough that it may end up being a different product line.
 
 ## Backlog
@@ -200,6 +200,6 @@ Third structural take on a long-running personal photo-gallery side project — 
 - **0.16** (Jun 2026) — Filter & viewing UX polish: redesigned filter widget (inline strip + per-category modal cards with faceted counts), continuous-variable range filters, stacked-area evolution chart, virtual-gallery edit page + hybrid-source admin UI, persistent map modal.
 - **0.17** (Jun 2026) — Admin UI shift to layered modals + Section card primitive; per-photo visibility + editor-tier admin actions on `/g/`; `/m/instance` page with runtime-overridable `meta` defaults; configurable rendition ladder + collapsed `photos/display/<maxDim>/` layout; `/m/photos` filters move into a modal; Stats Evolution adds `weekday` and `hour`; Finnish geocoding cleanup (state-code lvl fallthrough + script-rule address blob filter).
 - **0.18** (Jun 2026) — Cleanup + observability: `meta` table is the only source for SPA runtime defaults (no `.env` fallback); `/m/operations` admin page surfaces converter activity, pending queues, and failures; tidied `bin/photo.ts` surface; vitest coverage wired; frontend security audit pass; auth tokens move from localStorage to HttpOnly cookies.
-- **1.0-rc.6** (Jul 2026) — Release candidate for 1.0. End of the JWT-cookie transition, CSP enable pass, cross-host SSO for the UserMenu virtual-host switcher (with federated login from non-main hosts), Playwright e2e suite, docs overhaul, session-state reconcile on boot + across tabs, session-hardening pass. Feature freeze until 1.0.
+- **1.0** (Jul 2026) — Stable milestone. End of the JWT-cookie transition, CSP enable pass, cross-host SSO for the UserMenu virtual-host switcher (with federated login from non-main hosts), Playwright e2e suite, docs overhaul, session-state reconcile on boot + across tabs, session-hardening pass across six rcs. From here, further work ships as patch releases or moves onto the 2.0 direction.
 
 See the [Roadmap](#roadmap) for what's in flight after 1.0.

--- a/SETUP.md
+++ b/SETUP.md
@@ -79,13 +79,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  1.0.0-rc.6/                               #   so different instances can run different versions
+  1.0.0/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/1.0.0-rc.6      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/1.0.0      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  thumbnail/        # display/<maxDim>/ subdirs auto-created on intake
@@ -112,7 +112,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=1.0.0-rc.6
+V=1.0.0
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -127,7 +127,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/1.0.0-rc.6/bin/instance.ts /var/photo-diary/dailybw
+/opt/photo-diary/1.0.0/bin/instance.ts /var/photo-diary/dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -159,7 +159,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/1.0.0-rc.6/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
+/opt/photo-diary/1.0.0/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                                # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                                     # migration runner applies any schema bumps
@@ -176,7 +176,7 @@ The DB backup is named `db.sqlite3.pre-<new-version>` — a plain file copy that
 The multi-instance layout never garbage-collects old `/opt/photo-diary/<version>/` directories — each one is 400+ MB (`sharp`, `better-sqlite3`, etc. in `node_modules`), so after a dozen releases they add up. `bin/instance.ts gc` scans the conventional layout and reports versions that no scanned instance references:
 
 ```sh
-/opt/photo-diary/1.0.0-rc.6/bin/instance.ts gc
+/opt/photo-diary/1.0.0/bin/instance.ts gc
 ```
 
 It walks `/var/photo-diary/*/code` symlinks to collect what's in use, then prints anything under `/opt/photo-diary/` that isn't in that set, along with sizes and the `rm -rf` commands you would run. It never deletes — an operator with non-conventional instance layouts may have instances outside `/var/photo-diary/` that reference these dirs, so the actual `rm` is left to you after reviewing. Override the scan roots with `--code-root` / `--instances-root` if your layout differs.

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1"
   },
-  "version": "1.0.0-rc.6"
+  "version": "1.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.0",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -71,5 +71,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "1.0.0-rc.6"
+  "version": "1.0.0"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "1.0.0-rc.6"
+    "version": "1.0.0"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -60,5 +60,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "1.0.0-rc.6"
+  "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary

Stable **1.0.0** milestone. Content unchanged from \`1.0.0-rc.6\` after prod soak — no new fixes or features since. The rc.1-6 arc bundled: end of the JWT-cookie transition, CSP enable pass, cross-host SSO with federated login from non-main hosts, Playwright e2e suite, docs overhaul, session-state reconcile on boot + across tabs, and a session-hardening sweep.

## Release step touchpoints (per AGENTS.md)

- Version bumped \`1.0.0-rc.6\` → \`1.0.0\` in root + server + react-app + converter \`package.json\`.
- \`server/openapi.json\` regenerated; \`react-app/src/lib/api-schema.ts\` re-codegen'd (unchanged content — no route or schema deltas since rc.6).
- \`CHANGELOG.md\`: new \`[1.0.0] - 2026-07-19\` section with a short "released unchanged from rc.6" note; diff-link at footer. Per-release detail already lives under \`[1.0.0-rc.1]\` through \`[1.0.0-rc.6]\`.
- \`README.md\`: Roadmap 1.0 bullet collapsed to a shipped marker pointing at the Version History entry; rc.6 Version History entry folded into a single 1.0 entry.
- \`SETUP.md\`: install / upgrade / gc examples bumped in six sites.

## Not in this PR (post-merge)

- Close [milestone/4 (1.0)](https://github.com/vlumi/photo-diary/milestones/4).
- Tag \`v1.0.0\` + push.
- Publish GitHub Release (**latest**, not prerelease) with the \`[1.0.0]\` CHANGELOG section as notes.

## Test plan

- [x] Full test pass: react-app 1000/1000, server 957/957, converter 28/28.
- [x] typecheck + lint clean; react-app build green.
- [x] rc.6 already soaked in prod without regression.
- [ ] CI (4 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)