### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-26
+
+Dependency refresh across all workspaces after the 1.0 tag. In-range patch/minor bumps for the Fastify family, React 19.2.8, TanStack Query 5.101.4, i18next 26.3.6, react-easy-crop 6.2.3, jose 6.2.4, sharp 0.35.3, vite 8.1.5, vitest 4.1.10, typescript-eslint 8.65, and eslint 10.8 (server + converter). Then four majors, each on its own PR:
+
+### Dependencies
+
+- Bump `better-sqlite3` 12 → 13 (#710). Migrates the DB driver to N-API; prebuilt binaries now ship with the package instead of being fetched via the deprecated `prebuild-install`. No SQL / statement / transaction API changes — additions only (`db.explain()` for parameterless EXPLAIN queries, `preparedStatement.toString()` for expanded SQL).
+- Bump `@fastify/static` 9 → 10 (#711). The `setHeaders` callback receives a `FastifyReply` instead of a raw `Response`; the `fastifyStatic` register in `server/app.ts` doesn't use `setHeaders` so the change is transparent.
+- Bump `@testing-library/jest-dom` 6 → 7 (#712). `@testing-library/dom` becomes a required (not implicit) peer, so it's now an explicit react-app devDep. Node engine already met (`>=22`).
+- Bump `c8` 11 → 12 (#713). Yargs 18 internally, which tightens Node to `^20.19.0 || ^22.12.0 || >=23`; already met.
+
+### Deferred
+
+Two majors couldn't ship in this refresh because their downstream tooling doesn't support the new version yet: `typescript` 6 → 7 (blocked — `typescript-eslint` throws "does not support TS 7.0" at load) and `eslint` 9 → 10 in react-app (blocked — `eslint-plugin-react@^7.37`'s `eslint@^9.7` peer cap, still). Server + converter already run eslint 10.
+
 ## [1.0.0] - 2026-07-19
 
 Released unchanged from `1.0.0-rc.6` after prod verification. See the [Version History](README.md#version-history) in the README for the milestone-level summary of what this release covers.
@@ -757,6 +772,7 @@ Release candidate for 1.0. Cumulative 0.18 → 1.0 changes: end of the JWT-cooki
 
 ## Initial commit - 2020-07-04
 
+[1.0.1]: https://github.com/vlumi/photo-diary/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.6...v1.0.0
 [1.0.0-rc.6]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.5...v1.0.0-rc.6
 [1.0.0-rc.5]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.4...v1.0.0-rc.5

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Per-instance state — the SQLite DB, the `photos/` tree, `.env` — lives in a 
 
 Where the project is headed. Each bullet links the GitHub milestone for live status.
 
-- **1.0** — shipped 2026-07-19 (see the [Version History](#version-history) entry below).
+- **1.0** — shipped 2026-07-19; latest patch `1.0.1` 2026-07-26 (see the [Version History](#version-history) entry below).
 - [**2.0 — Thin server, cloud-native direction**](https://github.com/vlumi/photo-diary/milestone/18) *(direction-setting, far out)* — originals leave the server for client-side / cold storage, the converter's sharp pipeline becomes a bundled local uploader, all DB ops route through the API, storage backends behind a vendor-agnostic interface. Likely diverges from today's self-hosted-monolith shape enough that it may end up being a different product line.
 
 ## Backlog
@@ -200,6 +200,6 @@ Third structural take on a long-running personal photo-gallery side project — 
 - **0.16** (Jun 2026) — Filter & viewing UX polish: redesigned filter widget (inline strip + per-category modal cards with faceted counts), continuous-variable range filters, stacked-area evolution chart, virtual-gallery edit page + hybrid-source admin UI, persistent map modal.
 - **0.17** (Jun 2026) — Admin UI shift to layered modals + Section card primitive; per-photo visibility + editor-tier admin actions on `/g/`; `/m/instance` page with runtime-overridable `meta` defaults; configurable rendition ladder + collapsed `photos/display/<maxDim>/` layout; `/m/photos` filters move into a modal; Stats Evolution adds `weekday` and `hour`; Finnish geocoding cleanup (state-code lvl fallthrough + script-rule address blob filter).
 - **0.18** (Jun 2026) — Cleanup + observability: `meta` table is the only source for SPA runtime defaults (no `.env` fallback); `/m/operations` admin page surfaces converter activity, pending queues, and failures; tidied `bin/photo.ts` surface; vitest coverage wired; frontend security audit pass; auth tokens move from localStorage to HttpOnly cookies.
-- **1.0** (Jul 2026) — Stable milestone. End of the JWT-cookie transition, CSP enable pass, cross-host SSO for the UserMenu virtual-host switcher (with federated login from non-main hosts), Playwright e2e suite, docs overhaul, session-state reconcile on boot + across tabs, session-hardening pass across six rcs. From here, further work ships as patch releases or moves onto the 2.0 direction.
+- **1.0** (Jul 2026) — Stable milestone. End of the JWT-cookie transition, CSP enable pass, cross-host SSO for the UserMenu virtual-host switcher (with federated login from non-main hosts), Playwright e2e suite, docs overhaul, session-state reconcile on boot + across tabs, session-hardening pass across six rcs. `1.0.1` (Jul 26) is a dependency-refresh patch (better-sqlite3 13, @fastify/static 10, jest-dom 7, c8 12, plus in-range bumps across the tree). From here, further work ships as patch releases or moves onto the 2.0 direction.
 
 See the [Roadmap](#roadmap) for what's in flight after 1.0.

--- a/SETUP.md
+++ b/SETUP.md
@@ -79,13 +79,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  1.0.0/                               #   so different instances can run different versions
+  1.0.1/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/1.0.0      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/1.0.1      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  thumbnail/        # display/<maxDim>/ subdirs auto-created on intake
@@ -112,7 +112,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=1.0.0
+V=1.0.1
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -127,7 +127,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/1.0.0/bin/instance.ts /var/photo-diary/dailybw
+/opt/photo-diary/1.0.1/bin/instance.ts /var/photo-diary/dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -159,7 +159,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/1.0.0/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
+/opt/photo-diary/1.0.1/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                                # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                                     # migration runner applies any schema bumps
@@ -176,7 +176,7 @@ The DB backup is named `db.sqlite3.pre-<new-version>` — a plain file copy that
 The multi-instance layout never garbage-collects old `/opt/photo-diary/<version>/` directories — each one is 400+ MB (`sharp`, `better-sqlite3`, etc. in `node_modules`), so after a dozen releases they add up. `bin/instance.ts gc` scans the conventional layout and reports versions that no scanned instance references:
 
 ```sh
-/opt/photo-diary/1.0.0/bin/instance.ts gc
+/opt/photo-diary/1.0.1/bin/instance.ts gc
 ```
 
 It walks `/var/photo-diary/*/code` symlinks to collect what's in use, then prints anything under `/opt/photo-diary/` that isn't in that set, along with sizes and the `rm -rf` commands you would run. It never deletes — an operator with non-conventional instance layouts may have instances outside `/var/photo-diary/` that reference these dirs, so the actual `rm` is left to you after reviewing. Override the scan roots with `--code-root` / `--instances-root` if your layout differs.

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1"
   },
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -72,5 +72,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -60,5 +60,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
## Summary

First patch on the 1.0 line. Dependency refresh across all workspaces — no user-facing changes.

## Bundled PRs

- **Safe in-range bumps** (#709) — lockfile-only refresh: Fastify family, React 19.2.8, TanStack Query 5.101.4, i18next 26.3.6, jose 6.2.4, sharp 0.35.3, vite 8.1.5, vitest 4.1.10, typescript-eslint 8.65, eslint 10.8 (server + converter).
- **better-sqlite3 12 → 13** (#710) — N-API migration; prebuilt binaries ship with the package. No SQL API changes.
- **@fastify/static 9 → 10** (#711) — `setHeaders` callback receives `FastifyReply` now; we don't use `setHeaders`.
- **@testing-library/jest-dom 6 → 7** (#712) — makes `@testing-library/dom` a required peer; added as an explicit react-app devDep.
- **c8 11 → 12** (#713) — yargs 18 internally; Node engine already met.

## Deferred (upstream not yet compatible)

- `typescript` 6 → 7 — `typescript-eslint` throws \`typescript-eslint does not support TS 7.0\` at load.
- `eslint` 9 → 10 in react-app — `eslint-plugin-react@^7.37`'s peer still caps at `eslint@^9.7` (CLAUDE.md footgun).

## Release step touchpoints

- Version bumped `1.0.0` → `1.0.1` in root + server + react-app + converter `package.json`.
- `server/openapi.json` regenerated; `react-app/src/lib/api-schema.ts` re-codegen'd (unchanged content).
- `CHANGELOG.md`: new `[1.0.1] - 2026-07-26` section with the dep listing + diff-link at footer.
- `README.md`: Roadmap 1.0 pointer notes the 1.0.1 patch; Version History 1.0 entry gets an inline mention (dep patch doesn't warrant its own themed entry).
- `SETUP.md`: install / upgrade / gc examples bumped in six sites.

## Not in this PR (post-merge)

- Tag `v1.0.1` + push.
- Publish GitHub Release as **latest** with the `[1.0.1]` CHANGELOG section as notes.

## Test plan

- [x] react-app 1000/1000, server 957/957, converter 28/28.
- [x] typecheck + lint clean; react-app build green.
- [ ] CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)