### PR TITLE
Stats: clip boundary daysInYear / daysInYearMonth to dataset range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Server
+
+- Stats `daysInYear` and `daysInYearMonth` clip the first and last buckets to the [first-photo, last-photo] date range, restoring the pre-server-move behaviour. The first year's May counted 31 days when the earliest photo was on the 5th; the last year's current month counted 31 even mid-month. Both surfaces are now "days the project was actually active" in the boundary buckets, so `photos/day` averages for boundary years and months read as intended instead of being diluted by empty pre-first / post-last days. Interior years and months keep the full calendar length (leap-aware).
+
 ## [1.0.1] - 2026-07-26
 
 Dependency refresh across all workspaces after the 1.0 tag. In-range patch/minor bumps for the Fastify family, React 19.2.8, TanStack Query 5.101.4, i18next 26.3.6, react-easy-crop 6.2.3, jose 6.2.4, sharp 0.35.3, vite 8.1.5, vitest 4.1.10, typescript-eslint 8.65, and eslint 10.8 (server + converter). Then four majors, each on its own PR:

--- a/server/lib/stats-compute.ts
+++ b/server/lib/stats-compute.ts
@@ -140,22 +140,62 @@ const buildByYearMonth = (photos: Photo[]): YearMonthCounts => {
   return out;
 };
 
-const daysInCalendarYear = (year: number): number => {
-  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
-  return leap ? 366 : 365;
-};
 const daysInCalendarMonth = (year: number, month: number): number =>
   new Date(year, month, 0).getDate();
 
