### PR TITLE
Fix #674 flake: guard token reload timer against generation drift

### DIFF
--- a/server/models/token.ts
+++ b/server/models/token.ts
@@ -20,6 +20,14 @@ const encodeSecret = (secret: string): Uint8Array =>
 
 const secrets: Record<string, string> = {};
 let reloadTimer: NodeJS.Timeout | undefined = undefined;
+// Generation counter for the reload timer. Every `_resetTokenStateForTests`
+// bumps it; every fired timer captures the generation active at schedule
+// time and refuses to reschedule if it no longer matches. Prevents an
+// in-flight `init()` (whose `await db.loadUsers()` was resolving while
+// the reset ran) from installing an orphan follow-up timer that would
+// then fire mid-next-file's tests. Was the source of the #674 cascade
+// hook-timeout flake.
+let reloadGeneration = 0;
 
 const loadSecrets = async (): Promise<void> => {
   logger.debug("Loading secrets");
@@ -40,6 +48,7 @@ export const _resetTokenStateForTests = (): void => {
     clearTimeout(reloadTimer);
     reloadTimer = undefined;
   }
+  reloadGeneration++;
 };
 
 const getSecret = (userId: string): string => {
@@ -49,17 +58,24 @@ const getSecret = (userId: string): string => {
   return `${secrets[userId]}${config.SECRET}`;
 };
 
-const init = async (): Promise<void> => {
-  await loadSecrets();
+const scheduleReload = (generation: number): void => {
+  if (generation !== reloadGeneration) return;
   if (reloadTimer) clearTimeout(reloadTimer);
   // 5-second reload so a `bin/user.ts passwd` rotation (which kills sessions
   // by rotating the user's `secret`) takes effect quickly. The DB read is one
   // indexed SELECT against a small table; trivial cost. unref() so the timer
   // doesn't keep the event loop alive on its own (matters in tests).
   reloadTimer = setTimeout(() => {
+    if (generation !== reloadGeneration) return;
     init().catch(() => {});
   }, 5000);
   reloadTimer.unref();
+};
+
+const init = async (): Promise<void> => {
+  const gen = reloadGeneration;
+  await loadSecrets();
+  scheduleReload(gen);
 };
 
 type Credentials = { id: string; password: string };


### PR DESCRIPTION
## Summary

Fixes #674 — the cascade hook-timeout flake that hit ~20% of server-suite runs and blew wall time from ~26s to 60-90s.

## Root cause

\`_resetTokenStateForTests\` only cancelled the tracked timer. If a timer had already fired and its \`init()\` callback was in-flight (awaiting \`db.loadUsers()\`), the reset couldn't stop it. When \`loadSecrets()\` completed, the callback happily scheduled a NEW timer — orphaned, tracked by nothing.

That orphan would then fire ~5s later, mid-next-file's tests, during another \`_resetForTests\` DB wipe window. The resulting \`db.loadUsers()\` could see the transient empty-users state and populate the in-memory \`secrets\` map with nothing. Every subsequent authed request in that file then failed JWT verification because the secret cache was empty — cascading 20-30 test failures behind one poisoned setup.

## Fix

Monotonic generation counter, bumped by every \`_resetTokenStateForTests\` call. \`init()\` captures the generation at entry; \`scheduleReload\` and the timer's fire callback both refuse to touch state if the captured generation no longer matches the current one. In-flight callbacks from a previous generation exit as no-ops.

## Validation

**35 consecutive \`npm test\` runs clean, all ~26s wall time.**

Previous state: ~20% of runs hit the cascade pattern (30-90s wall time, 20-30 test failures). Acceptance criterion from #674 (10 consecutive clean runs) exceeded by 3.5x.

- [x] Server tests 957/957 across 35 consecutive runs.
- [ ] CI (should be the same story now).

Closes #674.

🤖 Generated with [Claude Code](https://claude.com/claude-code)