### PR TITLE
Drop image-size, use sharp().metadata()

### DIFF
--- a/converter/extract-properties/set-dimensions.ts
+++ b/converter/extract-properties/set-dimensions.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { imageSizeFromFile } from "image-size/fromFile";
+import sharp from "sharp";
 
 import {
   DIR_ORIGINAL,
@@ -19,12 +19,17 @@ export default async (
     target: string,
     filePath: string
   ): Promise<void> => {
-    const dims = await imageSizeFromFile(filePath);
+    // sharp().metadata() returns raw pixel width/height (EXIF orientation
+    // not applied) plus the tag itself. Values 5-8 are the 90°/270°
+    // rotated cases where the "logical" width and height swap.
+    const meta = await sharp(filePath).metadata();
+    const width = meta.width ?? 0;
+    const height = meta.height ?? 0;
     properties.dimensions = properties.dimensions ?? {};
-    if ((dims.orientation ?? 0) >= 5) {
-      properties.dimensions[target] = { width: dims.height, height: dims.width };
+    if ((meta.orientation ?? 0) >= 5) {
+      properties.dimensions[target] = { width: height, height: width };
     } else {
-      properties.dimensions[target] = { width: dims.width, height: dims.height };
+      properties.dimensions[target] = { width, height };
     }
   };
 

--- a/converter/package.json
+++ b/converter/package.json
@@ -22,7 +22,6 @@
     "dotenv": "^17.4.2",
     "exifr": "^7.1.3",
     "geo-coord": "^0.2.0",
-    "image-size": "^2.0.2",
     "photo-diary-server": "*",
     "sharp": "^0.35.1"
   },

--- a/converter/tests/pipeline.test.ts
+++ b/converter/tests/pipeline.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import processFile from "../process-file.js";
-import { imageSizeFromFile } from "image-size/fromFile";
+import sharp from "sharp";
 import db from "photo-diary-server/db/index.js";
 import sqlite3Factory from "photo-diary-server/db/sqlite3/index.js";
 
@@ -78,17 +78,17 @@ test("processes a JPEG with EXIF end-to-end and renames to <ts>-<uuid>.jpg", asy
   assert.equal(await onlyFile(path.join(rootDir, "display", "1500")), id);
   assert.equal(await onlyFile(path.join(rootDir, "thumbnail")), id);
 
-  const displayDims = await imageSizeFromFile(
+  const displayDims = await sharp(
     path.join(rootDir, "display", "1500", id)
-  );
-  assert.ok(displayDims.width <= 1500);
-  assert.ok(displayDims.height <= 1500);
+  ).metadata();
+  assert.ok((displayDims.width ?? 0) <= 1500);
+  assert.ok((displayDims.height ?? 0) <= 1500);
 
-  const thumbDims = await imageSizeFromFile(
+  const thumbDims = await sharp(
     path.join(rootDir, "thumbnail", id)
-  );
-  assert.ok(thumbDims.width <= 600);
-  assert.ok(thumbDims.height <= 200);
+  ).metadata();
+  assert.ok((thumbDims.width ?? 0) <= 600);
+  assert.ok((thumbDims.height ?? 0) <= 200);
 
   // DB row holds the EXIF-extracted properties + the original filename.
   const row = (await db.loadPhoto(id)) as any;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3341,7 +3341,7 @@
       "version": "26.1.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -3357,7 +3357,7 @@
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -10259,6 +10259,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/typescript-eslint": {
       "version": "8.66.0",
       "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
@@ -10316,7 +10331,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "dotenv": "^17.4.2",
         "exifr": "^7.1.3",
         "geo-coord": "^0.2.0",
-        "image-size": "^2.0.2",
         "photo-diary-server": "*",
         "sharp": "^0.35.1"
       },
@@ -3342,7 +3341,7 @@
       "version": "26.1.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -3358,7 +3357,7 @@
       "version": "19.2.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4290,6 +4289,7 @@
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.2.tgz",
       "integrity": "sha512-jW6oufeDhXZaiX9Lw5A+oerVClx4iFrI6uDj1zu7SqUAjak9vbJvA0NEcKLNxHiQHb6kYCoFzzXYV0YOauhV3g==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"
@@ -6561,18 +6561,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/image-size": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
       }
     },
     "node_modules/import-fresh": {
@@ -10271,21 +10259,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/typescript-eslint": {
       "version": "8.66.0",
       "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
@@ -10343,7 +10316,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/uri-js": {


### PR DESCRIPTION
## Summary

Removes the \`image-size\` dep from the converter and reads dimensions via \`sharp().metadata()\` instead. Sharp was already a dep — this is a direct API swap with no behavioural change.

## Why

Two open CVE advisories on \`image-size\` with **no upstream patch available**:

- **GHSA-w3rx-r6r6-pgpr** — ICNS parser DoS via infinite loop.
- **GHSA-5p2g-fcmc-qvqq** — JXL and HEIF parser DoS via infinite loops.

Since \`sharp\` provides the same \`{ width, height, orientation }\` fields on its \`.metadata()\` call and is already loaded for the resize pipeline, the swap eliminates the dep entirely and kills both alerts.

## Diff

- \`converter/extract-properties/set-dimensions.ts\` — swap \`imageSizeFromFile\` for \`sharp(filePath).metadata()\`. Portrait-orientation width/height swap logic unchanged; sharp uses the same EXIF orientation encoding (values 5-8 = 90°/270° rotated).
- \`converter/tests/pipeline.test.ts\` — same swap on the post-intake dimension check.
- \`converter/package.json\` — remove \`image-size\` from \`dependencies\`.
- \`package-lock.json\` — lockfile refreshed; \`image-size\` gone from the tree.

## Test plan

- [x] Converter tests: 28/28 pass, typecheck clean.
- [ ] CI (server + react-app + e2e + converter — all touch the workspace but only converter changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)