### PR TITLE
Release 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-08-11
+
 ### Server
 
 - Drop the `image-size` dep; read dimensions via `sharp().metadata()` instead. `image-size` had two open CVE advisories (GHSA-w3rx-r6r6-pgpr for the ICNS parser, GHSA-5p2g-fcmc-qvqq for the JXL / HEIF parsers — both infinite-loop DoS) with no upstream patch available. `sharp` was already a converter dep for the resize pipeline, and its `.metadata()` returns the same `{ width, height, orientation }` shape used at intake, so the swap is a direct API replacement. Closes #722.
@@ -789,6 +791,7 @@ Release candidate for 1.0. Cumulative 0.18 → 1.0 changes: end of the JWT-cooki
 
 ## Initial commit - 2020-07-04
 
+[1.0.3]: https://github.com/vlumi/photo-diary/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/vlumi/photo-diary/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/vlumi/photo-diary/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/vlumi/photo-diary/compare/v1.0.0-rc.6...v1.0.0

--- a/SETUP.md
+++ b/SETUP.md
@@ -79,13 +79,13 @@ Directory layout:
 ```text
 /opt/photo-diary/                       # parent dir, owned by the deploy user (see below)
   0.11.0/                               #   each version unpacked into its own subdir
-  1.0.2/                               #   so different instances can run different versions
+  1.0.3/                               #   so different instances can run different versions
                                         #   and upgrades are atomic (flip a symlink)
 
 /var/photo-diary/
   dailybw/                              # one directory per instance
     .env                                # per-instance config (see below)
-    code -> /opt/photo-diary/1.0.2      # symlink to the code version this instance runs
+    code -> /opt/photo-diary/1.0.3      # symlink to the code version this instance runs
     db.sqlite3                          # auto-created on first server start
     photos/
       inbox/  original/  thumbnail/        # display/<maxDim>/ subdirs auto-created on intake
@@ -112,7 +112,7 @@ sudo install -d -o "$USER" /opt/photo-diary /var/photo-diary
 GitHub auto-generates a source tarball for every tag. Extract it directly into a version subdirectory of `/opt/photo-diary/` with `tar --strip-components=1` (no rename step), then run `npm run setup` to install everything and build the bundled frontend:
 
 ```sh
-V=1.0.2
+V=1.0.3
 mkdir -p "/opt/photo-diary/$V"
 curl -L "https://github.com/vlumi/photo-diary/archive/refs/tags/v$V.tar.gz" \
   | tar xz -C "/opt/photo-diary/$V" --strip-components=1
@@ -127,7 +127,7 @@ Repeat this block for each new version you want to land on this host.
 The `bin/instance.ts` script handles directory creation, `.env` generation (with a fresh random `SECRET`), the `code` symlink, and the per-instance `bin/` shortcuts in one shot. Invoke it from the version of the code you want the instance to run:
 
 ```sh
-/opt/photo-diary/1.0.2/bin/instance.ts /var/photo-diary/dailybw
+/opt/photo-diary/1.0.3/bin/instance.ts /var/photo-diary/dailybw
 ```
 
 That creates `/var/photo-diary/dailybw/` with everything wired up — including `/var/photo-diary/dailybw/bin/{photo,gallery,user}.ts` symlinks so the routine operator commands are short paths (`./bin/photo.ts …` instead of `./code/server/bin/photo.ts …`). The positional is the instance directory; it's resolved via `path.resolve()` against cwd, so `dailybw` and `./dailybw` both mean `<cwd>/dailybw`, while `../sibling` and absolute paths resolve as expected. To pin a logical name different from the dir basename, pass `--name`. Re-running on an existing instance acts as a doctor — verifies the directory tree, checks for missing required `.env` keys, reports `✓`/`✗`. Add `--fix` to append any missing keys with defaults (without touching existing values).
@@ -159,7 +159,7 @@ Re-run `bin/instance.ts` from the new version of the code, then **delete + start
 
 ```sh
 pm2 stop dailybw dailybw-converter
-/opt/photo-diary/1.0.2/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
+/opt/photo-diary/1.0.3/bin/instance.ts /var/photo-diary/dailybw    # backs up the DB, flips the symlink
 pm2 delete dailybw dailybw-converter                                # drop cached metadata
 cd /var/photo-diary/dailybw
 ./code/server/bin/start-prod.sh                                     # migration runner applies any schema bumps
@@ -176,7 +176,7 @@ The DB backup is named `db.sqlite3.pre-<new-version>` — a plain file copy that
 The multi-instance layout never garbage-collects old `/opt/photo-diary/<version>/` directories — each one is 400+ MB (`sharp`, `better-sqlite3`, etc. in `node_modules`), so after a dozen releases they add up. `bin/instance.ts gc` scans the conventional layout and reports versions that no scanned instance references:
 
 ```sh
