### PR TITLE
Bump @fastify/static 9 → 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11648,7 +11648,7 @@
         "@fastify/compress": "^9.0.0",
         "@fastify/cookie": "^11.0.2",
         "@fastify/helmet": "^13.0.2",
-        "@fastify/static": "^9.1.3",
+        "@fastify/static": "^10.1.2",
         "@fastify/swagger": "^9.7.0",
         "@fastify/swagger-ui": "^6.0.0",
         "@fastify/type-provider-typebox": "^6.1.0",
@@ -11683,6 +11683,44 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "server/node_modules/@fastify/static": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-10.1.2.tgz",
+      "integrity": "sha512-G/g18cG9tLutT/OVyN1AIsHIl9L1UwmJ+S3dkyhVpplIx0nEMicd7RGQ+uJLyhKKF4a3tTcQydccn3Mop1fX+Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/error": "^4.0.0",
+        "@fastify/send": "^4.0.0",
+        "content-disposition": "^2.0.1",
+        "fastify-plugin": "^6.0.0",
+        "fastq": "^1.17.1",
+        "glob": "^13.0.0"
+      }
+    },
+    "server/node_modules/content-disposition": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.1.tgz",
+      "integrity": "sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,7 @@
     "@fastify/compress": "^9.0.0",
     "@fastify/cookie": "^11.0.2",
     "@fastify/helmet": "^13.0.2",
-    "@fastify/static": "^9.1.3",
+    "@fastify/static": "^10.1.2",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^6.0.0",
     "@fastify/type-provider-typebox": "^6.1.0",


### PR DESCRIPTION
## Summary

Major-version release of the static-file plugin. Bumps its internal \`content-disposition\` to 2.x and refactors \`setHeaders\` to receive a \`FastifyReply\` instead of the raw \`Response\`.

## Breaking?

We don't use \`setHeaders\` in the \`fastifyStatic\` register in \`server/app.ts\` — only \`root\` and \`prefix\`. The change is transparent.

## Test plan

- [x] Server tests pass in isolation (targeted files 100% green)
- [x] typecheck + lint clean
- [ ] CI

The pre-existing #674 flake still trips full-suite runs once every few tries; runs of individual files stay clean. Not caused by this bump.

Stacked on top of #709 (safe dep refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)