-const buildDaysInYear = (photos: Photo[]): Record<string, number> => {
+// Days elapsed in the (year, month) bucket, clipped to the dataset's
+// [first-photo, last-photo] range. Full months in the interior return
+// the calendar length; the first / last months of the dataset are
+// clipped so the average reflects the days the project was actually
+// active. Buckets outside the dataset range return 0.
+const daysInMonthBucket = (
+  year: number,
+  month: number,
+  first: { year: number; month: number; day: number },
+  last: { year: number; month: number; day: number }
+): number => {
+  const bucketStart = { year, month, day: 1 };
+  const bucketEnd = { year, month, day: daysInCalendarMonth(year, month) };
+  const cmp = (
+    a: { year: number; month: number; day: number },
+    b: { year: number; month: number; day: number }
+  ): number =>
+    a.year !== b.year
+      ? a.year - b.year
+      : a.month !== b.month
+        ? a.month - b.month
+        : a.day - b.day;
+  const lo = cmp(first, bucketStart) > 0 ? first : bucketStart;
+  const hi = cmp(last, bucketEnd) < 0 ? last : bucketEnd;
+  if (cmp(lo, hi) > 0) return 0;
+  return hi.day - lo.day + 1;
+};
+
+const buildDaysInYear = (
+  photos: Photo[],
+  first: Photo | undefined,
+  last: Photo | undefined
+): Record<string, number> => {
+  if (!first || !last) return {};
   const years = new Set<number>();
   for (const photo of photos) years.add(photo.taken.instant.year);
   const out: Record<string, number> = {};
-  for (const year of years) out[String(year)] = daysInCalendarYear(year);
+  for (const year of years) {
+    let total = 0;
+    for (let m = 1; m <= 12; m++) {
+      total += daysInMonthBucket(year, m, first.taken.instant, last.taken.instant);
+    }
+    out[String(year)] = total;
+  }
   return out;
 };
 
-const buildDaysInYearMonth = (photos: Photo[]): YearMonthCounts => {
+const buildDaysInYearMonth = (
+  photos: Photo[],
+  first: Photo | undefined,
+  last: Photo | undefined
+): YearMonthCounts => {
+  if (!first || !last) return {};
   const seen = new Map<number, Set<number>>();
   for (const photo of photos) {
     const year = photo.taken.instant.year;
@@ -167,7 +207,12 @@ const buildDaysInYearMonth = (photos: Photo[]): YearMonthCounts => {
   for (const [year, months] of seen.entries()) {
     out[String(year)] = {};
     for (const month of months) {
-      out[String(year)][String(month)] = daysInCalendarMonth(year, month);
+      out[String(year)][String(month)] = daysInMonthBucket(
+        year,
+        month,
+        first.taken.instant,
+        last.taken.instant
+      );
     }
   }
   return out;
@@ -514,8 +559,8 @@ export const computeStats = (
     byCategory,
     byYearMonth,
     summary,
-    daysInYear: buildDaysInYear(filtered),
-    daysInYearMonth: buildDaysInYearMonth(filtered),
+    daysInYear: buildDaysInYear(filtered, first, last),
+    daysInYearMonth: buildDaysInYearMonth(filtered, first, last),
     byStateCountry: annotations.byStateCountry,
     byCityCountry: annotations.byCityCountry,
     byCityLocalized: annotations.byCityLocalized,

--- a/server/tests/api/stats.test.ts
+++ b/server/tests/api/stats.test.ts
@@ -77,17 +77,21 @@ describe("response shape (unfiltered)", () => {
     });
   });
 
-  test("daysInYear is the calendar year length", async () => {
+  test("daysInYear clips boundary years to the [first, last] range", async () => {
     const res = await postStats(token, "gallery1");
-    // 2020 is a leap year; 2018 is not.
-    expect(res.body.daysInYear).toEqual({ "2018": 365, "2020": 366 });
+    // gallery1: first photo 2018-05-04, last photo 2020-07-04.
+    // 2018 counts May 4 → Dec 31 = 28 + 30 + 31 + 31 + 30 + 31 + 30 + 31 = 242.
+    // 2020 (leap) counts Jan 1 → Jul 4 = 31 + 29 + 31 + 30 + 31 + 30 + 4 = 186.
+    // Interior years with no photos aren't in the map (loop is over years
+    // that actually carry photos).
+    expect(res.body.daysInYear).toEqual({ "2018": 242, "2020": 186 });
   });
 
-  test("daysInYearMonth has the calendar month length", async () => {
+  test("daysInYearMonth clips boundary months to the [first, last] range", async () => {
     const res = await postStats(token, "gallery1");
-    // May 2018 = 31 days, July 2020 = 31 days
-    expect(res.body.daysInYearMonth["2018"]["5"]).toBe(31);
-    expect(res.body.daysInYearMonth["2020"]["7"]).toBe(31);
+    // May 2018 = 28 (May 4 → May 31), July 2020 = 4 (Jul 1 → Jul 4).
+    expect(res.body.daysInYearMonth["2018"]["5"]).toBe(28);
+    expect(res.body.daysInYearMonth["2020"]["7"]).toBe(4);
   });
 
   test("camera bucket uses formatGear output", async () => {


### PR DESCRIPTION
## Summary

Restores the pre-server-move behaviour where the first / last year and month averages ran against the days the project was actually active — not the full calendar. Since \`d5f2282\` (2020, when stats moved from client-side to a server endpoint), \`daysInYear\` and \`daysInYearMonth\` returned the full calendar length (365/366, 28-31) for every bucket, regardless of where the earliest / latest photo landed inside the boundary bucket.

Visible effect in the UI:

- **First year** was diluted by pre-first-photo days. A project starting on May 4 got 365 as the denominator instead of ~242, so the average was ~66% of the true value.
- **Last year** was diluted by post-last-photo days. Under normal use the last photo is in the current month; the average dropped as the calendar month progressed.
- Same shape on the boundary months of \`daysInYearMonth\` — May 2018 was 31 days in the denominator even though only 28 were spent in the range.

## Fix

Add a shared \`daysInMonthBucket(year, month, first, last)\` helper. It clips each bucket to the closed \`[first, last]\` range and returns 0 for buckets fully outside. \`buildDaysInYear\` sums it across the 12 months of each year that carries a photo; \`buildDaysInYearMonth\` uses it per bucket directly. Interior years and months are unaffected — they get the full calendar length, leap-aware.

## Tests

- Updated the two \`stats.test.ts\` assertions that locked in the buggy full-calendar behavior to assert clipped values against gallery1's fixture (2018-05-04 → 2020-07-04): 242 / 186 for the boundary years; 28 / 4 for May 2018 and July 2020.
- Full server suite runs 957/957.

🤖 Generated with [Claude Code](https://claude.com/claude-code)