-/opt/photo-diary/1.0.2/bin/instance.ts gc
+/opt/photo-diary/1.0.3/bin/instance.ts gc
 ```
 
 It walks `/var/photo-diary/*/code` symlinks to collect what's in use, then prints anything under `/opt/photo-diary/` that isn't in that set, along with sizes and the `rm -rf` commands you would run. It never deletes — an operator with non-conventional instance layouts may have instances outside `/var/photo-diary/` that reference these dirs, so the actual `rm` is left to you after reviewing. Override the scan roots with `--code-root` / `--instances-root` if your layout differs.

--- a/converter/package.json
+++ b/converter/package.json
@@ -34,5 +34,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1"
   },
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "photo-diary",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "photo-diary",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "workspaces": [
         "server",
@@ -20,7 +20,7 @@
     },
     "converter": {
       "name": "photo-diary-converter",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -10950,7 +10950,7 @@
     },
     "react-app": {
       "name": "photo-diary-app",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -11226,7 +11226,7 @@
     },
     "server": {
       "name": "photo-diary-server",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "photo-diary",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "description": "Photo Diary — personal photo gallery (monorepo root)",
   "license": "MIT",

--- a/react-app/package.json
+++ b/react-app/package.json
@@ -72,5 +72,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Photo Diary API",
     "description": "Self-hosted photo-diary backend. Schema is generated from TypeBox-validated route handlers.",
-    "version": "1.0.2"
+    "version": "1.0.3"
   },
   "components": {
     "securitySchemes": {

--- a/server/package.json
+++ b/server/package.json
@@ -60,5 +60,5 @@
     "type": "git",
     "url": "github:vlumi/photo-diary"
   },
-  "version": "1.0.2"
+  "version": "1.0.3"
 }


### PR DESCRIPTION
## Summary

### Server

- Drop the `image-size` dep; read dimensions via `sharp().metadata()` instead. `image-size` had two open CVE advisories (GHSA-w3rx-r6r6-pgpr for the ICNS parser, GHSA-5p2g-fcmc-qvqq for the JXL / HEIF parsers — both infinite-loop DoS) with no upstream patch available. `sharp` was already a converter dep for the resize pipeline, and its `.metadata()` returns the same `{ width, height, orientation }` shape used at intake, so the swap is a direct API replacement. Closes #722.
- Test-only: fix the cascading hook-timeout flake (#674) by guarding the token model's reload timer against generation drift. `_resetTokenStateForTests` only cancelled the tracked timer; a timer that had already fired left its `init()` callback in-flight, which then scheduled an orphan follow-up timer that would fire mid-next-file's tests and poison the in-memory secrets cache. Every `_resetTokenStateForTests` now bumps a generation counter; `init()` captures it at entry and refuses to install a follow-up timer if the generation has drifted. Validated with 35 consecutive clean runs. Closes #723.

### Dependencies

- Security bump `fast-uri` 3.1.4 → 3.1.5 / 4.1.1 → 4.1.2 (GHSA-7p8r-x3mc-p8w7, transitive via Fastify's URL parsing stack). Closes #718.
- Safe in-range refresh across the tree over multiple rounds: fastify 5.11.3, jose 6.2.8, framer-motion 12.43, better-sqlite3 13.0.3, tsx 4.23.12, @fastify/static 10.1.3, @fastify/compress 9.2, @testing-library/jest-dom 7.0.1, eslint 10.8.1 (server + converter), typebox 1.3.12, @types/node 26.2, and smaller bumps across @tanstack, @types/react, @playwright/test, globals, @vitejs/plugin-react. Closes #719, and the follow-up sweep bundled with this release.
- Security bump `js-yaml` 4.3.0 → 4.3.1 + `@redocly/openapi-core` (dependabot combined PR; quadratic-complexity fix on `!!omap` duplicate-key detection). Closes #721.

---

Prepared with `npm run release -- patch`.

**Post-merge (automated):** tag `v1.0.3`, push, publish GitHub Release as `--latest` with the `[1.0.3]` CHANGELOG section as notes.
