### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-07-30
+
 ### Server
 
 - Stats `daysInYear` and `daysInYearMonth` clip the first and last buckets to the [first-photo, last-photo] date range, restoring the pre-server-move behaviour. The first year's May counted 31 days when the earliest photo was on the 5th; the last year's current month counted 31 even mid-month. Both surfaces are now "days the project was actually active" in the boundary buckets, so `photos/day` averages for boundary years and months read as intended instead of being diluted by empty pre-first / post-last days. Interior years and months keep the full calendar length (leap-aware).
@@ -776,6 +778,7 @@ Release candidate for 1.0. Cumulative 0.18 → 1.0 changes: end of the JWT-cooki
 
 ## Initial commit - 2020-07-04
 
+[1.0.2]: https://github.com/vlumi/photo-diary/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/vlumi/photo-diary/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.6...v1.0.0
 [1.0.0-rc.6]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.5...v1.0.0-rc.6

--- a/SETUP.md
+++ b/SETUP.md
@@ -79,13 +79,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  1.0.1/                               #   so different instances can run different versions
+  1.0.2/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/1.0.1      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/1.0.2      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  thumbnail/        # display/<maxDim>/ subdirs auto-created on intake
@@ -112,7 +112,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=1.0.1
+V=1.0.2
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -127,7 +127,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/1.0.1/bin/instance.ts /var/photo-diary/dailybw
+/opt/photo-diary/1.0.2/bin/instance.ts /var/photo-diary/dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -159,7 +159,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/1.0.1/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
+/opt/photo-diary/1.0.2/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                                # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                                     # migration runner applies any schema bumps
@@ -176,7 +176,7 @@ The DB backup is named `db.sqlite3.pre-<new-version>` — a plain file copy that
 The multi-instance layout never garbage-collects old `/opt/photo-diary/<version>/` directories — each one is 400+ MB (`sharp`, `better-sqlite3`, etc. in `node_modules`), so after a dozen releases they add up. `bin/instance.ts gc` scans the conventional layout and reports versions that no scanned instance references:
 
 ```sh
-/opt/photo-diary/1.0.1/bin/instance.ts gc
+/opt/photo-diary/1.0.2/bin/instance.ts gc
 ```
 
 It walks `/var/photo-diary/*/code` symlinks to collect what's in use, then prints anything under `/opt/photo-diary/` that isn't in that set, along with sizes and the `rm -rf` commands you would run. It never deletes — an operator with non-conventional instance layouts may have instances outside `/var/photo-diary/` that reference these dirs, so the actual `rm` is left to you after reviewing. Override the scan roots with `--code-root` / `--instances-root` if your layout differs.

--- a/converter/package.json
+++ b/converter/package.json
@@ -35,5 +35,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1"
   },
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -20,7 +20,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -11009,7 +11009,7 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -11285,7 +11285,7 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -72,5 +72,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -60,5 +60,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "1.0.1"
+  "version": "1.0.2"
 }


### PR DESCRIPTION
## Summary

### Server

- Stats `daysInYear` and `daysInYearMonth` clip the first and last buckets to the [first-photo, last-photo] date range, restoring the pre-server-move behaviour. The first year's May counted 31 days when the earliest photo was on the 5th; the last year's current month counted 31 even mid-month. Both surfaces are now "days the project was actually active" in the boundary buckets, so `photos/day` averages for boundary years and months read as intended instead of being diluted by empty pre-first / post-last days. Interior years and months keep the full calendar length (leap-aware).

---

Prepared with `npm run release -- patch`.

**Post-merge (automated):** tag `v1.0.2`, push, publish GitHub Release as `--latest` with the `[1.0.2]` CHANGELOG section as notes.
